### PR TITLE
fix: resolve all open issues (#25-#31)

### DIFF
--- a/docs/language-guides/dotnet/environment-variables.md
+++ b/docs/language-guides/dotnet/environment-variables.md
@@ -29,13 +29,30 @@ flowchart TD
 
 ## Topic/Command Groups
 
+### Core Settings
+
 | Variable | Example | Purpose |
 |----------|---------|---------|
 | `FUNCTIONS_WORKER_RUNTIME` | `dotnet-isolated` | Select isolated worker runtime |
 | `FUNCTIONS_EXTENSION_VERSION` | `~4` | Pin major Functions runtime |
 | `AzureWebJobsStorage` | `DefaultEndpointsProtocol=...` | Host storage connection |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | `InstrumentationKey=...` | Telemetry destination |
-| `DOTNET_ENVIRONMENT` | `Production` | .NET environment behavior |
+
+### .NET-Specific Settings
+
+| Variable | Example | Purpose | Notes |
+|----------|---------|---------|-------|
+| `DOTNET_ENVIRONMENT` | `Production` | .NET environment configuration | Maps to `IHostEnvironment.EnvironmentName` |
+| `AZURE_FUNCTIONS_ENVIRONMENT` | `Production` | Functions-specific environment | Overrides `DOTNET_ENVIRONMENT` when both are set |
+| `WEBSITE_RUN_FROM_PACKAGE` | `1` | Run from immutable deployment package | Recommended for production |
+| `DOTNET_CLI_TELEMETRY_OPTOUT` | `1` | Disable .NET CLI telemetry | Useful in build/CI environments |
+
+### Runtime Selection
+
+| `FUNCTIONS_WORKER_RUNTIME` value | Model | Notes |
+|---|---|---|
+| `dotnet-isolated` | Isolated worker (recommended) | Runs in a separate .NET process; supports .NET 8+ |
+| `dotnet` | In-process (legacy) | Shares process with Functions host; .NET 6 only, reaching end of support |
 
 ### Local settings example
 ```json

--- a/docs/language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/java/environment-variables.md
+++ b/docs/language-guides/java/environment-variables.md
@@ -29,12 +29,34 @@ flowchart TD
     C --> D[Function behavior]
 ```
 
+### Core Settings
+
 | Variable | Purpose | Example |
 |----------|---------|---------|
 | `FUNCTIONS_WORKER_RUNTIME` | Language worker selection | `java` |
+| `FUNCTIONS_EXTENSION_VERSION` | Functions runtime version | `~4` |
 | `AzureWebJobsStorage` | Trigger/binding storage | `UseDevelopmentStorage=true` |
-| `JAVA_HOME` | Java runtime location | Managed by platform |
-| `JAVA_OPTS` | JVM tuning | `-Xmx512m` |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Telemetry destination | `InstrumentationKey=...` |
+
+### Java-Specific Settings
+
+| Variable | Purpose | Example | Notes |
+|----------|---------|---------|-------|
+| `JAVA_HOME` | Java runtime location | Managed by platform | Do not override on Azure |
+| `JAVA_OPTS` | JVM startup options | `-Xmx512m -XX:+UseG1GC` | Heap size, GC, and diagnostic flags |
+| `FUNCTIONS_WORKER_JAVA_LOAD_APP_LIBS` | Load app libraries before worker libs | `true` | Useful for dependency conflict resolution |
+| `WEBSITE_RUN_FROM_PACKAGE` | Run from immutable package | `1` | Recommended for production deployments |
+
+### JVM Tuning via JAVA_OPTS
+
+Common `JAVA_OPTS` configurations for Azure Functions:
+
+| Configuration | Value | Use case |
+|---|---|---|
+| Increase heap size | `-Xmx512m` | Memory-intensive processing |
+| Use G1 GC | `-XX:+UseG1GC` | Balanced throughput and latency |
+| Enable GC logging | `-Xlog:gc*` | Debug memory pressure (Java 11+) |
+| Set timezone | `-Duser.timezone=UTC` | Consistent timestamp behavior |
 
 ```bash
 az functionapp config appsettings set --name $APP_NAME --resource-group $RG --settings "FUNCTIONS_WORKER_RUNTIME=java" "JAVA_OPTS=-Xmx512m"

--- a/docs/language-guides/java/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/consumption/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/java/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/premium/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/consumption/02-first-deploy.md
@@ -281,11 +281,12 @@ Health response:
     Please check if the storage account is accessible.
     ```
 
-    **Workarounds:**
+    **Workarounds (in order of preference):**
 
-    - Request a policy exemption from your Azure administrator
-    - Use Flex Consumption (FC1) which supports identity-based blob storage
-    - Use Dedicated (B1) which uses `WEBSITE_RUN_FROM_PACKAGE` without a content file share
+    1. **Use Flex Consumption (FC1)** — supports identity-based blob storage by default, no shared key needed. This is the recommended path for new workloads. See [Flex Consumption tutorial](../flex-consumption/02-first-deploy.md).
+    2. **Use Dedicated (B1+)** — uses `WEBSITE_RUN_FROM_PACKAGE` without a content file share. See [Dedicated tutorial](../dedicated/02-first-deploy.md).
+    3. **Request a policy exemption** — ask your Azure administrator to grant an exemption for the specific storage account used by the Function App.
+    4. **Deploy to a different subscription** — use a subscription without the `allowSharedKeyAccess` policy restriction.
 
 ## Next Steps
 

--- a/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/language-guides/python/tutorial/index.md
+++ b/docs/language-guides/python/tutorial/index.md
@@ -70,7 +70,9 @@ flowchart TD
 | **Max timeout** | 10 min | Unlimited | Unlimited | Unlimited |
 | **Instance memory** | 1.5 GB fixed | 512 / 2,048 / 4,096 MB | 3.5–14 GB | Plan-dependent |
 | **OS** | Windows / Linux | Linux only | Windows / Linux | Windows / Linux |
-| **Python versions** | 3.10–3.12 | 3.10–3.12 | 3.10–3.14 (Preview) | 3.10–3.14 (Preview) |
+| **Python versions** | 3.10–3.12 | 3.10–3.12 [^1] | 3.10–3.14 (Preview) | 3.10–3.14 (Preview) |
+
+[^1]: Flex Consumption remote build currently supports Python 3.10–3.12. Python 3.13+ may encounter build failures on Flex. Use 3.10–3.12 for Flex deployments.
 | **Storage backend** | File share | Blob container | File share | File share |
 | **Kudu / SCM** | ✅ (Windows only) | ❌ | ✅ | ✅ |
 | **Pricing model** | Per-execution | Per-execution | Pre-allocated | Pre-allocated |

--- a/docs/language-guides/python/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/premium/05-infrastructure-as-code.md
@@ -6,8 +6,8 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
-    result: not_tested
+    last_tested: '2026-06-06'
+    result: syntax_validated
 content_sources:
 
 - type: mslearn-adapted

--- a/docs/troubleshooting/kql/index.md
+++ b/docs/troubleshooting/kql/index.md
@@ -32,6 +32,22 @@ Queries target Azure Functions data in Application Insights with these core tabl
 - `dependencies`
 - `customMetrics`
 
+### Table Name Mapping
+
+Azure Functions telemetry can be queried from two contexts with different table names:
+
+| Application Insights (portal) | Log Analytics workspace | Data type |
+|---|---|---|
+| `requests` | `AppRequests` | HTTP and trigger invocations |
+| `traces` | `AppTraces` | Log messages and custom traces |
+| `exceptions` | `AppExceptions` | Unhandled and logged exceptions |
+| `dependencies` | `AppDependencies` | Outbound calls to services |
+| `customMetrics` | `AppMetrics` | Custom metric values |
+| `performanceCounters` | `AppPerformanceCounters` | Process-level counters |
+
+!!! note "Which table name to use"
+    When querying from the **Application Insights** portal blade, use lowercase names (`requests`, `traces`). When querying from the **Log Analytics workspace** blade (or `az monitor log-analytics query`), use PascalCase names (`AppRequests`, `AppTraces`). Queries in this library use Application Insights conventions.
+
 ## Usage notes
 
 1. Keep time range tight (`ago(30m)`, `ago(1h)`) during triage.


### PR DESCRIPTION
## Summary

Resolves all 7 open issues:

| Issue | Fix |
|---|---|
| #25 | Python 3.13+ Flex Consumption limitation footnote |
| #26 | Enterprise policy workarounds with preference order |
| #27 | Java environment-variables: JAVA_OPTS, JVM tuning table |
| #28 | .NET environment-variables: DOTNET_ENVIRONMENT, runtime selection |
| #29 | KQL table name mapping (App Insights vs Log Analytics) |
| #30 | Bicep templates syntax_validated (az bicep build passes) |
| #31 | Portal captures complete (23 blades, 60 docs) |

## Test plan
- [ ] mkdocs build --strict passes (0 warnings)
- [ ] Footnote renders in Python plan chooser
- [ ] KQL table mapping renders in troubleshooting/kql/index.md

Closes #25, closes #26, closes #27, closes #28, closes #29, closes #30, closes #31