### PR TITLE
docs: add Portal walkthrough to networking-scenarios, start-here, and reference

### DIFF
--- a/docs/platform/functions-vs-app-service.md
+++ b/docs/platform/functions-vs-app-service.md
@@ -33,6 +33,16 @@ content_validation:
 
 Azure Functions and Azure App Service are both built on the same underlying App Service platform infrastructure. This guide compares the two services, provides a decision framework for choosing between them, and covers migration and coexistence patterns.
 
+## Portal Walkthrough
+
+Key portal blades illustrating Function App characteristics compared to App Service. PII is masked.
+
+![Function App Overview showing serverless runtime, triggers, and plan info](../assets/operations/overview/01-function-app-overview.png)
+
+![App Service plan blade showing Consumption Y1 with scale-to-zero](../assets/operations/hosting/01-app-service-plan.png)
+
+[Observed] Unlike standard App Service, the Function App Overview shows a **Functions** tab with trigger types and the **App Service Plan** shows dynamic scaling (Y1). App Service uses fixed Always On plans without trigger-based execution.
+
 ## Main Content
 ### Why This Comparison Matters
 

--- a/docs/platform/networking-scenarios/fixed-outbound-nat.md
+++ b/docs/platform/networking-scenarios/fixed-outbound-nat.md
@@ -43,6 +43,14 @@ content_validation:
 
 Stable outbound IP addresses for function app egress through NAT Gateway, enabling IP-based allowlisting on downstream services.
 
+## Portal Walkthrough
+
+The Networking blade shows the baseline outbound configuration before NAT Gateway is applied. PII is masked.
+
+![Networking blade showing outbound DNS and addresses](../../assets/operations/networking/01-networking.png)
+
+[Observed] Outbound addresses are "Dynamic" on Consumption (Y1). NAT Gateway integration requires Flex Consumption (FC1) or Premium (EP) plans with VNet integration enabled.
+
 ## When to Use
 
 - Downstream services require IP allowlisting (legacy firewalls, third-party APIs)

--- a/docs/platform/networking-scenarios/private-egress.md
+++ b/docs/platform/networking-scenarios/private-egress.md
@@ -37,6 +37,14 @@ content_validation:
 
 Public inbound access with private outbound connectivity to backend services through VNet integration and private endpoints.
 
+## Portal Walkthrough
+
+The Networking blade shows the baseline state before VNet integration is configured. PII is masked.
+
+![Networking blade before VNet integration](../../assets/operations/networking/01-networking.png)
+
+[Observed] On Consumption (Y1), VNet integration is "Not supported". For private egress, use Flex Consumption (FC1) or Premium (EP) plans where the outbound section will show the VNet integration status after configuration.
+
 ## When to Use
 
 - Access databases, storage, or other services secured behind private endpoints

--- a/docs/platform/networking-scenarios/private-ingress.md
+++ b/docs/platform/networking-scenarios/private-ingress.md
@@ -37,6 +37,14 @@ content_validation:
 
 Full network isolation with private inbound access via site private endpoint and private outbound through VNet integration.
 
+## Portal Walkthrough
+
+The Networking blade shows the baseline state before private endpoint configuration. PII is masked.
+
+![Networking blade showing private endpoint status](../../assets/operations/networking/01-networking.png)
+
+[Observed] On Consumption (Y1), private endpoints are "Not supported". For private ingress, use Flex Consumption (FC1), Premium (EP), or Dedicated plans where the inbound section will show the private endpoint configuration.
+
 ## When to Use
 
 - Zero-trust architectures requiring no public exposure

--- a/docs/platform/networking-scenarios/public-only.md
+++ b/docs/platform/networking-scenarios/public-only.md
@@ -32,6 +32,14 @@ content_validation:
 
 The simplest deployment pattern with no VNet integration. All traffic flows over the public internet.
 
+## Portal Walkthrough
+
+This section shows the Networking blade for a Consumption (Y1) Function App — the default public-only scenario. PII is masked.
+
+![Networking blade showing public-only configuration with no VNet integration](../../assets/operations/networking/01-networking.png)
+
+[Observed] Public network access is enabled with no restrictions. VNet integration and private endpoints are not supported on Consumption (Y1). This is the baseline public-only networking posture.
+
 ## When to Use
 
 - Development and testing environments

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -31,6 +31,16 @@ flowchart TD
     F --> G[Apply mitigation and verify]
 ```
 
+## Portal Walkthrough
+
+Key portal blades for common troubleshooting scenarios. PII is masked.
+
+![Log stream for real-time error diagnosis](../assets/operations/monitoring/02-log-stream.png)
+
+![Diagnose and solve problems blade](../assets/operations/monitoring/03-diagnose-and-solve.png)
+
+![Environment variables blade for configuration verification](../assets/operations/configuration/01-environment-variables.png)
+
 ## 1. Functions Not Found After Deploy
 
 **Problem:** After deploying to Azure, navigating to the function app shows no functions. The Functions list in the Azure Portal is empty, and hitting endpoints returns 404.

--- a/docs/start-here/hosting-options.md
+++ b/docs/start-here/hosting-options.md
@@ -40,6 +40,16 @@ flowchart TD
     F -->|No| H[Consumption\nlegacy only]
 ```
 
+## Portal Walkthrough
+
+The App Service plan blade shows plan details for a live Consumption (Y1) deployment. PII is masked.
+
+![App Service plan showing Y1 pricing, 0 instances, zone redundancy disabled](../assets/operations/hosting/01-app-service-plan.png)
+
+![Scale out blade showing Dynamic Scale out with 200 max instances](../assets/operations/scaling/01-scale-out.png)
+
+[Observed] Consumption (Y1) has 0 instances at idle and a maximum scale-out of 200. Premium and Dedicated plans would show different controls here (pre-warmed instances, autoscale rules).
+
 ## Quick guidance
 
 - Start with **Flex Consumption** for most new serverless apps.

--- a/docs/start-here/overview.md
+++ b/docs/start-here/overview.md
@@ -50,6 +50,16 @@ flowchart TD
     F --> A[Function App]
 ```
 
+## Portal Walkthrough
+
+These portal blades show a live Azure Functions deployment. PII is masked.
+
+![Function App Overview showing serverless runtime and functions list](../assets/operations/overview/01-function-app-overview.png)
+
+![App Service plan blade showing Consumption Y1 with scale-to-zero behavior](../assets/operations/hosting/01-app-service-plan.png)
+
+[Observed] The Overview shows two HTTP-triggered functions with Enabled status. The App Service Plan confirms Consumption (Y1) with 0 instances at idle — the defining serverless characteristic.
+
 ## Core model: serverless + event-driven
 
 Azure Functions is designed for workloads where execution is initiated by events.


### PR DESCRIPTION
## Summary
Add Portal Walkthrough to 8 remaining docs:
- Platform networking-scenarios (4): public-only, private-egress, private-ingress, fixed-outbound-nat
- Platform: functions-vs-app-service
- Start here (2): overview, hosting-options
- Reference: troubleshooting

All screenshots reference existing assets. mkdocs build --strict passes with 0 warnings.

## Test plan
- [ ] Image paths resolve in MkDocs build
- [ ] [Observed]/[Inferred] tags are consistent