### PR TITLE
chore(scripts): add portal-capture-helpers from sibling repos

### DIFF
--- a/scripts/portal-capture-helpers.js
+++ b/scripts/portal-capture-helpers.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const PII_RULES = [
+  {
+    pattern: /(?<![0-9a-f])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?![0-9a-f])/gi,
+    replacement: '00000000-0000-0000-0000-000000000000',
+  },
+  {
+    pattern: /\bMCAPS[-A-Za-z0-9_]*\b/g,
+    replacement: 'Visual Studio Enterprise Subscription',
+  },
+  {
+    pattern: /Microsoft\s+Non-Production/gi,
+    replacement: 'Contoso',
+  },
+  {
+    pattern: /\b[A-Za-z0-9._%+-]+@microsoft\.com(?![A-Za-z0-9.-])/gi,
+    replacement: 'user@example.com',
+  },
+  {
+    pattern: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.onmicrosoft\.com(?![A-Za-z0-9.-])/gi,
+    replacement: 'user@example.com',
+  },
+  {
+    pattern: /\b[A-Za-z0-9-]+\.onmicrosoft\.com(?![A-Za-z0-9.-])/gi,
+    replacement: 'contoso.onmicrosoft.com',
+  },
+  {
+    pattern: /\bychoe\b/gi,
+    replacement: 'demouser',
+  },
+  {
+    pattern: /Yeongseon\s+Choe/g,
+    replacement: 'Demo User',
+  },
+  {
+    pattern: /\byeongseon\b/gi,
+    replacement: 'demouser',
+  },
+  {
+    pattern: /\b[0-9A-F]{32,}\b/g,
+    replacement: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  },
+];
+
+const PORTAL_BLUE = '#0078d4';
+
+const ACCOUNT_AVATAR_SELECTORS = [
+  'button[aria-label*="Account menu"]',
+  'button.fxs-menu-account',
+];
+
+const PII_REPLACEMENT_SCRIPT = (() => {
+  const serialized = PII_RULES
+    .map(({ pattern, replacement }) => `{ re: ${pattern.toString()}, val: ${JSON.stringify(replacement)} }`)
+    .join(', ');
+
+  return `(() => {
+    const subs = [${serialized}];
+    let count = 0;
+    const applySubs = (input) => {
+      let out = input;
+      for (const { re, val } of subs) {
+        re.lastIndex = 0;
+        out = out.replace(re, val);
+      }
+      return out;
+    };
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+    const nodes = [];
+    let n;
+    while ((n = walker.nextNode())) nodes.push(n);
+    for (const node of nodes) {
+      const orig = node.textContent || '';
+      const next = applySubs(orig);
+      if (next !== orig) {
+        node.textContent = next;
+        count++;
+      }
+    }
+    document.querySelectorAll('[aria-label]').forEach((el) => {
+      const orig = el.getAttribute('aria-label') || '';
+      const next = applySubs(orig);
+      if (next !== orig) el.setAttribute('aria-label', next);
+    });
+    document.querySelectorAll('input, textarea').forEach((el) => {
+      const orig = el.value || '';
+      const next = applySubs(orig);
+      if (next !== orig) {
+        el.value = next;
+        count++;
+      }
+    });
+    document.querySelectorAll('[title]').forEach((el) => {
+      const orig = el.getAttribute('title') || '';
+      const next = applySubs(orig);
+      if (next !== orig) el.setAttribute('title', next);
+    });
+    return count;
+  })()`;
+})();
+
+async function applyPiiReplacements(page) {
+  const mainFrame = page.mainFrame();
+  let total = await mainFrame.evaluate(PII_REPLACEMENT_SCRIPT);
+  for (const frame of page.frames()) {
+    if (frame === mainFrame) continue;
+    try {
+      total += await frame.evaluate(PII_REPLACEMENT_SCRIPT);
+    } catch (_) {
+      continue;
+    }
+  }
+  return total;
+}
+
+async function resolveAccountAvatarMask(page) {
+  for (const selector of ACCOUNT_AVATAR_SELECTORS) {
+    const locator = page.locator(selector);
+    if ((await locator.count()) > 0) {
+      return locator.first();
+    }
+  }
+  return null;
+}
+
+async function capturePortalScreenshot(page, outputPath, options = {}) {
+  const { fullPage = false, requireAvatarMask = true } = options;
+
+  const replacements = await applyPiiReplacements(page);
+  await page.waitForTimeout(400);
+
+  const avatar = await resolveAccountAvatarMask(page);
+  const masks = avatar ? [avatar] : [];
+
+  if (!avatar && requireAvatarMask) {
+    const message =
+      'capturePortalScreenshot: no Account-avatar element matched any of ' +
+      JSON.stringify(ACCOUNT_AVATAR_SELECTORS) +
+      '. The English-language Portal exposes the primary `aria-label` selector; ' +
+      'a localized Portal may still match the `button.fxs-menu-account` fallback, ' +
+      'but neither is guaranteed if the page is not fully rendered. ' +
+      'Wait for the target blade to settle before capture, or pass ' +
+      '{ requireAvatarMask: false } to override.';
+    throw new Error(message);
+  }
+
+  await page.screenshot({
+    path: outputPath,
+    fullPage,
+    mask: masks,
+    maskColor: PORTAL_BLUE,
+  });
+
+  return { replacements, path: outputPath, avatarMasked: Boolean(avatar) };
+}
+
+module.exports = {
+  PII_RULES,
+  PII_REPLACEMENT_SCRIPT,
+  PORTAL_BLUE,
+  ACCOUNT_AVATAR_SELECTORS,
+  applyPiiReplacements,
+  resolveAccountAvatarMask,
+  capturePortalScreenshot,
+};

--- a/scripts/portal-capture-helpers.md
+++ b/scripts/portal-capture-helpers.md
@@ -1,0 +1,163 @@
+# Portal capture helpers
+
+Reusable PII-masking utilities for Azure Portal screenshots. Used across every
+documentation capture in this repository to keep redactions consistent and to
+avoid leaking real Azure account identifiers into the documentation.
+
+## What it does
+
+- Replaces real identifiers in text nodes, `aria-label`, `title`, and `input`/
+  `textarea` values with documentation-safe placeholders (see PII Replacement
+  Rules section in `AGENTS.md` — to be added when this convention is fully
+  adopted; the canonical rule set is encoded in `PII_RULES` below).
+- Walks the main frame **and** every nested iframe (Portal blades render
+  inside iframes).
+- Masks only the Account-menu avatar using Playwright's native `mask` option
+  with Portal blue (`#0078d4`), so the masked region blends into the UI
+  instead of leaving a jarring black rectangle.
+- Throws by default if the Account-avatar selector matches nothing (the only
+  visual element the helper cannot rewrite). Pass
+  `{ requireAvatarMask: false }` to override for blades where the top bar is
+  intentionally absent.
+
+## Node.js usage
+
+```javascript
+const { chromium } = require('playwright');
+const { capturePortalScreenshot } = require('./portal-capture-helpers');
+
+const browser = await chromium.launch({ headless: false });
+const context = await browser.newContext({ viewport: { width: 1600, height: 1000 } });
+const page = await context.newPage();
+
+await page.goto(
+  'https://ms.portal.azure.com/#@<tenant>.onmicrosoft.com/resource/' +
+  'subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Web/sites/<app>/appServices'
+);
+
+await capturePortalScreenshot(
+  page,
+  'docs/assets/troubleshooting/first-10-minutes/01-overview.png'
+);
+
+await browser.close();
+```
+
+> **Note for Azure Functions captures.** Function apps are surfaced under the
+> `Microsoft.Web/sites` resource type (`kind=functionapp`). The Portal URL
+> fragment for a function app is typically `/Microsoft.Web/sites/<app>/appServices`
+> — the same as Web Apps. Some blades use `/functionApps` instead; both resolve
+> to the same function app overview.
+
+## MCP `browser_run_code_unsafe` usage
+
+The MCP browser tool executes a single async function in an isolated page
+context, so it cannot `require()` this module. Inline the snippet below
+(replace `<OUTPUT_PATH>` per capture). Keep this snippet in lockstep with
+`PII_RULES` in `portal-capture-helpers.js` — any change in one must be
+mirrored in the other (and in the PII Replacement Rules section in
+`AGENTS.md` once it is added).
+
+```javascript
+async (page) => {
+  const piiScript = `(() => {
+    const subs = [
+      { re: /(?<![0-9a-f])[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?![0-9a-f])/gi, val: '00000000-0000-0000-0000-000000000000' },
+      { re: /\\bMCAPS[-A-Za-z0-9_]*\\b/g, val: 'Visual Studio Enterprise Subscription' },
+      { re: /Microsoft\\s+Non-Production/gi, val: 'Contoso' },
+      { re: /\\b[A-Za-z0-9._%+-]+@microsoft\\.com(?![A-Za-z0-9.-])/gi, val: 'user@example.com' },
+      { re: /\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.onmicrosoft\\.com(?![A-Za-z0-9.-])/gi, val: 'user@example.com' },
+      { re: /\\b[A-Za-z0-9-]+\\.onmicrosoft\\.com(?![A-Za-z0-9.-])/gi, val: 'contoso.onmicrosoft.com' },
+      { re: /\\bychoe\\b/gi, val: 'demouser' },
+      { re: /Yeongseon\\s+Choe/g, val: 'Demo User' },
+      { re: /\\b[0-9A-F]{32,}\\b/g, val: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+    ];
+    let count = 0;
+    const applySubs = (input) => {
+      let out = input;
+      for (const { re, val } of subs) { re.lastIndex = 0; out = out.replace(re, val); }
+      return out;
+    };
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+    const nodes = []; let n; while ((n = walker.nextNode())) nodes.push(n);
+    for (const node of nodes) {
+      const orig = node.textContent || '';
+      const next = applySubs(orig);
+      if (next !== orig) { node.textContent = next; count++; }
+    }
+    document.querySelectorAll('[aria-label]').forEach(el => {
+      const orig = el.getAttribute('aria-label') || '';
+      const next = applySubs(orig);
+      if (next !== orig) el.setAttribute('aria-label', next);
+    });
+    document.querySelectorAll('input, textarea').forEach(el => {
+      const orig = el.value || '';
+      const next = applySubs(orig);
+      if (next !== orig) { el.value = next; count++; }
+    });
+    document.querySelectorAll('[title]').forEach(el => {
+      const orig = el.getAttribute('title') || '';
+      const next = applySubs(orig);
+      if (next !== orig) el.setAttribute('title', next);
+    });
+    return count;
+  })()`;
+
+  const mainFrame = page.mainFrame();
+  let total = await mainFrame.evaluate(piiScript);
+  for (const frame of page.frames()) {
+    if (frame === mainFrame) continue;
+    try { total += await frame.evaluate(piiScript); } catch (_) {}
+  }
+  await page.waitForTimeout(400);
+
+  const selectors = ['button[aria-label*="Account menu"]', 'button.fxs-menu-account'];
+  let avatar = null;
+  for (const s of selectors) {
+    const loc = page.locator(s);
+    if ((await loc.count()) > 0) { avatar = loc.first(); break; }
+  }
+  if (!avatar) {
+    throw new Error('No Account-avatar element matched ' + JSON.stringify(selectors) + '. Wait for the blade to settle before capture; non-English Portals may still match the fxs-menu-account fallback but that is best-effort, not guaranteed.');
+  }
+
+  await page.screenshot({
+    path: '<OUTPUT_PATH>',
+    fullPage: false,
+    mask: [avatar],
+    maskColor: '#0078d4',
+  });
+
+  return 'replaced ' + total + ' text occurrences';
+};
+```
+
+## Capture workflow rules
+
+- **Re-navigate (`browser_navigate`) between captures.** Portal CSS is
+  cumulative, and leftover styles from a previous capture can leak into the
+  next page (for example, the left-nav rendering as a black box).
+- **Use `ms.portal.azure.com` with the tenant hint fragment** (e.g.
+  `#@<tenant>.onmicrosoft.com/...`). Plain `portal.azure.com` triggers a login
+  redirect.
+- **Prefer the English-language Portal.** The primary avatar selector keys
+  off the English `aria-label` "Account menu". A localized Portal may still
+  match the `button.fxs-menu-account` fallback class, but that fallback is
+  best-effort and not a stable contract. The helper throws if neither
+  selector matches; non-English captures should be reviewed manually.
+- **Close every transient flyout, drawer, and command-bar dropdown** before
+  capture. Account panel, Recent menu, notifications panel, and tenant
+  switcher each surface PII the helper cannot fully rewrite (avatar
+  thumbnails, embedded canvases, late-rendered iframe content).
+- **Wait for the target blade to finish rendering** before applying
+  replacements. The 400 ms post-replacement pause inside the helper is not a
+  substitute for a per-blade `browser_wait_for` against a stable text or
+  element on the blade.
+- **Viewport: 1600 x 1000** captures the standard Portal blade layout without
+  horizontal scrollbars.
+- **No black-box masking.** If a value cannot be rewritten and is not a known
+  avatar/badge, fail the capture and update `PII_RULES` rather than fall back
+  to a black rectangle.
+
+If `PII_RULES` is updated, mirror the change in the inline MCP snippet above
+(and in any future `AGENTS.md` PII Replacement Rules section once added).

--- a/scripts/portal-capture-helpers.md
+++ b/scripts/portal-capture-helpers.md
@@ -70,6 +70,7 @@ async (page) => {
       { re: /\\b[A-Za-z0-9-]+\\.onmicrosoft\\.com(?![A-Za-z0-9.-])/gi, val: 'contoso.onmicrosoft.com' },
       { re: /\\bychoe\\b/gi, val: 'demouser' },
       { re: /Yeongseon\\s+Choe/g, val: 'Demo User' },
+      { re: /\\byeongseon\\b/gi, val: 'demouser' },
       { re: /\\b[0-9A-F]{32,}\\b/g, val: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
     ];
     let count = 0;


### PR DESCRIPTION
## Summary

- Phase 1.2 of cross-repo tooling unification across the three sibling Azure practical guides (Container Apps / App Service / Functions).
- Adds the reusable Azure Portal screenshot PII-masking helper that is already used in [`azure-app-service-practical-guide`](https://github.com/yeongseon/azure-app-service-practical-guide/blob/main/scripts/portal-capture-helpers.js) and [`azure-container-apps-practical-guide`](https://github.com/yeongseon/azure-container-apps-practical-guide/blob/main/scripts/portal-capture-helpers.js).
- Tool-only addition. No CI wiring, no AGENTS.md changes in this commit.

## What the helper does

A reusable Playwright helper that:

1. Walks the main frame and every nested iframe (Portal blades render inside iframes).
2. Rewrites real Azure identifiers to documentation-safe placeholders across text nodes, \`aria-label\`, \`title\`, and \`input\`/\`textarea\` values.
3. Masks only the Account-menu avatar (the one element that cannot be rewritten) using Playwright's native \`mask\` with Portal blue (\`#0078d4\`) — no black-box redactions.
4. Throws by default if the Account-avatar selector matches nothing (overridable per-capture).

Used in two modes:

- **Standalone Playwright** — \`require('./portal-capture-helpers')\` from a Node.js capture script.
- **MCP \`browser_run_code_unsafe\`** — an inline snippet (documented in the \`.md\`) that mirrors \`PII_RULES\` exactly because MCP cannot \`require()\` modules.

## Best-version selection

The sibling repos have drifted slightly. App Service has 10 PII rules; ACA has 8. This PR copies the App Service version verbatim (the best version):

| Rule | App Service | ACA | Functions (after this PR) |
|---|---|---|---|
| GUID → zero-GUID | yes | yes | yes |
| MCAPS-* → \"Visual Studio Enterprise Subscription\" | yes | yes | yes |
| \"Microsoft Non-Production\" → \"Contoso\" | yes | yes | yes |
| \`*@microsoft.com\` → \`user@example.com\` | yes | yes | yes |
| \`*@*.onmicrosoft.com\` → \`user@example.com\` | yes | yes | yes |
| \`*.onmicrosoft.com\` (bare) → \`contoso.onmicrosoft.com\` | yes | yes | yes |
| \`ychoe\` alias → \`demouser\` | yes | yes | yes |
| \`Yeongseon Choe\` → \`Demo User\` | yes | yes | yes |
| \`yeongseon\` (lowercase) → \`demouser\` | **yes** | no | **yes** |
| 32+ uppercase hex → masked token | **yes** | no | **yes** |

The two extra rules (lowercase \`yeongseon\` alias and 32+ uppercase hex) catch real leak patterns that the ACA version misses (e.g. internal storage account keys and ETag-shaped tokens that surface in some Portal blades).

A separate PR will sync these two rules into the ACA helper (Phase 2 — drift alignment).

## Files

| File | Source | Adaptation |
|---|---|---|
| \`scripts/portal-capture-helpers.js\` | App Service verbatim | None — pure utility |
| \`scripts/portal-capture-helpers.md\` | App Service base | Adapted example output path to \`docs/assets/troubleshooting/first-10-minutes/\` and added a note about the \`Microsoft.Web/sites\` resource type used by function apps |

## What is NOT in this PR

- **AGENTS.md update.** App Service and ACA both have a \"Portal Screenshot Capture (PII Replacement Rules)\" section in their AGENTS.md. Functions does not yet; the \`.md\` notes this and the PII Replacement Rules are encoded directly in the helper. Adding the AGENTS.md section is a separate, larger decision (Phase 2 candidate).
- **Existing capture migration.** Functions already has 27 portal PNGs (most under \`docs/assets/troubleshooting/first-10-minutes/\`). They were captured manually or via inline snippets; migrating them to the new helper is out of scope for this tooling PR.
- **CI integration.** The helper is invoked from per-capture scripts, not from CI. No workflow changes.

## Testing

- \`node --check scripts/portal-capture-helpers.js\` — syntax OK.
- \`require()\` smoke test — all 7 named exports present (\`PII_RULES\`, \`PII_REPLACEMENT_SCRIPT\`, \`PORTAL_BLUE\`, \`ACCOUNT_AVATAR_SELECTORS\`, \`applyPiiReplacements\`, \`resolveAccountAvatarMask\`, \`capturePortalScreenshot\`); PII_RULES count = 10; PORTAL_BLUE = \`#0078d4\`.
- \`diff\` against App Service source — \`.js\` is byte-identical.
- No content files touched → \`mkdocs build --strict\` behavior unchanged. (\`scripts/*\` is outside the MkDocs docs tree.)

## Verification checklist

- [x] \`.js\` byte-identical to App Service source (best version)
- [x] \`.js\` syntax valid and module exports correct (10 PII rules, all 7 functions exported)
- [x] \`.md\` adapted for Functions context (example path + function-app resource type note)
- [x] No CI workflow changes
- [x] No \`AGENTS.md\` changes (deferred to a separate decision)