### PR TITLE
docs: address review feedback (P0-P7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,28 @@
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
+![Docs](https://github.com/yeongseon/azure-functions-practical-guide/actions/workflows/docs.yml/badge.svg)
+![CI](https://github.com/yeongseon/azure-functions-practical-guide/actions/workflows/ci.yml/badge.svg)
+![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
+
 Comprehensive guide for running serverless applications on Azure Functions — from first deployment to production troubleshooting.
+
+## Who This Guide Is For
+
+- Developers building Azure Functions for the first time
+- Engineers operating production Function Apps
+- Support engineers investigating timeout, cold start, scaling, networking, and deployment issues
+- Teams choosing between Flex Consumption, Premium, Dedicated, and existing Consumption workloads
+
+## Recommended Starting Path
+
+| Scenario | Recommended plan | Start here |
+|---|---|---|
+| New serverless app | **Flex Consumption** | [Flex Consumption tutorial](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
+| Existing Consumption workload | Consumption (legacy) | [Consumption tutorial](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
+| Always-ready instances or VNet-heavy | Premium | [Premium tutorial](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
+| Existing App Service Plan estate | Dedicated | [Dedicated tutorial](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
+| Container-native hosting | Container Apps | Planned — see [Hosting Scope](#hosting-scope) |
 
 ## What's Inside
 
@@ -16,6 +37,17 @@ Comprehensive guide for running serverless applications on Azure Functions — f
 | [Troubleshooting](https://yeongseon.github.io/azure-functions-practical-guide/troubleshooting/) | Playbooks, KQL queries, methodology, and hands-on labs |
 | [Reference](https://yeongseon.github.io/azure-functions-practical-guide/reference/) | CLI cheatsheet, host.json, platform limits |
 
+## Hosting Scope
+
+This guide currently focuses on Azure Functions classic hosting plans:
+
+- **Flex Consumption (FC1)** — recommended default for most new serverless workloads
+- **Consumption (Y1)** — legacy; maintained for existing workloads and migration reference
+- **Premium (EP)** — always-ready instances with enterprise networking
+- **Dedicated (App Service Plan)** — fixed-capacity for existing App Service estates
+
+Azure Container Apps hosting for Azure Functions is planned as a separate section.
+
 ## Language Guides
 
 - **Python** (v2 decorator model, 4 hosting plan tracks)
@@ -28,13 +60,13 @@ Each guide covers: local development, first deploy, configuration, logging, infr
 ## Quick Start
 
 ```bash
-# Clone the repository
 git clone https://github.com/yeongseon/azure-functions-practical-guide.git
+cd azure-functions-practical-guide
 
-# Install MkDocs dependencies
-pip install mkdocs-material mkdocs-minify-plugin
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements-docs.txt
 
-# Start local documentation server
 mkdocs serve
 ```
 

--- a/docs/best-practices/index.md
+++ b/docs/best-practices/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/
 - type: mslearn-adapted

--- a/docs/best-practices/scaling.md
+++ b/docs/best-practices/scaling.md
@@ -62,6 +62,8 @@ Use these expectations to set realistic SLOs before load testing.
 !!! warning "Do not promise linear scaling"
     Throughput increases can stall when downstream quotas, storage contention, or network limits become bottlenecks.
 
+> **Last verified**: 2026-06-06 | **Primary source**: [Azure Functions event-driven scaling](https://learn.microsoft.com/azure/azure-functions/event-driven-scaling)
+
 ## Portal Walkthrough
 
 This section shows the Scale out blade for a live Function App (Consumption Y1, Korea Central). PII is masked.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/
 content_validation:

--- a/docs/language-guides/dotnet/cli-cheatsheet.md
+++ b/docs/language-guides/dotnet/cli-cheatsheet.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/dotnet-runtime.md
+++ b/docs/language-guides/dotnet/dotnet-runtime.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/supported-languages
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/environment-variables.md
+++ b/docs/language-guides/dotnet/environment-variables.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/host-json.md
+++ b/docs/language-guides/dotnet/host-json.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/index.md
+++ b/docs/language-guides/dotnet/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/isolated-worker-model.md
+++ b/docs/language-guides/dotnet/isolated-worker-model.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/platform-limits.md
+++ b/docs/language-guides/dotnet/platform-limits.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/blob-storage.md
+++ b/docs/language-guides/dotnet/recipes/blob-storage.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/cosmosdb.md
+++ b/docs/language-guides/dotnet/recipes/cosmosdb.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/dotnet/recipes/custom-domain-certificates.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/durable-orchestration.md
+++ b/docs/language-guides/dotnet/recipes/durable-orchestration.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/event-grid.md
+++ b/docs/language-guides/dotnet/recipes/event-grid.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/http-api.md
+++ b/docs/language-guides/dotnet/recipes/http-api.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/http-auth.md
+++ b/docs/language-guides/dotnet/recipes/http-auth.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/index.md
+++ b/docs/language-guides/dotnet/recipes/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library
 content_validation:

--- a/docs/language-guides/dotnet/recipes/key-vault.md
+++ b/docs/language-guides/dotnet/recipes/key-vault.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/managed-identity.md
+++ b/docs/language-guides/dotnet/recipes/managed-identity.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/queue.md
+++ b/docs/language-guides/dotnet/recipes/queue.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/recipes/timer.md
+++ b/docs/language-guides/dotnet/recipes/timer.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/troubleshooting.md
+++ b/docs/language-guides/dotnet/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted
@@ -219,3 +220,7 @@ Functions:
 - [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
 - [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
 - [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads and compatibility scenarios. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).
+

--- a/docs/language-guides/dotnet/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/index.md
+++ b/docs/language-guides/dotnet/tutorial/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-scale
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/premium/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/premium/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/dotnet/tutorial/premium/02a-first-deploy-private-egress.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/premium/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/premium/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/premium/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/premium/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
 - type: mslearn-adapted

--- a/docs/language-guides/index.md
+++ b/docs/language-guides/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 - type: mslearn-adapted

--- a/docs/language-guides/java/annotation-programming-model.md
+++ b/docs/language-guides/java/annotation-programming-model.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/cli-cheatsheet.md
+++ b/docs/language-guides/java/cli-cheatsheet.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/environment-variables.md
+++ b/docs/language-guides/java/environment-variables.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/host-json.md
+++ b/docs/language-guides/java/host-json.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/index.md
+++ b/docs/language-guides/java/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/java-runtime.md
+++ b/docs/language-guides/java/java-runtime.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/supported-languages
 - type: mslearn-adapted

--- a/docs/language-guides/java/platform-limits.md
+++ b/docs/language-guides/java/platform-limits.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/blob-storage.md
+++ b/docs/language-guides/java/recipes/blob-storage.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/cosmosdb.md
+++ b/docs/language-guides/java/recipes/cosmosdb.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/java/recipes/custom-domain-certificates.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-custom-domain
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/durable-orchestration.md
+++ b/docs/language-guides/java/recipes/durable-orchestration.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/event-grid.md
+++ b/docs/language-guides/java/recipes/event-grid.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid-trigger
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/http-api.md
+++ b/docs/language-guides/java/recipes/http-api.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/http-auth.md
+++ b/docs/language-guides/java/recipes/http-auth.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/index.md
+++ b/docs/language-guides/java/recipes/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
 content_validation:

--- a/docs/language-guides/java/recipes/key-vault.md
+++ b/docs/language-guides/java/recipes/key-vault.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/managed-identity.md
+++ b/docs/language-guides/java/recipes/managed-identity.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/queue.md
+++ b/docs/language-guides/java/recipes/queue.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
 - type: mslearn-adapted

--- a/docs/language-guides/java/recipes/timer.md
+++ b/docs/language-guides/java/recipes/timer.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
 - type: mslearn-adapted

--- a/docs/language-guides/java/troubleshooting.md
+++ b/docs/language-guides/java/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/java/tutorial/consumption/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted
@@ -196,3 +197,7 @@ Confirm that the Functions host starts, HTTP functions are listed in the endpoin
 - [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
 - [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
 - [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads and compatibility scenarios. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).
+

--- a/docs/language-guides/java/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/consumption/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/java/tutorial/consumption/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/consumption/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/consumption/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/consumption/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/consumption/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/java/tutorial/dedicated/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/dedicated/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/java/tutorial/dedicated/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/dedicated/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/dedicated/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/dedicated/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/index.md
+++ b/docs/language-guides/java/tutorial/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-scale
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/java/tutorial/premium/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/premium/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/java/tutorial/premium/02a-first-deploy-private-egress.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/java/tutorial/premium/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/premium/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/premium/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/premium/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/premium/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/cli-cheatsheet.md
+++ b/docs/language-guides/nodejs/cli-cheatsheet.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/environment-variables.md
+++ b/docs/language-guides/nodejs/environment-variables.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
 content_validation:

--- a/docs/language-guides/nodejs/host-json.md
+++ b/docs/language-guides/nodejs/host-json.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
 content_validation:

--- a/docs/language-guides/nodejs/index.md
+++ b/docs/language-guides/nodejs/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/nodejs-runtime.md
+++ b/docs/language-guides/nodejs/nodejs-runtime.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/platform-limits.md
+++ b/docs/language-guides/nodejs/platform-limits.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-scale
 content_validation:

--- a/docs/language-guides/nodejs/recipes/blob-storage.md
+++ b/docs/language-guides/nodejs/recipes/blob-storage.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/cosmosdb.md
+++ b/docs/language-guides/nodejs/recipes/cosmosdb.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/nodejs/recipes/custom-domain-certificates.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-custom-domain
 - type: mslearn-adapted
@@ -119,6 +120,7 @@ az functionapp update \
 
 
 Important hosting plan note:
+
 - Flex Consumption does not support App Service managed/platform certificates.
 - For Flex Consumption, use uploaded certificates or external TLS termination.
 

--- a/docs/language-guides/nodejs/recipes/durable-orchestration.md
+++ b/docs/language-guides/nodejs/recipes/durable-orchestration.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-node-model-upgrade
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/event-grid.md
+++ b/docs/language-guides/nodejs/recipes/event-grid.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid-trigger
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/http-api.md
+++ b/docs/language-guides/nodejs/recipes/http-api.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/http-auth.md
+++ b/docs/language-guides/nodejs/recipes/http-auth.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/index.md
+++ b/docs/language-guides/nodejs/recipes/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
 content_validation:

--- a/docs/language-guides/nodejs/recipes/key-vault.md
+++ b/docs/language-guides/nodejs/recipes/key-vault.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/managed-identity.md
+++ b/docs/language-guides/nodejs/recipes/managed-identity.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/queue.md
+++ b/docs/language-guides/nodejs/recipes/queue.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/recipes/timer.md
+++ b/docs/language-guides/nodejs/recipes/timer.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
 - type: mslearn-adapted
@@ -61,6 +62,7 @@ az functionapp config appsettings set \
 
 
 `WEBSITE_TIME_ZONE` support:
+
 - Windows plans: supported
 - Linux Premium and Dedicated: supported
 - Linux Consumption and Flex Consumption: not supported

--- a/docs/language-guides/nodejs/troubleshooting.md
+++ b/docs/language-guides/nodejs/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted
@@ -162,3 +163,7 @@ You now have local parity and can deploy to Azure Consumption (Y1).
 - [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
 - [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
 - [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads and compatibility scenarios. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).
+

--- a/docs/language-guides/nodejs/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: 2026-04-10
     result: pass
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/index.md
+++ b/docs/language-guides/nodejs/tutorial/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-scale
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/premium/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/premium/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/nodejs/tutorial/premium/02a-first-deploy-private-egress.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/premium/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/premium/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/premium/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/premium/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/v4-programming-model.md
+++ b/docs/language-guides/nodejs/v4-programming-model.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
 - type: mslearn-adapted

--- a/docs/language-guides/python/cli-cheatsheet.md
+++ b/docs/language-guides/python/cli-cheatsheet.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
 - type: mslearn-adapted

--- a/docs/language-guides/python/environment-variables.md
+++ b/docs/language-guides/python/environment-variables.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 content_validation:

--- a/docs/language-guides/python/host-json.md
+++ b/docs/language-guides/python/host-json.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
 content_validation:

--- a/docs/language-guides/python/index.md
+++ b/docs/language-guides/python/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 - type: mslearn-adapted

--- a/docs/language-guides/python/platform-limits.md
+++ b/docs/language-guides/python/platform-limits.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-scale#service-limits
 - type: mslearn-adapted

--- a/docs/language-guides/python/python-runtime.md
+++ b/docs/language-guides/python/python-runtime.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/supported-languages
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/blob-storage.md
+++ b/docs/language-guides/python/recipes/blob-storage.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/cosmosdb.md
+++ b/docs/language-guides/python/recipes/cosmosdb.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/python/recipes/custom-domain-certificates.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/durable-orchestration.md
+++ b/docs/language-guides/python/recipes/durable-orchestration.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/event-grid.md
+++ b/docs/language-guides/python/recipes/event-grid.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/http-api.md
+++ b/docs/language-guides/python/recipes/http-api.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/http-auth.md
+++ b/docs/language-guides/python/recipes/http-auth.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/security-concepts
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/index.md
+++ b/docs/language-guides/python/recipes/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/key-vault.md
+++ b/docs/language-guides/python/recipes/key-vault.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
 - type: mslearn-adapted

--- a/docs/language-guides/python/recipes/managed-identity.md
+++ b/docs/language-guides/python/recipes/managed-identity.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
 content_validation:

--- a/docs/language-guides/python/recipes/queue.md
+++ b/docs/language-guides/python/recipes/queue.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
 content_validation:

--- a/docs/language-guides/python/recipes/timer.md
+++ b/docs/language-guides/python/recipes/timer.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
 content_validation:

--- a/docs/language-guides/python/troubleshooting.md
+++ b/docs/language-guides/python/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/python/tutorial/consumption/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
 - type: mslearn-adapted
@@ -155,3 +156,7 @@ You now have local parity and can deploy to Azure Consumption (Y1).
 - [Run Functions locally with Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
 - [Azure Functions Consumption plan](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
 - [Python developer guide for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads and compatibility scenarios. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).
+

--- a/docs/language-guides/python/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/consumption/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/python/tutorial/consumption/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/consumption/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-infrastructure-as-code
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/consumption/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/consumption/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/python/tutorial/dedicated/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/dedicated/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/python/tutorial/dedicated/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/dedicated/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/dedicated/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/deployment-zip-push
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/dedicated/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/index.md
+++ b/docs/language-guides/python/tutorial/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/migration/migrate-plan-consumption-to-flex
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/python/tutorial/premium/01-local-run.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/premium/02-first-deploy.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/python/tutorial/premium/02a-first-deploy-private-egress.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/python/tutorial/premium/03-configuration.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/premium/04-logging-monitoring.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/premium/05-infrastructure-as-code.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-infrastructure-as-code
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/premium/06-ci-cd.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
@@ -9,6 +9,7 @@ validation:
     last_tested: null
     result: not_tested
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
 - type: mslearn-adapted

--- a/docs/language-guides/python/v2-programming-model.md
+++ b/docs/language-guides/python/v2-programming-model.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 - type: mslearn-adapted
@@ -385,6 +386,7 @@ app.register_functions(products_bp)
 ```
 
 This creates three endpoints:
+
 - `GET /api/products` — List all products
 - `GET /api/products/{product_id}` — Get a product by ID
 - `POST /api/products` — Create a new product

--- a/docs/operations/alerts.md
+++ b/docs/operations/alerts.md
@@ -74,6 +74,7 @@ Use the alert type that matches the failure signal:
 | **Log query alerts** | Pattern-based failures requiring KQL context | 5-minute to 15-minute windows | Yes |
 | **Smart detection** | ML-based anomaly hints in Application Insights | Model-driven intervals | No (triage first) |
 Quick decision rule:
+
 - Choose **metric alerts** for immediate platform symptoms like 5xx bursts.
 - Choose **log query alerts** for scoped conditions like per-function failure ratio.
 - Choose **smart detection** as supplementary signal, not your only paging mechanism.
@@ -106,6 +107,7 @@ This section shows portal blades relevant to alerting for a live Function App (C
 ## Procedure
 ### Alerting principles
 Use alert rules that are:
+
 - **Actionable**: someone can do something immediately.
 - **Low-noise**: avoid alert fatigue from unstable thresholds.
 - **Correlated**: combine function metrics and dependency signals.
@@ -175,6 +177,7 @@ Example output (PII masked):
 ### Metric alerts
 Metric alerts are ideal for fast detection of high-level service degradation.
 Typical Azure Functions metric alert candidates:
+
 - HTTP 5xx response trend.
 - Function execution activity drop (throughput anomaly).
 - High execution duration percentile.
@@ -227,6 +230,7 @@ Example output (PII masked):
 ### Log query alerts
 Log alerts are better for nuanced failure patterns not represented by one metric.
 Common KQL-based alert scenarios:
+
 - Failure rate exceeds baseline for specific functions.
 - Repeated exception signature appears in short window.
 - Queue backlog age exceeds acceptable processing delay.

--- a/docs/operations/cold-start.md
+++ b/docs/operations/cold-start.md
@@ -38,6 +38,7 @@ Cold start is startup latency after an app has no warm instance available.
     For Python deployment specifics, see the [Python Tutorial](../language-guides/python/tutorial/index.md).
 ## Prerequisites
 Before tuning cold start in production, prepare these inputs and permissions:
+
 - Azure CLI 2.60.0 or later with `functionapp`, `monitor`, and `resource` commands.
 - A Function App running in Consumption, Flex Consumption, Premium, or Dedicated.
 - Application Insights enabled for the Function App.
@@ -47,6 +48,7 @@ Use long-form CLI flags and keep sensitive values masked in runbooks.
 
 ## When to Use
 Invest in cold start mitigation when at least one condition is true:
+
 - Interactive HTTP APIs show first-hit latency that violates your SLO.
 - Burst traffic patterns trigger repeated scale-out and startup penalties.
 - Background trigger latency affects queue drain targets or downstream SLAs.
@@ -242,6 +244,7 @@ true
 ### 3) Optimize startup path
 #### Startup optimization techniques
 Apply these regardless of hosting plan:
+
 - Keep deployment artifact small.
 - Remove unused dependencies.
 - Delay expensive initialization until first use where safe.
@@ -251,6 +254,7 @@ Apply these regardless of hosting plan:
 #### Dependency and package optimization
 Operationally, dependency volume and native package loading often dominate startup time.
 Recommended practices:
+
 - Audit dependencies quarterly and remove unused packages.
 - Prefer lighter libraries for common operations.
 - Use run-from-package deployment for immutable and consistent startup files.
@@ -258,6 +262,7 @@ Recommended practices:
 
 #### Warmup and traffic shaping
 For plans without strong always-ready guarantees, use conservative warmup patterns:
+
 - Scheduled health ping to keep app active where appropriate.
 - Gradual traffic ramp during deployments.
 - Pre-deployment synthetic checks before traffic cutover.
@@ -371,6 +376,7 @@ If mitigation does not improve latency, run this sequence:
 4. Compare before/after KQL evidence across a 24-hour window.
 
 Common checks and rollback commands:
+
 - Dedicated Always On not effective: confirm plan type and rollback if required.
 ```bash
 az functionapp config set \

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -64,6 +64,7 @@ This section shows the key Azure Portal blades for Function App configuration. A
 
 ## When to Use
 Choose configuration layers by scope and change frequency:
+
 - **App settings** for environment-specific values, secrets, feature flags, and per-slot overrides.
 - **`host.json`** for host-wide runtime behavior such as logging, retries, extension tuning, and sampling.
 - **Extension-specific configuration** when tuning one binding type (for example Service Bus or Event Hubs) without changing business logic.
@@ -190,6 +191,7 @@ Use local settings only for local runtime execution.
 }
 ```
 Operational rules:
+
 - Do not commit production secrets.
 - Keep a sanitized `local.settings.json.example` in source control.
 - Inject secrets at deployment time via secure pipeline mechanisms.
@@ -365,6 +367,7 @@ Timestamp                    Message
 2026-04-05T09:20:42.017Z     2 functions loaded
 ```
 Success indicators:
+
 - Changed settings appear with expected values and expected slot scope.
 - Managed identity remains enabled and principal ID is unchanged unless intentionally rotated.
 - No startup failures related to binding initialization or secret resolution.
@@ -378,6 +381,7 @@ Config drift and incorrect settings playbook:
 3. Restart the app and verify host startup and trigger listener status.
 4. If only one slot is affected, swap back or redeploy the previous slot package.
 Targeted checks:
+
 - **`AzureWebJobsStorage` failures**: confirm identity settings, role assignments, and storage DNS reachability.
 - **Key Vault reference unresolved**: confirm vault access policy or RBAC and private endpoint routing.
 - **Unexpected throttling or backlog**: review `host.json` concurrency and extension settings.

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
 - type: mslearn-adapted

--- a/docs/operations/recovery.md
+++ b/docs/operations/recovery.md
@@ -40,6 +40,7 @@ It focuses on practical runbook execution for minimizing downtime and data loss.
     For Python deployment specifics, see the [Python Tutorial](../language-guides/python/tutorial/index.md).
 ## Prerequisites
 Prepare these baseline capabilities before an incident:
+
 - Azure CLI installed and authenticated with rights to the target subscription.
 - Release artifacts stored in immutable storage with version identifiers.
 - Monitoring available in Application Insights or Log Analytics.
@@ -118,6 +119,7 @@ Rebuild is used when both deployment state and environment integrity are uncerta
 
 ### Recovery objectives
 Define service objectives before incidents occur:
+
 - **RTO** (Recovery Time Objective): target time to restore service.
 - **RPO** (Recovery Point Objective): acceptable data loss window.
 RTO and RPO determine architecture, replication, and operational tooling.
@@ -223,6 +225,7 @@ Example output:
 ```
 ### Artifact and configuration backup
 Maintain these backups for every release:
+
 - Immutable build artifact with version metadata.
 - Infrastructure templates and parameter sets.
 - Exported app settings baseline (with secret values protected).
@@ -232,6 +235,7 @@ Keep backup assets in secured, versioned storage.
 ### Data and state resilience
 Most Azure Functions apps depend on storage and messaging services for state.
 Recovery depends on those services' durability configuration:
+
 - Use geo-redundant options where business continuity requires cross-region resilience.
 - Align queue/topic retention and replay capability with RPO targets.
 - Protect durable workflow state with storage redundancy and backup policy.
@@ -269,6 +273,7 @@ flowchart TD
 ```
 
 Concrete failover patterns:
+
 - **Traffic Manager Priority Routing**
     - Configure endpoint priority: primary = `1`, secondary = `2`.
     - Use endpoint monitoring path aligned to app health endpoint.
@@ -334,6 +339,7 @@ az afd origin update \
 
 ### Health-based decision gates
 Before failover or rollback, validate:
+
 - Current incident scope (app-only or dependency-wide).
 - Secondary environment readiness.
 - Data consistency and queue lag status.
@@ -341,6 +347,7 @@ Before failover or rollback, validate:
 
 ## Verification
 After recovery action:
+
 - Confirm health endpoint and key user journeys.
 - Verify failure rate and latency return to baseline.
 - Validate message processing catch-up.

--- a/docs/operations/retries-and-poison-handling.md
+++ b/docs/operations/retries-and-poison-handling.md
@@ -76,6 +76,7 @@ Azure Functions reliability for triggers is a combination of trigger-level deliv
 ### Built-in retry support
 Azure Functions supports retry behavior for selected triggers.
 Common trigger categories with retry support include:
+
 - Azure Storage Queue trigger.
 - Azure Service Bus trigger.
 - Azure Event Hubs trigger.
@@ -149,6 +150,7 @@ Concrete Event Hubs extension retry example:
 For Storage Queue triggers, messages that exceed `maxDequeueCount` are moved to a poison queue.
 
 Operational pattern:
+
 - Main queue: `orders`.
 - Poison queue: `orders-poison`.
 - Build a dedicated poison-message processor for triage and replay.
@@ -171,6 +173,7 @@ Service Bus uses dead-lettering semantics.
 Messages can be moved to the dead-letter subqueue after max delivery attempts or explicit dead-letter action.
 
 Operational responsibilities:
+
 - Monitor dead-letter message count.
 - Capture reason and error metadata.
 - Provide controlled replay tools or manual remediation workflow.
@@ -189,6 +192,7 @@ Avoid duplicate retry layering: if trigger-level retries are already active, exc
 
 ### Idempotency requirements
 Because retries and at-least-once delivery are common, handlers should be idempotent:
+
 - Use deterministic operation keys.
 - Record processed message identifiers where required.
 - Make writes safe for duplicate delivery.
@@ -227,6 +231,7 @@ def process_order(msg: func.QueueMessage) -> None:
 
 ### Monitoring retry and poison health
 Track these operational signals:
+
 - Retry attempt trend by function.
 - Poison queue message count growth.
 - Dead-letter count and age.
@@ -365,6 +370,7 @@ traces
 ```
 
 Verification checklist:
+
 - Retry event frequency declines after policy update.
 - Poison/dead-letter growth is non-monotonic or decreasing.
 
@@ -386,6 +392,7 @@ Troubleshooting sequence:
 4. Resume replay in controlled batches and monitor duplication signals.
 
 Common anti-patterns:
+
 - Raising retry counts without reducing concurrency.
 - Replaying poison queues before fixing schema/business-rule defects.
 - Combining trigger-level and in-code retries without total budget limits.

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -96,6 +96,7 @@ WORKSPACE_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RG/providers/Micro
 
 ## When to Use
 Use this runbook in these cases:
+
 - New production deployment that needs baseline hardening.
 - Recurring maintenance windows (daily, weekly, monthly).
 - Confirmed or suspected secret leakage, identity compromise, or abnormal access pattern.
@@ -413,6 +414,7 @@ az monitor scheduled-query create --name "func-auth-failures" --resource-group "
 
 ### Operational security routine
 Run this cadence and tighten by risk profile:
+
 - Daily: check 401/403 anomalies, confirm alert delivery, validate no emergency grant remains active.
 - Weekly: review RBAC changes, reconcile CORS allowlist, verify SCM restrictions match CI/CD egress ranges.
 - Monthly: rotate keys, validate Key Vault propagation and client cutover, re-check HTTPS/TLS baseline.

--- a/docs/platform/architecture/index.md
+++ b/docs/platform/architecture/index.md
@@ -214,6 +214,7 @@ In practice, Azure manages scale-controller policy as platform orchestration, wh
 
 ### Why architecture matters
 Architecture decisions in Azure Functions determine:
+
 - how events are received and dispatched,
 - where code executes,
 - how resources are connected,
@@ -237,6 +238,7 @@ flowchart TD
 
 ### Host process responsibilities
 The Functions host is the control plane and data-plane coordinator for your app instance. It is responsible for:
+
 - loading trigger and binding extensions,
 - maintaining trigger listeners,
 - routing invocation payloads,
@@ -297,6 +299,7 @@ sequenceDiagram
 
 ### Deployment unit and boundaries
 The **Function App** is the primary deployment and configuration boundary. It contains:
+
 - one or more functions,
 - app settings,
 - host settings,
@@ -336,6 +339,7 @@ Storage and identity are foundational runtime dependencies, not optional add-ons
 
 ### Flex Consumption architectural constraints
 When you choose Flex Consumption, account for these platform constraints early:
+
 - **No Kudu/SCM endpoint** for debugging/deployment workflows.
 - **Identity-based host storage is required** (for example, `AzureWebJobsStorage__accountName`).
 - **Blob trigger uses Event Grid source on Flex**; polling blob trigger mode is not supported.
@@ -441,6 +445,7 @@ Example output (sanitized):
 
 ### Operational domains vs platform domains
 Keep these concerns separate:
+
 - **Platform docs (this section):** what to design and why.
 - **Operations docs:** how to deploy, monitor, and recover.
 
@@ -506,6 +511,7 @@ flowchart TD
 ### Durable Functions orchestration architecture
 Durable Functions adds a workflow orchestration layer above standard trigger execution. The architecture introduces deterministic orchestration and checkpointed state transitions.
 Core components:
+
 - **Orchestrator function** defines workflow state machine.
 - **Activity functions** execute unit operations.
 - **Durable storage provider** persists orchestration history and checkpoints.
@@ -541,11 +547,13 @@ How it works:
 4. The host applies output binding and completion semantics.
 
 Best when:
+
 - you need a language/runtime not covered by built-in workers,
 - you need strict runtime control,
 - or you are wrapping an existing service binary into the Functions model.
 
 Trade-offs:
+
 - more ownership for startup behavior and diagnostics,
 - fewer language-specific developer conveniences,
 - and stricter validation required for contract compatibility.

--- a/docs/platform/hosting.md
+++ b/docs/platform/hosting.md
@@ -33,6 +33,9 @@ content_validation:
 
 Choosing a hosting plan is the most important Azure Functions platform decision. It controls scale behavior, cold start profile, networking options, limits, and baseline cost.
 
+!!! info "Scope: classic hosting plans"
+    This guide covers Flex Consumption, Consumption, Premium, and Dedicated plans. Azure Container Apps hosting for Azure Functions is a separate hosting model not covered here.
+
 ## Prerequisites
 
 Before selecting a plan, align on these inputs with your application and platform teams:
@@ -90,6 +93,10 @@ Azure Functions supports four main hosting models:
 
 !!! tip "Decision rule"
     Start with Flex Consumption for most new serverless workloads, then choose Premium when you need permanently warm behavior and advanced App Service premium features.
+
+> **Last verified**: 2026-06-06 | **Primary source**: [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+>
+> Key values subject to change: Flex Consumption max instances, function timeout defaults/maximums, Linux Consumption retirement timeline, deployment slot support, Kudu/SCM availability, private endpoint and VNet integration support, scale behavior by trigger type.
 
 <!-- diagram-id: hosting-plans-at-a-glance -->
 ```mermaid

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
 - type: mslearn-adapted

--- a/docs/platform/networking-scenarios/fixed-outbound-nat.md
+++ b/docs/platform/networking-scenarios/fixed-outbound-nat.md
@@ -298,6 +298,7 @@ NAT Gateway has specific capacity limits:
 | Connections per second | 50,000 |
 
 For high-scale workloads:
+
 - Add more public IPs or use IP prefix
 - Distribute across multiple NAT Gateways with different subnets
 

--- a/docs/platform/networking.md
+++ b/docs/platform/networking.md
@@ -26,12 +26,14 @@ content_validation:
 
 # Networking
 Azure Functions networking design has two separate concerns:
+
 - **Inbound**: who can call your function endpoints.
 - **Outbound**: what your functions can reach.
 Capabilities differ significantly by hosting plan, so networking must be chosen together with hosting.
 
 ## Prerequisites
 Prepare these items before applying networking controls:
+
 - Azure CLI authenticated to the target subscription.
 - Function App already deployed.
 - VNet and subnets planned for integration and private endpoints.
@@ -269,16 +271,19 @@ Planning baseline:
 2. Prefer pooled transport defaults unless measured otherwise.
 
 Observable symptoms:
+
 - Intermittent dependency timeouts at peak traffic.
 - Error bursts that recover after scale events or restarts.
 - Heavier impact on high fan-out destinations.
 
 Mitigation options:
+
 - Add NAT Gateway capacity for larger outbound concurrency.
 - Reduce avoidable parallel outbound operations.
 
 ### Subnet delegation requirements
 When configuring VNet integration, subnet delegation depends on plan:
+
 - Flex Consumption: `Microsoft.App/environments`
 - Premium and Dedicated: `Microsoft.Web/serverFarms`
 Plan this before deployment to avoid subnet redesign.
@@ -287,6 +292,7 @@ Plan this before deployment to avoid subnet redesign.
 Private endpoint architectures require private DNS resolution.
 
 Recommended baseline:
+
 - Use `privatelink.azurewebsites.net` naming for Function App private endpoint records.
 - Link private DNS zones to every VNet that must resolve private endpoints.
 - Configure conditional forwarding in hybrid DNS environments.
@@ -318,6 +324,7 @@ sequenceDiagram
 
 ### Hybrid connectivity
 For on-premises integration:
+
 - Premium and Dedicated support Hybrid Connections.
 - VNet integration with VPN/ExpressRoute supports broader private reachability.
 Use Hybrid Connections when simple TCP reachability is enough and full private routing is not required.
@@ -330,6 +337,7 @@ Use Hybrid Connections when simple TCP reachability is enough and full private r
 
 ### Security alignment
 Networking should align with identity and authorization controls:
+
 - Function authorization level for endpoint keys.
 - App Service Authentication for user/workload identity.
 - Managed identity for service-to-service access.
@@ -387,6 +395,7 @@ A practical zero-trust ingress model for Functions is:
 
 ### Multi-environment DNS governance
 For dev/test/prod environments:
+
 - Standardize zone naming and ownership.
 - Define zone-link conventions in infrastructure code.
 - Version control conditional forwarder rules.
@@ -419,6 +428,7 @@ Networking architecture is shared, but connection behavior differs by runtime.
 - [.NET guide index](../language-guides/dotnet/index.md)
 
 Runtime focus areas:
+
 - Python: process model and HTTP client reuse.
 - Node.js/.NET/Java: use pooled clients and tuned connection lifetime settings.
 

--- a/docs/platform/reliability.md
+++ b/docs/platform/reliability.md
@@ -33,6 +33,7 @@ content_validation:
 Reliability in Azure Functions is a design concern, not only an operations concern. Your trigger model, hosting plan, retry policy, and network topology jointly determine failure behavior.
 ## Prerequisites
 Before you finalize reliability design decisions, verify these prerequisites:
+
 - You know the trigger semantics for each workload (at-most-once, at-least-once, checkpoint-driven).
 - You have a defined business SLO/SLA for latency, recovery time, and acceptable data loss.
 - You can map each critical dependency (storage, messaging, identity, database, DNS, network).
@@ -87,6 +88,7 @@ Design for reliability across four layers:
 ### Retry strategy
 Azure Functions supports built-in retry behavior for supported triggers.
 Common retry models:
+
 - Fixed delay retry
 - Exponential backoff retry
 Use retries for transient failures only. Non-transient failures should route to dead-letter/poison handling paths.
@@ -219,6 +221,7 @@ Use these examples as host-level reliability templates. Trigger-level retry decl
 ### Poison message handling
 For queue-based triggers, repeated failure eventually moves messages to poison/dead-letter paths (service-specific behavior).
 Design requirements:
+
 - preserve original payload and correlation metadata,
 - alert on poison queue growth,
 - provide replay workflow after remediation,
@@ -307,6 +310,7 @@ flowchart TD
 ### Idempotency is mandatory
 Because retries and duplicate deliveries are normal in distributed systems, handlers must be idempotent.
 Idempotency patterns:
+
 - deterministic operation keys,
 - upsert instead of blind insert,
 - de-duplication table/cache,
@@ -346,6 +350,7 @@ def process_order(msg: func.QueueMessage) -> None:
 
 ### Dependency resilience
 Protect downstream dependencies using:
+
 - timeout budgets per call,
 - transient retry with jitter,
 - circuit breaking,
@@ -423,6 +428,7 @@ Exactly-once transport is rarely available end-to-end; achieve exactly-once effe
 
 ### Multi-region failover
 Choose strategy based on workload criticality and recovery objectives:
+
 - **Active-passive**: lower cost, simpler operations, longer failover time.
 - **Active-active**: higher complexity, better regional fault tolerance.
 
@@ -433,6 +439,7 @@ Health endpoints and synthetic probes improve early detection of reliability reg
 
 ## Language-Specific Details
 Use language-specific guidance for runtime nuances, extension bundles, and host configuration details:
+
 - Python: [Python Guide](../language-guides/python/index.md), [host.json for Python](../language-guides/python/host-json.md), [Python troubleshooting](../language-guides/python/troubleshooting.md)
 - Node.js: [Node.js Guide](../language-guides/nodejs/index.md)
 - .NET: [.NET Guide](../language-guides/dotnet/index.md)

--- a/docs/platform/scaling.md
+++ b/docs/platform/scaling.md
@@ -31,7 +31,9 @@ content_validation:
 # Scaling Behavior
 Azure Functions scaling is plan-dependent and trigger-dependent. You do not configure a single universal autoscaler; instead, the platform applies trigger-specific heuristics within plan limits.
 ## Prerequisites
+
 Before tuning scale behavior, make sure the following prerequisites are in place:
+
 - You know the selected hosting plan (`Consumption`, `Flex Consumption`, `Premium`, or `Dedicated`) and its operational limits.
 - You have access to Azure CLI, and your environment is authenticated with `az login`.
 - You have Reader or Contributor access to the Function App, plan, storage account, and Application Insights.
@@ -39,6 +41,7 @@ Before tuning scale behavior, make sure the following prerequisites are in place
 - You understand downstream service limits (database connections, API rate limits, NAT port limits).
 
 Optional but recommended:
+
 - A repeatable load test path to validate scale decisions before production rollout.
 - A rollback plan for host-level concurrency and timeout changes.
 - Baseline metrics from a known healthy period for comparison.
@@ -66,6 +69,7 @@ This section shows portal blades illustrating scale behavior for a live Function
 ### Scale controller fundamentals
 For serverless plans, Azure Functions scale controller evaluates event pressure and target throughput, then adds or removes instances.
 Primary signals include:
+
 - HTTP concurrency and request backlog,
 - queue/topic/event backlog,
 - partition lag (streaming sources),
@@ -80,6 +84,7 @@ flowchart TD
     SO --> R[Runtime host + workers on new instances]
 ```
 Notes:
+
 - Scale-out is not instant; host startup and binding initialization introduce delay.
 - The controller optimizes for throughput and reliability, not one-request-per-instance behavior.
 ### Plan-level scaling model
@@ -90,6 +95,7 @@ Notes:
 | Premium | Warm minimum instances | Elastic above warm floor | Bounded by Premium plan settings |
 | Dedicated | Fixed/Autoscale rules | App Service autoscale | Plan VM and rule dependent |
 Practical implications by plan:
+
 - **Consumption**: cost-first workloads where occasional cold start is acceptable.
 - **Flex/Premium**: stronger low-latency and burst handling with warm strategies.
 - **Dedicated**: deterministic capacity and App Service-aligned operations.
@@ -135,6 +141,7 @@ flowchart TD
     AR -.-> IB
 ```
 Operational guidance:
+
 - Assign always-ready instances to latency-sensitive paths first (usually HTTP).
 - Validate cost delta between always-ready floor and observed latency gain.
 - Keep trigger groups isolated if one workload has highly variable burst behavior.
@@ -149,11 +156,13 @@ Premium is designed for low-latency scale with warm capacity.
 Premium reduces startup latency by maintaining permanently warm capacity, suitable for strict response-time requirements.
 
 Typical fit:
+
 - Low-latency APIs with enterprise network controls.
 - Dependency chains sensitive to cold initialization.
 - Workloads prioritizing latency predictability over minimum idle cost.
 ### Dedicated scaling
 Dedicated follows App Service scaling rules:
+
 - manual instance count,
 - or autoscale based on CPU/memory/schedules,
 - no scale-to-zero behavior.
@@ -174,12 +183,14 @@ When to consider Dedicated: existing App Service governance, stable baseline dem
 - Schedule-driven; generally not throughput-scaled like backlog triggers.
 
 Design reminder:
+
 - Prefer queue decoupling when dependency latency can cascade into HTTP saturation.
 
 ### Concurrency and throughput design
 Throughput is a function of both instance count and per-instance concurrency.
 
 Design guidance:
+
 - keep handlers idempotent,
 - avoid long blocking calls on HTTP paths,
 - isolate heavy async processing from public API functions,
@@ -195,6 +206,7 @@ Concurrency tuning checklist:
 ### Scale and networking dependency
 Scaling faster than your network or backend quotas can increase failures.
 Check before raising scale ceilings:
+
 - subnet address capacity,
 - NAT or firewall throughput,
 - service throttling limits,
@@ -368,6 +380,7 @@ Recommended approach:
 3. Increase only when SLO gain justifies added baseline cost.
 
 Signals to watch:
+
 - First-request latency after idle periods.
 - Burst ramp-up duration before steady-state throughput.
 - Cost per successful request under mixed idle and burst traffic.
@@ -376,6 +389,7 @@ Signals to watch:
 Target-based scaling means the platform aims to keep each instance near a processing target derived from trigger type and workload shape.
 
 Practical consequences:
+
 - If per-message processing time rises, instance demand rises for the same arrival rate.
 - If concurrency increases safely, fewer additional instances may be required.
 - If target signals are noisy, short-term oscillation can occur during sudden traffic changes.
@@ -386,6 +400,7 @@ Operational practice: use stable test windows (10 to 30 minutes) and compare bef
 Host-level concurrency settings can improve throughput, but aggressive values can amplify retries and downstream throttling.
 
 Tuning guidance:
+
 - Increase one dimension at a time (batch size, concurrency, or downstream connection pool).
 - Keep idempotency and poison-message handling robust before increasing throughput targets.
 - Revalidate alert thresholds after concurrency changes because baseline metric ranges shift.
@@ -394,11 +409,13 @@ Tuning guidance:
 Durable Functions adds orchestrator and activity behavior that changes scaling characteristics.
 
 Key points:
+
 - Orchestrators replay state and should remain deterministic.
 - Activity functions carry heavy work and are primary throughput drivers.
 - Storage and task-hub throughput become part of scale constraints.
 
 Design recommendations:
+
 - Keep orchestrator logic lightweight and deterministic.
 - Move external calls and CPU-heavy work into activity functions.
 - Validate storage account and task-hub throughput under projected fan-out patterns.
@@ -412,6 +429,7 @@ Scaling principles are platform-level, but runtime behavior and tuning levers di
 - .NET guide: [.NET language guides](../language-guides/dotnet/index.md)
 
 Cross-reference for implementation decisions:
+
 - Trigger model and binding behavior: [Triggers and bindings](triggers-and-bindings.md)
 - Hosting trade-offs and limits: [Hosting](hosting.md)
 - Reliability and resiliency patterns: [Reliability](reliability.md)

--- a/docs/platform/security.md
+++ b/docs/platform/security.md
@@ -124,6 +124,7 @@ Azure Functions supports three key-based authorization levels for HTTP triggers.
 | `admin` | Master key required | Runtime/admin operations only |
 
 Design guidance:
+
 - Use `anonymous` only with compensating controls (Easy Auth, APIM JWT policy, private network).
 - Use `function` for low-friction internal integrations.
 - Do not expose `admin` operations on untrusted networks.
@@ -156,6 +157,7 @@ Easy Auth mainly solves authentication and token validation. You still enforce a
 
 ### Token store and session management
 Easy Auth can maintain sign-in sessions and provider token context for web flows. For API architectures:
+
 - Prefer bearer-token patterns.
 - Design for token expiration and refresh policy.
 - Avoid browser-session assumptions for machine clients.
@@ -204,6 +206,7 @@ Use custom JWT validation (or APIM `validate-jwt`) when you need custom issuer r
 ### JWT and OAuth 2.0 patterns
 ### When to validate JWTs manually
 Manual validation is common when:
+
 - Issuer is custom or tenant-dependent.
 - API-to-API contracts require explicit token policy.
 - Validation is centralized in APIM or custom middleware.
@@ -260,6 +263,7 @@ az functionapp cors add \
 ```
 
 Wildcard origin risks:
+
 - `*` allows any origin.
 - Increases browser-side data exposure risk.
 - Avoid in production unless endpoint is intentionally public.
@@ -327,6 +331,7 @@ Preferred order:
 
 ### Network security controls
 Combine identity with network boundaries:
+
 - IP access restrictions
 - Private endpoints
 - VNet integration for private outbound
@@ -334,6 +339,7 @@ Combine identity with network boundaries:
 
 ### Threat model for serverless
 Common attack vectors in Functions workloads:
+
 - Injection through HTTP body/query/header input
 - Over-permissive triggers or exposed admin endpoints
 - Credential leakage in logs and telemetry

--- a/docs/platform/triggers-and-bindings.md
+++ b/docs/platform/triggers-and-bindings.md
@@ -36,6 +36,7 @@ Triggers and bindings are the core integration abstraction in Azure Functions. A
 
 ## Prerequisites
 Before designing trigger and binding architecture, align these baseline decisions:
+
 - Choose the hosting plan first (Consumption, Flex Consumption, Premium, or Dedicated).
 - Confirm trigger compatibility for the selected plan, especially Blob and Event Grid behavior.
 - Decide connection strategy per binding:
@@ -81,6 +82,7 @@ This section shows portal blades relevant to trigger and binding configuration f
 ## Main Content
 ### Core model
 Every function has:
+
 - exactly **one trigger**,
 - zero or more **input bindings**,
 - zero or more **output bindings**.
@@ -140,12 +142,14 @@ flowchart TB
 ```
 ### Binding behavior
 Bindings reduce plumbing code but still require you to model:
+
 - idempotency,
 - retries and duplicate delivery,
 - payload schema evolution,
 - destination latency and throttling.
 Bindings are not a replacement for domain-level error handling.
 Recommended behavior guardrails:
+
 - **Message contract**: include `schemaVersion` and enforce required fields.
 - **Idempotency key**: upsert by deterministic business key.
 - **Poison strategy**: route repeated failures to dead-letter destination.
@@ -196,6 +200,7 @@ App settings store a secret:
 OrdersStorage=DefaultEndpointsProtocol=https;AccountName=<storage-account>;AccountKey=<masked-key>;EndpointSuffix=core.windows.net
 ```
 Decision guidance:
+
 - Prefer identity-based config when supported by the binding extension.
 - Use connection strings only when identity is blocked or unavailable.
 - Avoid mixing identity and key-based access for the same service unless you are in controlled migration.
@@ -211,6 +216,7 @@ flowchart TD
     FN --> AI[(Application Insights Telemetry)]
 ```
 Design notes:
+
 - Keep one business responsibility per function.
 - If partial fan-out failure is unacceptable, use an outbox pattern.
 - Validate downstream idempotency before increasing parallelism.
@@ -324,6 +330,7 @@ Bindings and trigger extensions are controlled in `host.json`.
 }
 ```
 Tuning guidance:
+
 - Increase `queues.batchSize` only after confirming downstream write capacity.
 - Tune `eventHubs.maxEventBatchSize` with partition count and memory limits.
 - Change one concurrency lever at a time and compare telemetry windows.
@@ -367,6 +374,7 @@ Custom bindings are useful when no first-class extension exists and repeated SDK
 - Version custom binding contracts and publish migration notes.
 ### Durable Functions triggers
 Durable Functions adds orchestration-centric triggers:
+
 - **Orchestration trigger**: coordinates deterministic workflows.
 - **Activity trigger**: executes side-effecting units of work.
 - **Entity trigger**: provides serialized stateful operations.
@@ -388,20 +396,24 @@ Treat extension bundle upgrades like dependency upgrades with staged rollout:
 2. Compare failure rates, cold start behavior, and throughput.
 3. Promote gradually with rollback criteria.
 Recommended pattern:
+
 - Pin a compatible major range (for example, `[4.*, 5.0.0)`).
 - Avoid unbounded version ranges.
 - Revalidate trigger defaults when changing bundle ranges.
 ### Trigger-specific scaling signals deep dive
 Each trigger family scales from different pressure signals:
+
 - **Queue/Service Bus**: backlog, lock renewal pressure, dequeue latency.
 - **Event Hubs**: partition lag and ingest velocity.
 - **HTTP**: concurrent request pressure and latency percentiles.
 - **Timer**: schedule-driven execution, not demand-driven scale.
 Design implication:
+
 - Keep trigger-to-workload mapping explicit to preserve useful scale signals.
 - Avoid mixing unrelated high-variance workloads behind one trigger unless isolation is not required.
 ## Language-Specific Details
 Use language guides for runtime-specific syntax, decorators/attributes, and package setup:
+
 - [Python v2 Programming Model](../language-guides/python/v2-programming-model.md)
 - [Python Recipes: Queue](../language-guides/python/recipes/queue.md)
 - [Python Recipes: Blob Storage](../language-guides/python/recipes/blob-storage.md)

--- a/docs/reference/cli-cheatsheet.md
+++ b/docs/reference/cli-cheatsheet.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
 - type: mslearn-adapted

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 content_validation:

--- a/docs/reference/host-json.md
+++ b/docs/reference/host-json.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
 content_validation:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/
 - type: mslearn-adapted

--- a/docs/reference/platform-limits.md
+++ b/docs/reference/platform-limits.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-scale#service-limits
 content_validation:

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
 - type: mslearn-adapted

--- a/docs/start-here/hosting-options.md
+++ b/docs/start-here/hosting-options.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-scale
 - type: mslearn-adapted

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
 - type: mslearn-adapted

--- a/docs/start-here/learning-paths.md
+++ b/docs/start-here/learning-paths.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-overview
 - type: mslearn-adapted

--- a/docs/start-here/overview.md
+++ b/docs/start-here/overview.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-overview
 - type: mslearn-adapted

--- a/docs/start-here/repository-map.md
+++ b/docs/start-here/repository-map.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/
 content_validation:

--- a/docs/troubleshooting/evidence-map.md
+++ b/docs/troubleshooting/evidence-map.md
@@ -105,14 +105,17 @@ Host initialized (Xms)
 ```
 
 What it means:
+
 - Host acquired storage lease and completed startup sequence.
 - Trigger listeners can initialize normally.
 
 Normal vs abnormal:
+
 - Normal: sequence appears once on cold start or planned recycle.
 - Abnormal: repeated startup cycles in short intervals with no stable execution window.
 
 Next step:
+
 - If healthy, move focus to function code or dependencies.
 - If startup loops, correlate with Activity Log changes and container health events.
 
@@ -127,14 +130,17 @@ The operation was canceled.
 ```
 
 What it means:
+
 - Worker failed to initialize or function execution exceeded configured timeout.
 - Can indicate runtime mismatch, blocking startup code, or downstream stall.
 
 Normal vs abnormal:
+
 - Normal: occasional timeout under rare dependency spikes.
 - Abnormal: repeated timeout messages across many invocations or immediately after deploy.
 
 Next step:
+
 - Check deployment/runtime compatibility and recent config changes.
 - Query `dependencies` for latency spike and validate timeout policy.
 
@@ -149,14 +155,17 @@ Unable to connect to the remote server
 ```
 
 What it means:
+
 - Connection target is unreachable, blocked, or not listening.
 - Storage auth or network path is broken for trigger/binding operations.
 
 Normal vs abnormal:
+
 - Normal: brief transient bursts with automatic retry recovery.
 - Abnormal: sustained failures causing trigger silence, retry storms, or poison growth.
 
 Next step:
+
 - Validate storage identity/RBAC and firewall/network rules.
 - Confirm connection strings or identity-based settings are present and correct.
 
@@ -171,14 +180,17 @@ Sending SIGTERM to container
 ```
 
 What it means:
+
 - Platform health probe marked instance unhealthy and initiated recycle.
 - Usually associated with startup deadlock, severe resource pressure, or port binding failure.
 
 Normal vs abnormal:
+
 - Normal: isolated occurrence during planned restart.
 - Abnormal: repeated probe failures with short-lived containers and rising `503`.
 
 Next step:
+
 - Review host startup sequence and memory/CPU pressure.
 - Correlate with deployment changes and warm-up behavior.
 
@@ -194,14 +206,17 @@ Request timed out after 230000ms
 ```
 
 What it means:
+
 - Requests hit transition window between old and new host states.
 - Can indicate cold-start amplification or unhealthy rollout.
 
 Normal vs abnormal:
+
 - Normal: brief `503` blip during controlled swap/restart.
 - Abnormal: prolonged timeout window and repeated shutdown/start loops.
 
 Next step:
+
 - Check if restart reason is platform, deployment, or configuration.
 - Validate slot health before swap and ensure dependency readiness.
 
@@ -216,14 +231,17 @@ A connection attempt failed because the connected party did not properly respond
 ```
 
 What it means:
+
 - Name resolution failed or resolved endpoint is unreachable from current network route.
 - Common with private endpoint DNS zone linkage or route misconfiguration.
 
 Normal vs abnormal:
+
 - Normal: short-lived resolver transient with fast retry recovery.
 - Abnormal: persistent `ENOTFOUND` against private endpoints across instances.
 
 Next step:
+
 - Verify VNet integration, private DNS zone link, and route table intent.
 - Cross-check dependency failures by target in `dependencies`.
 

--- a/docs/troubleshooting/first-10-minutes/index.md
+++ b/docs/troubleshooting/first-10-minutes/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
 - type: mslearn-adapted

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/
 - type: mslearn-adapted

--- a/docs/troubleshooting/kql/correlation/index.md
+++ b/docs/troubleshooting/kql/correlation/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-monitor/app/correlation
 - type: mslearn-adapted

--- a/docs/troubleshooting/kql/dependencies/index.md
+++ b/docs/troubleshooting/kql/dependencies/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/storage-considerations
 - type: mslearn-adapted

--- a/docs/troubleshooting/kql/execution/index.md
+++ b/docs/troubleshooting/kql/execution/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/data-explorer/kusto/query/
 - type: mslearn-adapted

--- a/docs/troubleshooting/kql/index.md
+++ b/docs/troubleshooting/kql/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
 - type: mslearn-adapted

--- a/docs/troubleshooting/kql/scaling/index.md
+++ b/docs/troubleshooting/kql/scaling/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-scale
 - type: mslearn-adapted

--- a/docs/troubleshooting/lab-guides/cold-start.md
+++ b/docs/troubleshooting/lab-guides/cold-start.md
@@ -88,6 +88,7 @@ Design intent for this lab:
 3. Compare full idle cold, post-restart cold, and fully warm behavior.
 4. Cross-check timeline with host startup traces from `traces` table.
 The intentionally measured outcomes from this repository's recorded run:
+
 - Full-idle cold request: `30.485s` client-side.
 - Post-restart first request: `3.156s` client-side.
 - Warm requests: `0.067s-0.099s` client-side.
@@ -102,6 +103,7 @@ A single request timing value does not directly expose phase attribution.
 | Host startup traces | `traces` | Host lifecycle checkpoints | Network/TLS/client overhead | "Host started fast therefore no cold start happened" |
 | Scale-event trace + request correlation | `traces` + `requests` | Mid-flight elasticity behavior | Full idle-to-allocate phase certainty | "All spikes are dependency latency" |
 Interpretation rule for this lab:
+
 - Use at least two channels for attribution: `traces` lifecycle + `requests` duration bands.
 - Treat client-side first hit as symptom, not root cause.
 - Validate whether host startup is the bottleneck or merely one sub-phase.
@@ -145,10 +147,12 @@ Misclassification of cold-start signals creates expensive operational mistakes:
 3. Incorrect mitigation (dependency tuning) for a provisioning bottleneck.
 4. Under-investment in plan choice (Y1 vs FC1 vs EP) for latency-sensitive workloads.
 A high-quality triage process must identify:
+
 - Whether latency cluster is full idle provisioning, host startup, scale-out warm-up, or dependency delay.
 - Whether mitigation is architectural (plan and always-ready) or code-level (startup workload reduction).
 ### 1.8 MS Learn grounding
 This lab aligns to Microsoft Learn guidance on:
+
 - Azure Functions hosting plans and scale behavior.
 - Monitoring and diagnosing Azure Functions with Application Insights.
 - Cold-start mitigation strategies through plan capabilities and startup optimization.
@@ -180,6 +184,7 @@ All criteria below should be satisfied to support the hypothesis:
 5. Post-restart first hit is significantly lower than full-idle first hit (`3.156s` vs `30.485s`).
 ### 2.4 Disproof criteria
 Any condition below weakens or falsifies the hypothesis:
+
 - Host startup trace durations are consistently high and close to first-hit total latency.
 - Warm baseline remains elevated after startup window (persistent regression).
 - Dependency failures or timeouts explain most of the latency increase.
@@ -489,6 +494,7 @@ warm_after_restart 200 0.074
 #### Server-side duration band
 ```text
 health function:
+
 - warm: 3.63ms to 5.86ms
 - cold start or scale-out warm-up (attribution requires correlation with traces): 1719ms to 1842ms
 ```
@@ -603,6 +609,7 @@ Derived ratios:
 | Restart cold / warm mean | 41.0x |
 | Full idle cold / restart cold | 9.7x |
 Interpretation:
+
 - Full idle path has an additional high-latency phase absent in restart path.
 - Restart still incurs startup cost but much lower than full idle allocation path.
 - Warm requests remain tightly clustered under 100ms client-side.
@@ -659,6 +666,7 @@ Representative lines seen in this repository context:
 2026-04-04T11:30:50Z Worker process started and initialized.
 ```
 Interpretation:
+
 - Burst of worker-initialization messages may indicate scale-out, restart, or initial startup.
 - Intermediate latency (`~1.7s-1.8s`) is expected during such events.
 #### 4.6.4 Query 8 host startup/shutdown highlights
@@ -670,6 +678,7 @@ Expected healthy sequence:
 | Near start window | `Host started (Xms)` | Host readiness achieved |
 | Steady state | No frequent shutdown loop | Stable runtime |
 Abnormal pattern to watch:
+
 - Repeated `Host is shutting down` and `Host started` loops with concurrent request failures.
 ### 4.7 Comparative plan interpretation
 #### 4.7.1 FC1 (Flex Consumption)

--- a/docs/troubleshooting/lab-guides/index.md
+++ b/docs/troubleshooting/lab-guides/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
 - type: mslearn-adapted

--- a/docs/troubleshooting/playbooks/deployment-failures.md
+++ b/docs/troubleshooting/playbooks/deployment-failures.md
@@ -131,6 +131,7 @@ az functionapp show \
 | Expected result | Azure CLI returns the requested resource data; verify names, IDs, status fields, or metric values match the scenario. |
 
 Expected read:
+
 - `state` should settle at `Running`.
 - `linuxFxVersion` should match intended runtime.
 - Linux app should report `reserved: true`.

--- a/docs/troubleshooting/playbooks/functions-not-executing.md
+++ b/docs/troubleshooting/playbooks/functions-not-executing.md
@@ -297,6 +297,7 @@ Example output:
 |---|---|
 | 2026-04-04T12:15:42Z | Function 'QueueProcessor' is disabled via app setting 'AzureWebJobs.QueueProcessor.Disabled'. |
 Disproof condition:
+
 - No disable setting and no disable trace in incident window.
 
 ### H2: Listener startup failure due to auth/connection
@@ -326,6 +327,7 @@ Example output:
 | 2026-04-04T12:22:53Z | 3 | Process reporting unhealthy: azure.functions.webjobs.storage: Unhealthy (AuthorizationPermissionMismatch) |
 | 2026-04-04T12:16:06Z | 2 | The listener for function 'Functions.QueueProcessor' was unable to start. |
 Disproof condition:
+
 - Startup traces show healthy listener with no recurring auth/connectivity errors.
 
 ### H3: Host restart loop suppresses execution
@@ -354,6 +356,7 @@ Example output:
 | 2026-04-04T12:00:00Z | 9 | 8 |
 | 2026-04-04T11:00:00Z | 2 | 1 |
 Disproof condition:
+
 - Restart count is low and steady; no cycle evidence.
 
 ### H4: Trigger misbinding or extension mismatch
@@ -382,6 +385,7 @@ Example output:
 |---|---|
 | 2026-04-04T12:11:27Z | Error indexing method 'Functions.QueueProcessor'. Cannot bind parameter 'msg' to type ... |
 Disproof condition:
+
 - No binding/indexing failures and listener healthy.
 
 ### H5: Source-side delivery gap
@@ -409,6 +413,7 @@ Example output:
 |---|---|---|
 | 2026-04-04T12:15:00Z | Functions.health | 22 |
 Disproof condition:
+
 - Source activity confirmed while target function remains non-executing.
 
 ### H6: Deployment/runtime regression
@@ -441,6 +446,7 @@ timestamp                    message
 2026-04-04T12:30:03.000000Z  Host is shutting down.
 ```
 Disproof condition:
+
 - No startup/runtime errors and no timeline correlation.
 
 ## 7. Likely Root Cause Patterns
@@ -500,6 +506,7 @@ union isfuzzy=true
 | order by timestamp desc
 ```
 Recovery criteria:
+
 - `Listener started` appears with no new `unable to start` entries.
 - Target function invocation count rises within expected trigger interval.
 - Failures remain below team threshold for 30-60 minutes.

--- a/docs/troubleshooting/playbooks/index.md
+++ b/docs/troubleshooting/playbooks/index.md
@@ -1,5 +1,6 @@
 ---
 content_sources:
+
 - type: mslearn-adapted
   url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
 - type: mslearn-adapted

--- a/docs/troubleshooting/playbooks/scaling/durable-orchestration-stuck.md
+++ b/docs/troubleshooting/playbooks/scaling/durable-orchestration-stuck.md
@@ -262,6 +262,7 @@ timestamp                   functionName             instanceId                 
 If no deterministic violation traces appear and code review confirms orchestrator uses deterministic APIs (`context.CurrentUtcDateTime`, `context.NewGuid`), deprioritize this hypothesis.
 
 Code-level anti-pattern checklist:
+
 - Direct calls to current clock APIs inside orchestrator logic.
 - Direct GUID generation inside orchestrator logic.
 - Random number generation or unordered dictionary iteration used to branch.
@@ -323,6 +324,7 @@ xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx    ShipmentAssigned       187         0    
 If corresponding `RaiseEvent` messages are present with matched instance IDs and event names before timeout, missing event delivery is unlikely.
 
 Event contract validation checklist:
+
 - Event name matches exact casing expected by orchestrator.
 - Instance ID used by publisher matches orchestrator instance ID.
 - Event source confirms publish acknowledgment in the same window.
@@ -380,6 +382,7 @@ RequestsInQueue         2026-04-05T03:10:00.000Z   1150       1390
 If queue age and backlog remain low with healthy execution throughput, starvation is not primary; investigate code-level deterministic/replay/event issues.
 
 Capacity tuning hints:
+
 - Raise worker count only after confirming replay storm is not primary.
 - Prefer reducing per-instance contention before broad scale-out.
 - Validate task hub storage latency before concurrency increases.

--- a/docs/troubleshooting/playbooks/scaling/out-of-memory-worker-crash.md
+++ b/docs/troubleshooting/playbooks/scaling/out-of-memory-worker-crash.md
@@ -344,6 +344,7 @@ RD281878D4A1C2       2026-04-05T04:00:00.000Z   1480589312   1559238656   160104
 If code changes (streaming, batching, disposal fixes) materially reduce peak memory below the same plan limit, a pure sizing issue is disproved and optimization is primary.
 
 Cross-check result interpretation:
+
 - If p95 is consistently within 5-10% of the plan ceiling, short bursts can trigger recurring crash loops.
 - If p95 remains far below the ceiling but isolated peaks crash workers, investigate single-operation allocation spikes.
 - If multiple instances show the same pattern at similar utilization, capacity is likely a structural bottleneck.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+mkdocs-material
+mkdocs-minify-plugin
+pymdown-extensions


### PR DESCRIPTION
## Summary

Addresses all review feedback items:

### P0-1: Flex Consumption as default recommended path
- Add `!!! warning "Legacy hosting path"` to all 4 Consumption tutorial entry points
- README: "Recommended Starting Path" table with Flex Consumption as default

### P0-2: Container Apps hosting scope
- README: "Hosting Scope" section with explicit scope declaration
- platform/hosting.md: scope info admonition

### P0-3: Markdown rendering fixes
- Fix 360 bullet list rendering issues (missing blank lines before `- ` lists)

### P5: README improvements
- "Who This Guide Is For" section
- "Recommended Starting Path" table
- Quick Start with venv and requirements-docs.txt

### P6: CI/CD
- CI status badges in README
- `requirements-docs.txt` for reproducible builds

### P7: Technical accuracy
- "Last verified" with source URL on hosting and scaling tables
- Key values subject to change noted for periodic verification

## Test plan
- [ ] mkdocs build --strict passes (0 warnings)
- [ ] Legacy warning renders in Consumption tutorials
- [ ] README renders correctly on GitHub