### PR TITLE
docs: add Portal walkthrough to deployment, cold-start, and security operations

### DIFF
--- a/docs/operations/cold-start.md
+++ b/docs/operations/cold-start.md
@@ -53,6 +53,16 @@ Invest in cold start mitigation when at least one condition is true:
 - Deployment slots swap correctly, but first requests still spike.
 - Cost or platform constraints prevent immediate migration to a larger plan tier.
 
+## Portal Walkthrough
+
+### Function App Overview
+
+[Observed] The **Overview** blade shows the Function App status, hosting plan, and deployed functions. For a Consumption (Y1) plan, the App Service Plan field shows `KoreaCentralLinuxDynamicPlan (Y1: 0)` — the `0` indicates the app has scaled to zero instances, which is the normal idle state and the source of cold start latency:
+
+![Function App overview showing Y1 plan with 0 instances and 2 deployed functions](../assets/operations/overview/01-function-app-overview.png)
+
+[Inferred] The "Migrate your app to Flex Consumption" banner indicates Linux Consumption is approaching EOL (September 2028). Flex Consumption offers always-ready instances as a built-in cold start mitigation. If cold start is a production concern, evaluate migration to Flex or Premium.
+
 ## Procedure
 ### 1) Understand startup phases
 #### What causes cold start

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -107,6 +107,16 @@ az functionapp show \
 | `--query` | JMESPath query to filter specific properties |
 | `--output table` | Formats the output as a table |
 
+## Portal Walkthrough
+
+### Deployment Center
+
+[Observed] The **Deployment Center** blade provides a **Source** dropdown to connect the Function App to a CI/CD provider (GitHub, Azure Repos, Local Git, etc.). The banner warns "You are now in the production slot, which is not recommended for setting up CI/CD" — indicating slot-based deployment is preferred when available:
+
+![Deployment Center blade showing Source selector and production slot warning](../assets/operations/deployment/01-deployment-center.png)
+
+[Inferred] For Consumption plans, this is the expected view since Consumption supports only 2 slots (production + 1 staging, Windows only). For Flex Consumption, there are no slots at all, so direct production deployment is the only option. Premium and Dedicated plans should configure CI/CD against a staging slot instead.
+
 ## When to Use
 Choose deployment method by governance level, release frequency, and plan capability.
 

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -76,6 +76,24 @@ WORKSPACE_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RG/providers/Micro
 | `APP_RESOURCE_ID` | Fully qualified Azure resource ID for the function app |
 | `WORKSPACE_ID` | Fully qualified Azure resource ID for the workspace |
 
+## Portal Walkthrough
+
+### General Settings (TLS / HTTPS)
+
+[Observed] The **Configuration → General settings** blade shows platform security settings. For a new Consumption Function App: **HTTPS only** is unchecked, **Minimum Inbound TLS Version** is 1.2, **FTPS state** is FtpsOnly, and **Remote debugging** is off:
+
+![General settings blade showing TLS 1.2, FTPS Only, HTTPS unchecked, remote debugging off](../assets/operations/configuration/02-general-settings.png)
+
+[Inferred] Two items need attention for production hardening: (1) **HTTPS only** should be enabled to redirect all HTTP traffic to HTTPS, and (2) **FTPS state** should be set to `Disabled` if FTPS is not used, reducing the attack surface. These are the first two items in any security baseline checklist.
+
+### Environment Variables (Secrets Audit)
+
+[Observed] The **Environment variables** blade lists all app settings. The four core settings are visible with values hidden by default. The **Deployment slot setting** column is empty, meaning no settings are slot-sticky:
+
+![Environment variables blade with 4 app settings and hidden values](../assets/operations/configuration/01-environment-variables.png)
+
+[Inferred] For a security audit, check that sensitive values (connection strings, keys) are backed by Key Vault references (shown as `@Microsoft.KeyVault(...)` in the value column) rather than stored as plaintext. Use **Show values** to verify, and confirm that `AzureWebJobsStorage` uses identity-based connection for Flex Consumption deployments.
+
 ## When to Use
 Use this runbook in these cases:
 - New production deployment that needs baseline hardening.


### PR DESCRIPTION
## Summary

- Add Portal Walkthrough sections to 3 operations docs using existing portal captures
- **Deployment**: Deployment Center blade with production slot warning context
- **Cold Start**: Overview blade showing Y1 plan scaled to zero (cold start source)
- **Security**: General Settings (TLS/HTTPS audit) + Environment Variables (secrets audit)

## Pattern

Follows the [Container Apps portal capture convention](https://github.com/yeongseon/azure-container-apps-practical-guide/blob/main/AGENTS.md#portal-screenshot-capture-pii-replacement-rules):
- `[Observed]` tags describe what the Portal blade shows
- `[Inferred]` tags explain operational implications
- PII: GUIDs masked, subscription name preserved, avatar masked with Portal Blue

## Captures Used

| Blade | Asset Path | Doc |
|-------|-----------|-----|
| Deployment Center | `assets/operations/deployment/01-deployment-center.png` | `operations/deployment.md` |
| Overview (Y1: 0) | `assets/operations/overview/01-function-app-overview.png` | `operations/cold-start.md` |
| General Settings | `assets/operations/configuration/02-general-settings.png` | `operations/security.md` |
| Environment Variables | `assets/operations/configuration/01-environment-variables.png` | `operations/security.md` |

## Blades Not Yet Captured (Portal SPA routing issue)

These blades need recapture — Portal SPA did not navigate away from Overview:
- Networking
- Identity
- Scale Out

## Test plan

- [ ] Verify images render on GitHub Pages after merge
- [ ] Check [Observed]/[Inferred] text matches screenshot content
- [ ] Confirm no PII visible in captures

🤖 Generated with [Claude Code](https://claude.com/claude-code)