### PR TITLE
chore(scripts): adopt canonical normalization scripts from sibling repos

### DIFF
--- a/.github/workflows/validate-content-sources.yml
+++ b/.github/workflows/validate-content-sources.yml
@@ -3,20 +3,39 @@ name: Validate Content Sources
 on:
   pull_request:
     paths:
-      - 'docs/**/*.md'
-      - 'scripts/**/*.py'
+      # These path filters MUST stay at least as broad as the EXTENSIONS set
+      # in scripts/normalize_mslearn_locale.py (.md, .py, .yml, .yaml, .json,
+      # .bicep, .tf, .txt). Narrowing 'docs/**' to 'docs/**/*.md' or
+      # 'scripts/**' to 'scripts/**/*.py' lets a PR touching only .json files
+      # under those paths bypass the MSLearn locale check entirely.
+      - 'docs/**'
       - 'scripts/**'
-      - '.github/workflows/validate-content-sources.yml'
+      - 'apps/**'
+      - 'labs/**'
+      - 'infra/**'
+      - 'AGENTS.md'
+      - 'README*.md'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+      - 'CODE_OF_CONDUCT.md'
       - 'mkdocs.yml'
+      - '.github/workflows/**'
   push:
     branches:
       - main
     paths:
-      - 'docs/**/*.md'
-      - 'scripts/**/*.py'
+      - 'docs/**'
       - 'scripts/**'
-      - '.github/workflows/validate-content-sources.yml'
+      - 'apps/**'
+      - 'labs/**'
+      - 'infra/**'
+      - 'AGENTS.md'
+      - 'README*.md'
+      - 'CONTRIBUTING.md'
+      - 'SECURITY.md'
+      - 'CODE_OF_CONDUCT.md'
       - 'mkdocs.yml'
+      - '.github/workflows/**'
 
 jobs:
   validate-content-sources:
@@ -36,7 +55,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pyyaml
+          pip install pyyaml 'ruamel.yaml==0.19.1'
 
       - name: Validate mermaid format
         run: |
@@ -55,6 +74,14 @@ jobs:
         run: |
           python scripts/validate_content_sources.py
         continue-on-error: true
+
+      - name: Check frontmatter YAML style (canonical ruamel.yaml format)
+        run: |
+          python scripts/normalize_yaml_frontmatter.py --check
+
+      - name: Check Microsoft Learn URL locale (en-us prefix required)
+        run: |
+          python scripts/normalize_mslearn_locale.py --check
 
       - name: Validate CLI explanation tables
         run: |

--- a/.github/workflows/validate-content-sources.yml
+++ b/.github/workflows/validate-content-sources.yml
@@ -57,6 +57,13 @@ jobs:
         run: |
           pip install pyyaml 'ruamel.yaml==0.19.1'
 
+      # ---------------------------------------------------------------------
+      # STRICT checks run first so canonical-drift failures are surfaced
+      # before any advisory/lenient audits. Each step below MUST keep its
+      # current exit semantics (no `continue-on-error`). Re-ordering or
+      # weakening these blocks lets non-canonical content land on main.
+      # ---------------------------------------------------------------------
+
       - name: Validate mermaid format
         run: |
           python scripts/validate_mermaid_format.py
@@ -65,16 +72,6 @@ jobs:
         run: |
           python scripts/validate_mermaid_syntax.py
 
-      - name: Validate changed documentation quality
-        run: |
-          python scripts/validate_doc_quality.py --changed-only --base-ref "${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}"
-        continue-on-error: true
-
-      - name: Audit existing content sources
-        run: |
-          python scripts/validate_content_sources.py
-        continue-on-error: true
-
       - name: Check frontmatter YAML style (canonical ruamel.yaml format)
         run: |
           python scripts/normalize_yaml_frontmatter.py --check
@@ -82,35 +79,6 @@ jobs:
       - name: Check Microsoft Learn URL locale (en-us prefix required)
         run: |
           python scripts/normalize_mslearn_locale.py --check
-
-      - name: Validate CLI explanation tables
-        run: |
-          python scripts/validate_cli_explanations.py
-        continue-on-error: true
-
-      - name: Audit existing diagram IDs
-        run: |
-          # Count mermaid blocks
-          MERMAID_COUNT=$(grep -r '```mermaid' docs/ --include="*.md" \
-            --exclude="content-validation-status.md" \
-            --exclude="validation-status.md" | wc -l)
-
-          # Count diagram-id comments
-          DIAGRAM_ID_COUNT=$(grep -r '<!-- diagram-id:' docs/ --include="*.md" \
-            --exclude="content-validation-status.md" \
-            --exclude="validation-status.md" | wc -l)
-
-          echo "Mermaid blocks: $MERMAID_COUNT"
-          echo "Diagram IDs: $DIAGRAM_ID_COUNT"
-
-          if [ "$MERMAID_COUNT" -ne "$DIAGRAM_ID_COUNT" ]; then
-            echo "::error::Mismatch! Some mermaid blocks are missing diagram-id comments."
-            echo "Missing: $((MERMAID_COUNT - DIAGRAM_ID_COUNT)) diagram IDs"
-            exit 1
-          fi
-
-          echo "All mermaid blocks have diagram-id comments."
-        continue-on-error: true
 
       - name: Check for content_sources in new/modified files
         run: |
@@ -143,6 +111,53 @@ jobs:
           fi
 
           echo "All changed files with mermaid diagrams have content_sources metadata."
+
+      # ---------------------------------------------------------------------
+      # LENIENT (advisory) checks run after all strict checks. Each step
+      # below intentionally sets `continue-on-error: true` so it surfaces
+      # gaps in older Functions content without blocking PRs while the
+      # incremental cleanup is in progress. Promote a step to strict only
+      # after the underlying backlog has been closed.
+      # ---------------------------------------------------------------------
+
+      - name: Validate changed documentation quality
+        run: |
+          python scripts/validate_doc_quality.py --changed-only --base-ref "${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}"
+        continue-on-error: true
+
+      - name: Audit existing content sources
+        run: |
+          python scripts/validate_content_sources.py
+        continue-on-error: true
+
+      - name: Validate CLI explanation tables
+        run: |
+          python scripts/validate_cli_explanations.py
+        continue-on-error: true
+
+      - name: Audit existing diagram IDs
+        run: |
+          # Count mermaid blocks
+          MERMAID_COUNT=$(grep -r '```mermaid' docs/ --include="*.md" \
+            --exclude="content-validation-status.md" \
+            --exclude="validation-status.md" | wc -l)
+
+          # Count diagram-id comments
+          DIAGRAM_ID_COUNT=$(grep -r '<!-- diagram-id:' docs/ --include="*.md" \
+            --exclude="content-validation-status.md" \
+            --exclude="validation-status.md" | wc -l)
+
+          echo "Mermaid blocks: $MERMAID_COUNT"
+          echo "Diagram IDs: $DIAGRAM_ID_COUNT"
+
+          if [ "$MERMAID_COUNT" -ne "$DIAGRAM_ID_COUNT" ]; then
+            echo "::error::Mismatch! Some mermaid blocks are missing diagram-id comments."
+            echo "Missing: $((MERMAID_COUNT - DIAGRAM_ID_COUNT)) diagram IDs"
+            exit 1
+          fi
+
+          echo "All mermaid blocks have diagram-id comments."
+        continue-on-error: true
 
   validate-mslearn-urls:
     name: Validate MSLearn URLs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,23 +145,56 @@ Every Mermaid diagram must have source metadata in frontmatter.
 
 ### Text Content Validation
 
-Every non-tutorial document should include a `content_validation` block in frontmatter to track the verification status of its core claims.
+Factual-claim documents include a `content_validation` block in frontmatter to track the verification status of their core technical assertions.
+
+The single source of truth for "is this page in scope?" is [`scripts/lib/content_scope.py`](scripts/lib/content_scope.py) — specifically the `is_in_scope(rel_path)` function. The dashboard generator and the out-of-scope cleanup tool both import this helper, so they are guaranteed to agree on scope. If you change the scope policy, update both `scripts/lib/content_scope.py` AND this section in the same commit.
+
+#### Scope
+
+The `content_validation` block is **required** on factual-claim pages under these sections:
+
+| Section | Required? | Examples |
+|---|---|---|
+| `docs/platform/` | Required (including factual subsection landing pages such as `platform/architecture/index.md` and `platform/networking-scenarios/index.md`) | Hosting plans, scaling, networking, security, observability |
+| `docs/best-practices/` | Required | Hosting selection, triggers, scaling, reliability, security, deployment |
+| `docs/operations/` | Required | Deployment, monitoring, alerts, cost optimization, recovery |
+| `docs/troubleshooting/` | Required, except for the `EXCLUDED_SUBPATHS` and `NAVIGATION_INDEXES` listed below | Playbooks, methodology pages, first-10-minutes runbooks |
+
+The block is **out of scope** on these pages — the dashboard does not count them, the cleanup tool does not require them, and new pages added in these locations should not introduce a `content_validation` block:
+
+- **Out-of-scope sections** — any path that does not start with `platform/`, `best-practices/`, `operations/`, or `troubleshooting/`. This covers `docs/start-here/`, `docs/reference/`, `docs/contributing/`, `docs/language-guides/` (tutorials and recipes), and `docs/index.md`.
+- **`EXCLUDED_SUBPATHS`** under `troubleshooting/`:
+    - `troubleshooting/kql/` — KQL query packs make no factual assertions of their own
+    - `troubleshooting/lab-guides/` — labs use the evidence-integrity model (Falsification step) instead
+- **`NAVIGATION_INDEXES`** — section landing pages that only introduce a section and make no factual claims:
+    - `platform/index.md`
+    - `best-practices/index.md`
+    - `operations/index.md`
+    - `troubleshooting/index.md`
+    - `troubleshooting/first-10-minutes/index.md`
+    - `troubleshooting/playbooks/index.md`
+
+Subsection landing pages that DO make factual claims (for example `platform/architecture/index.md` and `platform/networking-scenarios/index.md`) are intentionally NOT in `NAVIGATION_INDEXES` — they are treated like any other factual-claim page.
+
+Legacy `content_validation` blocks may still exist on a number of out-of-scope pages (notably under `docs/reference/`, `docs/start-here/`, `docs/troubleshooting/kql/`, and `docs/troubleshooting/lab-guides/`) from before this scope policy was formalized. These blocks are accepted but are not counted by the dashboard; they will be reviewed in a follow-up editorial pass and can be removed with `python3 scripts/remove_out_of_scope_validation.py --apply`.
+
+#### Schema
 
 ```yaml
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/...
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/...
 content_validation:
   status: verified  # verified | pending_review | unverified
   last_reviewed: 2026-04-12
   reviewer: agent  # agent | human
   core_claims:
     - claim: "Flex Consumption supports VNet integration"
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
     - claim: "Premium plan requires Azure Files content share"
-      source: https://learn.microsoft.com/azure/azure-functions/storage-considerations
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
       verified: true
 ---
 ```
@@ -176,11 +209,12 @@ content_validation:
 
 #### Agent Rules for Content Validation
 
-1. When creating or modifying Platform, Best Practices, or Operations documents, add `content_validation` frontmatter.
-2. List 2-5 core claims that are factual assertions (not opinions or procedures).
-3. Each claim must have a Microsoft Learn source URL.
-4. Set `status: verified` only when ALL core claims have verified sources.
-5. Run `python3 scripts/generate_content_validation_status.py` after updates.
+1. Add `content_validation` only when the page is in scope per `scripts/lib/content_scope.is_in_scope`. Do NOT add it to out-of-scope pages (tutorials, recipes, reference look-ups, KQL packs, lab guides, navigation indexes).
+2. If you create a new in-scope page, you MUST add `content_validation` to it.
+3. Each `core_claim` MUST be a verifiable factual assertion about Azure behavior (a quoted limit, a documented feature behavior, a configuration default). Meta-statements such as "this page uses Microsoft Learn as the primary source basis" are tautological and forbidden.
+4. List 2-5 core claims per page; each MUST cite a Microsoft Learn URL.
+5. Set `status: verified` only when ALL core claims have verified sources.
+6. Run `python3 scripts/generate_content_validation_status.py` after updates to regenerate `docs/reference/content-validation-status.md`.
 
 ### PII Removal (Quality Gate)
 
@@ -203,6 +237,51 @@ content_validation:
 - Sample resource names used consistently in docs
 
 The goal is to prevent leaking **real Azure account information**, not to mask obviously-fake example values that aid readability.
+
+### Frontmatter YAML Style
+
+Every Markdown file in `docs/` begins with a YAML frontmatter block delimited by `---`. The serialization style is **enforced by CI** and centralized in [`scripts/lib/yaml_style.py`](scripts/lib/yaml_style.py). Any script that mutates frontmatter MUST import `dump_frontmatter()` (preferred single-call API) or `build_yaml()` (for tools that need to call `load()` and `dump()` on the same instance) from that module — direct use of PyYAML's `yaml.dump()` is forbidden because it silently reformats files on every run (quoting dates, flattening nested sequences, folding multi-line strings), producing noisy diffs and unstable history.
+
+#### Canonical style
+
+| Setting | Value | Why |
+|---|---|---|
+| Library | `ruamel.yaml` (`typ='rt'`, round-trip mode) | Preserves comments, quoting, and key order across load/dump cycles. PyYAML cannot. |
+| `indent(mapping=2, sequence=4, offset=2)` | `mapping=2`, `sequence=4`, `offset=2` | Matches the historical repository layout: list hyphens sit at column 4 under their parent key, list-item content at column 6. |
+| `preserve_quotes` | `True` | Existing files are normalized for *structure* only; intentionally quoted dates and strings are kept as-is to avoid surprising semantic changes (e.g., `"2026-04-12"` becoming a `datetime.date` object). |
+| `width` | `4096` | Practically disables line folding so long `claim`, `summary`, and `justification` strings stay on one line. Folding produces fragile diffs and harms grep-ability. |
+| `explicit_end` | `False` | Frontmatter is delimited by a single closing `---` (no `...` document terminator). |
+
+Example of correct style (matches the canonical output):
+
+```yaml
+---
+content_sources:
+  diagrams:
+    - id: flex-consumption-scaling
+      type: flowchart
+      source: mslearn-adapted
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+        - https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
+---
+```
+
+#### Workflow
+
+1. **Never write frontmatter with PyYAML.** Any new generator or mutation tool MUST import `build_yaml()` (or the higher-level `dump_frontmatter()` helper) from `scripts/lib/yaml_style.py`. `dump_frontmatter()` is the public single-call API used by `scripts/normalize_yaml_frontmatter.py` itself; prefer it over instantiating `build_yaml()` and managing a `StringIO` buffer manually.
+2. **Bulk normalize when needed:**
+
+    ```bash
+    python3 scripts/normalize_yaml_frontmatter.py --apply
+    ```
+
+3. **CI enforces drift:** the `Validate Content Sources` workflow runs `python scripts/normalize_yaml_frontmatter.py --check` and fails if any frontmatter would change. The workflow triggers on changes to `docs/**`, `scripts/**`, `apps/**`, `labs/**`, `infra/**`, the repo-root markdown files (`AGENTS.md`, `README*.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`), or the workflow itself, so that updates to the shared library or the normalizer always re-run the check. The trigger surface intentionally mirrors the `EXTENSIONS` scan set in `scripts/normalize_mslearn_locale.py` (`.md`, `.py`, `.yml`, `.yaml`, `.json`, `.bicep`, `.tf`, `.txt`) so a PR touching only `.json`/`.bicep`/`.tf` files under those paths cannot bypass the locale check. `ruamel.yaml` is pinned to a specific version in CI so the canonical bytes are reproducible across runs.
+4. **Body is preserved byte-exact for the repo invariant (UTF-8, no BOM, LF line endings).** The normalizer only rewrites the YAML region between the two `---` delimiters; the blank line (or its absence) between the closing `---` and the first body line is preserved as-is. Files with a UTF-8 BOM are silently skipped (the regex won't match), and files with CRLF line endings would be converted to LF on `--apply` -- no such files exist in this repo today, but if that ever changes, update this policy first.
+
+#### When to update this section
+
+If [`scripts/lib/yaml_style.py`](scripts/lib/yaml_style.py) changes (different indent, width, or quoting policy), the table above MUST be updated in the same commit. The shared library is the source of truth; this section is the human-readable mirror.
 
 ### Admonition Indentation Rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Every Mermaid diagram must have source metadata in frontmatter.
 
 Factual-claim documents include a `content_validation` block in frontmatter to track the verification status of their core technical assertions.
 
-The single source of truth for "is this page in scope?" is [`scripts/lib/content_scope.py`](scripts/lib/content_scope.py) — specifically the `is_in_scope(rel_path)` function. The dashboard generator and the out-of-scope cleanup tool both import this helper, so they are guaranteed to agree on scope. If you change the scope policy, update both `scripts/lib/content_scope.py` AND this section in the same commit.
+The single source of truth for "is this page in scope?" is [`scripts/lib/content_scope.py`](scripts/lib/content_scope.py) — specifically the `is_in_scope(rel_path)` function. The out-of-scope cleanup tool (`scripts/remove_out_of_scope_validation.py`) imports this helper. The dashboard generator (`scripts/generate_content_validation_status.py`) still uses its legacy local `SCAN_SECTIONS` list and `index.md` skip heuristic, and will be migrated to `content_scope.is_in_scope` in the strict-validator sync follow-up PR; until then the dashboard may surface a few out-of-scope pages (notably lab guides under `troubleshooting/lab-guides/`) that pre-date this scope policy. If you change the scope policy, update both `scripts/lib/content_scope.py` AND this section in the same commit.
 
 #### Scope
 
@@ -160,7 +160,7 @@ The `content_validation` block is **required** on factual-claim pages under thes
 | `docs/operations/` | Required | Deployment, monitoring, alerts, cost optimization, recovery |
 | `docs/troubleshooting/` | Required, except for the `EXCLUDED_SUBPATHS` and `NAVIGATION_INDEXES` listed below | Playbooks, methodology pages, first-10-minutes runbooks |
 
-The block is **out of scope** on these pages — the dashboard does not count them, the cleanup tool does not require them, and new pages added in these locations should not introduce a `content_validation` block:
+The block is **out of scope** on these pages — the cleanup tool does not require them, and new pages added in these locations should not introduce a `content_validation` block (the dashboard generator will be aligned with this policy in the strict-validator sync follow-up PR):
 
 - **Out-of-scope sections** — any path that does not start with `platform/`, `best-practices/`, `operations/`, or `troubleshooting/`. This covers `docs/start-here/`, `docs/reference/`, `docs/contributing/`, `docs/language-guides/` (tutorials and recipes), and `docs/index.md`.
 - **`EXCLUDED_SUBPATHS`** under `troubleshooting/`:
@@ -176,7 +176,7 @@ The block is **out of scope** on these pages — the dashboard does not count th
 
 Subsection landing pages that DO make factual claims (for example `platform/architecture/index.md` and `platform/networking-scenarios/index.md`) are intentionally NOT in `NAVIGATION_INDEXES` — they are treated like any other factual-claim page.
 
-Legacy `content_validation` blocks may still exist on a number of out-of-scope pages (notably under `docs/reference/`, `docs/start-here/`, `docs/troubleshooting/kql/`, and `docs/troubleshooting/lab-guides/`) from before this scope policy was formalized. These blocks are accepted but are not counted by the dashboard; they will be reviewed in a follow-up editorial pass and can be removed with `python3 scripts/remove_out_of_scope_validation.py --apply`.
+Legacy `content_validation` blocks may still exist on a number of out-of-scope pages (notably under `docs/reference/`, `docs/start-here/`, `docs/troubleshooting/kql/`, and `docs/troubleshooting/lab-guides/`) from before this scope policy was formalized. These blocks are accepted today and may still appear in the dashboard while the generator uses its legacy scan; they will be reviewed in a follow-up editorial pass and can be removed with `python3 scripts/remove_out_of_scope_validation.py --apply`.
 
 #### Schema
 

--- a/docs/best-practices/common-anti-patterns.md
+++ b/docs/best-practices/common-anti-patterns.md
@@ -1,25 +1,25 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions 핸들러는 재시작과 스케일 아웃에 대비해 상태 비저장으로 설계해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
       verified: true
     - claim: "이벤트 기반 처리에서는 중복 전달과 재시도를 고려해 멱등성을 구현해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
       verified: true
     - claim: "연결 문자열 비밀 대신 관리형 ID와 Key Vault 같은 더 안전한 비밀 관리 방식을 우선해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
       verified: true
     - claim: "Flex Consumption에서는 Blob 트리거를 Event Grid 기반으로 구성해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
       verified: true
 ---
 
@@ -389,5 +389,5 @@ Use this anti-pattern checklist at three control points:
 
 ## Sources
 
-- [Improve performance and reliability of Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
-- [Azure Functions best practices (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-best-practices)
+- [Improve performance and reliability of Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)
+- [Azure Functions best practices (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)

--- a/docs/best-practices/cost-optimization.md
+++ b/docs/best-practices/cost-optimization.md
@@ -1,25 +1,25 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-consumption-costs
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/pricing
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/pricing
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Consumption 플랜에는 월 1,000,000회 실행과 400,000 GB-초의 무료 사용량이 제공된다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-consumption-costs
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs
       verified: true
     - claim: "Application Insights 샘플링은 고트래픽 Functions 워크로드의 텔레메트리 수집 비용을 줄이는 핵심 제어 수단이다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-consumption-costs
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs
       verified: true
     - claim: "Azure Functions 비용에는 컴퓨트 외에도 스토리지와 모니터링 같은 종속 서비스 비용이 포함될 수 있다."
-      source: https://learn.microsoft.com/azure/azure-functions/pricing
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/pricing
       verified: true
     - claim: "최대 인스턴스 수 같은 스케일 가드레일을 설정하면 과도한 확장으로 인한 비용 급증을 억제할 수 있다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-consumption-costs
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs
       verified: true
 ---
 
@@ -317,5 +317,5 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions Consumption plan costs (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-consumption-costs)
-- [Azure Functions pricing (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/pricing)
+- [Azure Functions Consumption plan costs (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs)
+- [Azure Functions pricing (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/pricing)

--- a/docs/best-practices/deployment.md
+++ b/docs/best-practices/deployment.md
@@ -1,25 +1,25 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Run-from-package 배포는 패키지를 읽기 전용으로 마운트해 배포 중 파일 변이를 줄인다."
-      source: https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
       verified: true
     - claim: "Flex Consumption은 Kudu/SCM 엔드포인트를 사용하지 않는 배포 방식을 따라야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
       verified: true
     - claim: "Consumption 플랜의 배포 슬롯은 프로덕션을 포함해 총 2개까지만 지원된다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
       verified: true
     - claim: "동일한 빌드 산출물을 환경별로 승격하는 immutable artifact 배포 방식이 안전하다."
-      source: https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
       verified: true
 ---
 
@@ -316,5 +316,5 @@ flowchart TD
 
 ## Sources
 
-- [Deployment technologies in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies)
-- [Run Azure Functions from a deployment package (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package)
+- [Deployment technologies in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies)
+- [Run Azure Functions from a deployment package (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package)

--- a/docs/best-practices/hosting-plan-selection.md
+++ b/docs/best-practices/hosting-plan-selection.md
@@ -1,27 +1,27 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Sporadic workload에는 scale-to-zero가 가능한 Consumption 또는 Flex Consumption이 유리할 수 있다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
     - claim: "Private networking 요구가 있으면 Flex Consumption 또는 Premium 같은 지원 플랜을 우선 검토해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
     - claim: "엄격한 저지연 HTTP 요구사항에는 warm baseline을 제공하는 Premium 플랜이 적합하다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
     - claim: "호스팅 플랜 선택은 비용표가 아니라 워크로드 특성과 성능/신뢰성 요구를 기준으로 해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
       verified: true
 ---
 
@@ -197,6 +197,6 @@ Before finalizing a plan decision, hand off these concrete items to operations:
 
 ## Sources
 
-- [Azure Functions hosting options and scaling (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Azure Functions performance and reliability (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
+- [Azure Functions hosting options and scaling (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions performance and reliability (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)

--- a/docs/best-practices/index.md
+++ b/docs/best-practices/index.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/
+      verified: true
 ---
 # Best Practices
 
@@ -169,6 +168,6 @@ Use these criteria as a minimum quality bar before production go-live:
 
 ## Sources
 
-- [Azure Functions documentation (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/)
-- [Azure Functions hosting options and scaling (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions performance and reliability (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
+- [Azure Functions documentation (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/)
+- [Azure Functions hosting options and scaling (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions performance and reliability (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)

--- a/docs/best-practices/networking.md
+++ b/docs/best-practices/networking.md
@@ -1,31 +1,31 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-create-vnet
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options#private-endpoints
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options#private-endpoints
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/private-link/private-endpoint-dns
+    url: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Consumption 플랜은 VNet 통합이나 private endpoint 기반 아키텍처에 적합하지 않다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "Flex Consumption의 통합 서브넷은 Microsoft.App/environments 위임을 사용해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-create-vnet
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
       verified: true
     - claim: "Function App private endpoint를 사용할 때는 private DNS zone과 VNet 링크를 함께 구성해야 한다."
-      source: https://learn.microsoft.com/azure/private-link/private-endpoint-dns
+      source: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
       verified: true
     - claim: "Private-only 인바운드가 필요하면 public network access 설정도 함께 검토해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options#private-endpoints
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options#private-endpoints
       verified: true
 ---
 
@@ -374,8 +374,8 @@ az functionapp config access-restriction show \
 
 ## Sources
 
-- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Integrate Azure Functions with an Azure virtual network](https://learn.microsoft.com/azure/azure-functions/functions-create-vnet)
-- [Private endpoints for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-networking-options#private-endpoints)
-- [Azure Private Endpoint DNS configuration](https://learn.microsoft.com/azure/private-link/private-endpoint-dns)
-- [Azure Functions app settings reference (network-related settings)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
+- [Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Integrate Azure Functions with an Azure virtual network](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet)
+- [Private endpoints for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options#private-endpoints)
+- [Azure Private Endpoint DNS configuration](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns)
+- [Azure Functions app settings reference (network-related settings)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)

--- a/docs/best-practices/reliability.md
+++ b/docs/best-practices/reliability.md
@@ -1,37 +1,37 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-idempotent
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-idempotent
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reliable-event-processing
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reliable-event-processing
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/storage-considerations
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale#timeout
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#timeout
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "이벤트 기반 Azure Functions 처리는 중복 전달 가능성을 전제로 멱등하게 설계해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-idempotent
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-idempotent
       verified: true
     - claim: "신뢰할 수 있는 이벤트 처리를 위해 재시도, 중복, 부분 실패를 고려한 설계가 필요하다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-reliable-event-processing
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reliable-event-processing
       verified: true
     - claim: "Storage Queue 트리거는 maxDequeueCount 초과 시 poison queue로 메시지를 이동시킨다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
       verified: true
     - claim: "Durable Functions는 장기 실행 워크플로를 위해 상태와 체크포인트를 유지하는 오케스트레이션 모델을 제공한다."
-      source: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
       verified: true
 ---
 
@@ -322,11 +322,11 @@ flowchart TD
 
 ## Sources
 
-- [Designing Azure Functions for identical input (idempotency)](https://learn.microsoft.com/azure/azure-functions/functions-idempotent)
-- [Reliable event processing in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reliable-event-processing)
-- [Error handling and retries in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages)
-- [Queue trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger)
-- [Service Bus trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus-trigger)
-- [Azure Functions host storage considerations](https://learn.microsoft.com/azure/azure-functions/storage-considerations)
-- [Function app timeout duration](https://learn.microsoft.com/azure/azure-functions/functions-scale#timeout)
-- [Durable Functions overview](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview)
+- [Designing Azure Functions for identical input (idempotency)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-idempotent)
+- [Reliable event processing in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reliable-event-processing)
+- [Error handling and retries in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages)
+- [Queue trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger)
+- [Service Bus trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger)
+- [Azure Functions host storage considerations](https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations)
+- [Function app timeout duration](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#timeout)
+- [Durable Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview)

--- a/docs/best-practices/scaling.md
+++ b/docs/best-practices/scaling.md
@@ -1,29 +1,29 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/event-driven-scaling
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-concurrency
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions 스케일링은 이벤트 기반이며 다운스트림 한계 때문에 선형 확장을 보장하지 않는다."
-      source: https://learn.microsoft.com/azure/azure-functions/event-driven-scaling
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
       verified: true
     - claim: "Consumption과 Premium에서는 functionAppScaleLimit로 최대 인스턴스 수를 제한할 수 있다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
     - claim: "Flex Consumption은 always-ready 인스턴스와 메모리 프로필 같은 추가 스케일 튜닝 옵션을 제공한다."
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
     - claim: "동시성 설정은 트리거 유형과 런타임 특성에 맞게 조정해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-concurrency
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency
       verified: true
 ---
 
@@ -62,7 +62,7 @@ Use these expectations to set realistic SLOs before load testing.
 !!! warning "Do not promise linear scaling"
     Throughput increases can stall when downstream quotas, storage contention, or network limits become bottlenecks.
 
-> **Last verified**: 2026-06-06 | **Primary source**: [Azure Functions event-driven scaling](https://learn.microsoft.com/azure/azure-functions/event-driven-scaling)
+> **Last verified**: 2026-06-06 | **Primary source**: [Azure Functions event-driven scaling](https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling)
 
 ## Portal Walkthrough
 
@@ -254,7 +254,7 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions event-driven scaling (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/event-driven-scaling)
-- [Azure Functions concurrency (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-concurrency)
-- [Azure Functions hosting options and scaling (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions event-driven scaling (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling)
+- [Azure Functions concurrency (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency)
+- [Azure Functions hosting options and scaling (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/best-practices/security.md
+++ b/docs/best-practices/security.md
@@ -1,33 +1,33 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/security-concepts
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/function-keys-how-to
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions는 임베디드 비밀보다 관리형 ID와 identity-based connection 구성을 우선해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
       verified: true
     - claim: "Key Vault 참조는 app settings에서 비밀 값을 직접 저장하지 않고 사용할 수 있게 해준다."
-      source: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
       verified: true
     - claim: "Function key는 호출 제어용 공유 비밀이지 완전한 사용자 인증/권한 부여 모델이 아니다."
-      source: https://learn.microsoft.com/azure/azure-functions/function-keys-how-to
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
       verified: true
     - claim: "HTTPS-only와 최소 TLS 1.2 같은 전송 보안 기준을 강제해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/security-concepts
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
       verified: true
 ---
 
@@ -398,9 +398,9 @@ az role assignment create \
 
 ## Sources
 
-- [Azure Functions security concepts](https://learn.microsoft.com/azure/azure-functions/security-concepts)
-- [Tutorial: Create a function app that connects to Azure services using identities](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
-- [Identity-based connections in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
-- [App settings reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Use Key Vault references for App Service and Functions](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references)
-- [Function keys in Azure Functions](https://learn.microsoft.com/azure/azure-functions/function-keys-how-to)
+- [Azure Functions security concepts](https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts)
+- [Tutorial: Create a function app that connects to Azure services using identities](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Identity-based connections in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
+- [App settings reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Use Key Vault references for App Service and Functions](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+- [Function keys in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to)

--- a/docs/best-practices/trigger-and-binding.md
+++ b/docs/best-practices/trigger-and-binding.md
@@ -1,27 +1,27 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "트리거와 바인딩 선택은 워크로드의 전달 의미와 실패 처리 방식에 맞춰야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
       verified: true
     - claim: "Flex Consumption의 Blob 트리거 워크로드는 Event Grid 기반 blob trigger source를 사용해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
       verified: true
     - claim: "일반적인 Blob 트리거는 스토리지 이벤트를 처리할 수 있지만 플랜별 지원 모델 차이를 검증해야 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
       verified: true
     - claim: "함수 호스트와 일부 트리거는 호스트 스토리지 및 바인딩 구성을 올바르게 필요로 한다."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
       verified: true
 ---
 
@@ -209,6 +209,6 @@ Operationally, Event Grid models provide clearer event-flow visibility and reduc
 
 ## Sources
 
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Blob storage trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger)
-- [Event Grid blob trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Blob storage trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger)
+- [Event Grid blob trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger)

--- a/docs/contributing/cross-guide-baseline.md
+++ b/docs/contributing/cross-guide-baseline.md
@@ -1,11 +1,11 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/supported-languages
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
 ---
 
 # Cross-Guide Shared Structure Baseline
@@ -408,6 +408,6 @@ Use this checklist when adding or reviewing a language guide:
 
 ## Sources
 
-- [Azure Functions supported languages and runtimes (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/supported-languages)
-- [Azure Functions developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference)
-- [Azure Functions best practices (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-best-practices)
+- [Azure Functions supported languages and runtimes (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+- [Azure Functions developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference)
+- [Azure Functions best practices (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/
+      verified: true
 ---
 # Azure Functions Practical Guide
 
@@ -88,7 +87,7 @@ flowchart TD
 
 This is an independent community project. Not affiliated with or endorsed by Microsoft.
 
-Primary product reference: [Azure Functions documentation (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/)
+Primary product reference: [Azure Functions documentation (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/)
 
 ## See Also
 
@@ -102,4 +101,4 @@ Primary product reference: [Azure Functions documentation (Microsoft Learn)](htt
 
 ## Sources
 
-- [Azure Functions documentation (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/)
+- [Azure Functions documentation (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/)

--- a/docs/language-guides/dotnet/cli-cheatsheet.md
+++ b/docs/language-guides/dotnet/cli-cheatsheet.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # CLI Cheatsheet
 
@@ -75,5 +74,5 @@ az functionapp restart --name "$APP_NAME" --resource-group "$RG"
 - [Recipes Index](recipes/index.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/language-guides/dotnet/dotnet-runtime.md
+++ b/docs/language-guides/dotnet/dotnet-runtime.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/supported-languages
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/supported-languages
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+      verified: true
 ---
 # .NET Runtime
 
@@ -118,5 +117,5 @@ az functionapp create   --name "$APP_NAME"   --resource-group "$RG"   --storage-
 - [Troubleshooting](troubleshooting.md)
 
 ## Sources
-- [Azure Functions supported languages](https://learn.microsoft.com/azure/azure-functions/supported-languages)
-- [Guide for running C# Azure Functions in the isolated worker model](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions supported languages](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+- [Guide for running C# Azure Functions in the isolated worker model](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)

--- a/docs/language-guides/dotnet/environment-variables.md
+++ b/docs/language-guides/dotnet/environment-variables.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Environment Variables
 
@@ -73,5 +72,5 @@ flowchart TD
 - [Recipes Index](recipes/index.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/language-guides/dotnet/host-json.md
+++ b/docs/language-guides/dotnet/host-json.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # host.json Reference
 
@@ -74,5 +73,5 @@ flowchart TD
 - [Recipes Index](recipes/index.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/language-guides/dotnet/index.md
+++ b/docs/language-guides/dotnet/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+      verified: true
 ---
 # .NET Language Guide
 
@@ -119,5 +118,5 @@ The following content is planned for the .NET track:
 
 ## Sources
 
-- [Azure Functions .NET developer guide](https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library)
-- [Guide for running C# Azure Functions in the isolated worker model](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions .NET developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library)
+- [Guide for running C# Azure Functions in the isolated worker model](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)

--- a/docs/language-guides/dotnet/isolated-worker-model.md
+++ b/docs/language-guides/dotnet/isolated-worker-model.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # .NET Isolated Worker Model
 
@@ -147,5 +146,5 @@ project-root/
 - [Platform: Triggers and Bindings](../../platform/triggers-and-bindings.md)
 
 ## Sources
-- [Guide for running C# Azure Functions in the isolated worker model](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Guide for running C# Azure Functions in the isolated worker model](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/platform-limits.md
+++ b/docs/language-guides/dotnet/platform-limits.md
@@ -1,23 +1,22 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Platform Limits
 
@@ -62,7 +61,7 @@ flowchart TD
 - [Recipes Index](recipes/index.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Azure Functions hosting options and scale comparison](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Consumption plan details](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Azure Functions hosting options and scale comparison](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Consumption plan details](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)

--- a/docs/language-guides/dotnet/recipes/blob-storage.md
+++ b/docs/language-guides/dotnet/recipes/blob-storage.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Blob Storage
 
@@ -65,5 +64,5 @@ public byte[] BlobTransform(
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/cosmosdb.md
+++ b/docs/language-guides/dotnet/recipes/cosmosdb.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Cosmos DB
 
@@ -66,5 +65,5 @@ public Order WriteOrder([HttpTrigger(AuthorizationLevel.Function, "post", Route 
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/dotnet/recipes/custom-domain-certificates.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Custom Domain and Certificates
 
@@ -77,5 +76,5 @@ az functionapp config ssl bind --name "$APP_NAME" --resource-group "$RG" --certi
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/durable-orchestration.md
+++ b/docs/language-guides/dotnet/recipes/durable-orchestration.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Durable Orchestration
 
@@ -68,5 +67,5 @@ public async Task<HttpResponseData> StartOrder(
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/event-grid.md
+++ b/docs/language-guides/dotnet/recipes/event-grid.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Event Grid
 
@@ -56,5 +55,5 @@ az eventgrid event-subscription create   --name "sub-func-events"   --source-res
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/http-api.md
+++ b/docs/language-guides/dotnet/recipes/http-api.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # HTTP API Patterns
 
@@ -70,5 +69,5 @@ return response;
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/http-auth.md
+++ b/docs/language-guides/dotnet/recipes/http-auth.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # HTTP Authentication
 
@@ -82,5 +81,5 @@ if (req.Headers.TryGetValues("x-ms-client-principal", out var values))
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/index.md
+++ b/docs/language-guides/dotnet/recipes/index.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+      verified: true
 ---
 # .NET Recipes
 
@@ -60,4 +59,4 @@ flowchart TD
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET developer guide](https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library)
+- [Azure Functions .NET developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library)

--- a/docs/language-guides/dotnet/recipes/key-vault.md
+++ b/docs/language-guides/dotnet/recipes/key-vault.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Key Vault
 
@@ -56,5 +55,5 @@ var secretValue = response.Value.Value;
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/managed-identity.md
+++ b/docs/language-guides/dotnet/recipes/managed-identity.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Managed Identity
 
@@ -78,5 +77,5 @@ var blobService = new BlobServiceClient(new Uri($"https://{storageName}.blob.cor
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/queue.md
+++ b/docs/language-guides/dotnet/recipes/queue.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Queue
 
@@ -67,5 +66,5 @@ public string QueueWorker(
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/recipes/timer.md
+++ b/docs/language-guides/dotnet/recipes/timer.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Timer Trigger
 
@@ -63,5 +62,5 @@ public void Heartbeat([TimerTrigger("0 */5 * * * *")] TimerInfo timer)
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/troubleshooting.md
+++ b/docs/language-guides/dotnet/troubleshooting.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # Troubleshooting
 
@@ -68,5 +67,5 @@ func azure functionapp publish "$APP_NAME"
 - [Recipes Index](recipes/index.md)
 
 ## Sources
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/language-guides/dotnet/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 01 - Run Locally (Consumption)
 
@@ -217,9 +216,9 @@ Functions:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
 
 !!! warning "Legacy hosting path"
     Consumption plan (Y1) content is provided for existing workloads and compatibility scenarios. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/dotnet/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 02 - First Deploy (Consumption)
 
@@ -260,6 +259,6 @@ Health endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/dotnet/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 03 - Configuration (Consumption)
 
@@ -207,6 +206,6 @@ EventHubConnection                        Endpoint=sb://placeholder.servicebus.w
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)

--- a/docs/language-guides/dotnet/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 04 - Logging and Monitoring (Consumption)
 
@@ -272,6 +271,6 @@ LogLevels endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 05 - Infrastructure as Code (Consumption)
 
@@ -213,6 +212,6 @@ func-dotnetcon-04100220    Running  rg-func-dotnet-con-demo  func-dotnetcon-0410
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)

--- a/docs/language-guides/dotnet/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 06 - CI/CD (Consumption)
 
@@ -209,6 +208,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Continuous delivery with GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Continuous delivery with GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)

--- a/docs/language-guides/dotnet/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 07 - Extending with Triggers (Consumption)
 
@@ -375,6 +374,6 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 01 - Run Locally (Dedicated)
 
@@ -217,6 +216,6 @@ Functions:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/dotnet/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/02-first-deploy.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 02 - First Deploy (Dedicated)
 
@@ -314,7 +313,7 @@ Info endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-hosting-plans)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)

--- a/docs/language-guides/dotnet/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/03-configuration.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 03 - Configuration (Dedicated)
 
@@ -229,7 +228,7 @@ EventHubConnection                        Endpoint=sb://placeholder.servicebus.w
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-hosting-plans)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)

--- a/docs/language-guides/dotnet/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/04-logging-monitoring.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 04 - Logging and Monitoring (Dedicated)
 
@@ -287,7 +286,7 @@ LogLevels endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-hosting-plans)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)

--- a/docs/language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md
@@ -10,23 +10,22 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 05 - Infrastructure as Code (Dedicated)
 
@@ -214,7 +213,7 @@ func-dnetded-04100301      Running  rg-func-dotnet-ded-demo   func-dnetded-04100
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
-- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-hosting-plans)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)
+- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)

--- a/docs/language-guides/dotnet/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/06-ci-cd.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 06 - CI/CD (Dedicated)
 
@@ -214,7 +213,7 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Continuous delivery with GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
-- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-hosting-plans)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Continuous delivery with GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)
+- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)

--- a/docs/language-guides/dotnet/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/07-extending-triggers.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 07 - Extending with Triggers (Dedicated)
 
@@ -392,7 +391,7 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-hosting-plans)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure App Service plans overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 01 - Run Locally (Flex Consumption)
 
@@ -217,6 +216,6 @@ Functions:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 02 - First Deploy (Flex Consumption)
 
@@ -371,6 +370,6 @@ Identity probe (confirms managed identity is active on Flex Consumption):
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -1,30 +1,29 @@
 ---
 validation:
   az_cli:
-    last_tested: null
+    last_tested:
     cli_version: 2.83.0
     core_tools_version: 4.8.0
     result: not_tested
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 
@@ -961,6 +960,6 @@ Endpoint test results from the Korea Central deployment (all returned HTTP 200):
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Flex Consumption plan hosting](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Create and manage Flex Consumption apps](https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Flex Consumption plan hosting](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Create and manage Flex Consumption apps](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to)

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 03 - Configuration (Flex Consumption)
 
@@ -189,6 +188,6 @@ AZURE_FUNCTIONS_ENVIRONMENT               Production                            
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 04 - Logging and Monitoring (Flex Consumption)
 
@@ -272,6 +271,6 @@ LogLevels endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 05 - Infrastructure as Code (Flex Consumption)
 
@@ -244,6 +243,6 @@ func-dnetflex-04100301     Running  rg-func-dotnet-flex-demo   func-dnetflex-041
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 06 - CI/CD (Flex Consumption)
 
@@ -209,6 +208,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Continuous delivery with GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Continuous delivery with GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 07 - Extending with Triggers (Flex Consumption)
 
@@ -378,6 +377,6 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/dotnet/tutorial/index.md
+++ b/docs/language-guides/dotnet/tutorial/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-scale
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+      verified: true
 ---
 # Tutorial — Choose Your Hosting Plan
 
@@ -94,5 +93,5 @@ flowchart TD
 - [Operations: Deployment](../../../operations/deployment.md)
 
 ## Sources
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Guide for running C# Azure Functions in the isolated worker model](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Guide for running C# Azure Functions in the isolated worker model](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)

--- a/docs/language-guides/dotnet/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/premium/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 01 - Run Locally (Premium)
 
@@ -217,6 +216,6 @@ Functions:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/dotnet/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/premium/02-first-deploy.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 02 - First Deploy (Premium)
 
@@ -308,7 +307,7 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Develop Azure Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)

--- a/docs/language-guides/dotnet/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/dotnet/tutorial/premium/02a-first-deploy-private-egress.md
@@ -1,32 +1,31 @@
 ---
 validation:
   az_cli:
-    last_tested: null
+    last_tested:
     cli_version: 2.83.0
     core_tools_version: 4.8.0
     result: not_tested
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 
@@ -780,6 +779,6 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable)
-- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/azure/app-service/networking/private-endpoint)
+- [Azure Functions Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable)
+- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint)

--- a/docs/language-guides/dotnet/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/premium/03-configuration.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 03 - Configuration (Premium)
 
@@ -214,7 +213,7 @@ EventHubConnection                        Endpoint=sb://placeholder.servicebus.w
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)

--- a/docs/language-guides/dotnet/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/premium/04-logging-monitoring.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 04 - Logging and Monitoring (Premium)
 
@@ -274,7 +273,7 @@ LogLevels endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)

--- a/docs/language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
@@ -10,23 +10,22 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 05 - Infrastructure as Code (Premium)
 
@@ -215,7 +214,7 @@ func-dnetprem-04100301     Running  rg-func-dotnet-prem-demo   func-dnetprem-041
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)

--- a/docs/language-guides/dotnet/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/premium/06-ci-cd.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 06 - CI/CD (Premium)
 
@@ -214,7 +213,7 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Continuous delivery with GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Continuous delivery with GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)

--- a/docs/language-guides/dotnet/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/premium/07-extending-triggers.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+      verified: true
 ---
 # 07 - Extending with Triggers (Premium)
 
@@ -377,7 +376,7 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
+- [Azure Functions .NET isolated worker guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)

--- a/docs/language-guides/index.md
+++ b/docs/language-guides/index.md
@@ -1,23 +1,22 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # Language Guides
 
@@ -113,7 +112,7 @@ This table aligns with Microsoft Learn references for each language runtime.
 
 ## Sources
 
-- [Python developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Node.js developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [.NET class library guide](https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library)
-- [Java developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
+- [Python developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Node.js developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [.NET class library guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library)
+- [Java developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)

--- a/docs/language-guides/java/annotation-programming-model.md
+++ b/docs/language-guides/java/annotation-programming-model.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # Java Annotation Programming Model
 
@@ -99,5 +98,5 @@ public String queueToBlob(
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/java/cli-cheatsheet.md
+++ b/docs/language-guides/java/cli-cheatsheet.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/functionapp
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # CLI Cheatsheet
 
@@ -76,5 +75,5 @@ az functionapp log tail --name $APP_NAME --resource-group $RG
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/cli/azure/functionapp)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)

--- a/docs/language-guides/java/environment-variables.md
+++ b/docs/language-guides/java/environment-variables.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/functionapp
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # Environment Variables
 
@@ -78,5 +77,5 @@ az functionapp config appsettings set --name $APP_NAME --resource-group $RG --se
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/cli/azure/functionapp)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)

--- a/docs/language-guides/java/host-json.md
+++ b/docs/language-guides/java/host-json.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/functionapp
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # host.json Reference
 
@@ -67,5 +66,5 @@ Example baseline:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/cli/azure/functionapp)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)

--- a/docs/language-guides/java/index.md
+++ b/docs/language-guides/java/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # Java Language Guide
 
@@ -124,5 +123,5 @@ The following content is planned for the Java track:
 
 ## Sources
 
-- [Azure Functions Java developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Quickstart: Create a Java function in Azure Functions](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Quickstart: Create a Java function in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/java-runtime.md
+++ b/docs/language-guides/java/java-runtime.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/supported-languages
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/supported-languages
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+      verified: true
 ---
 # Java Runtime
 
@@ -133,5 +132,5 @@ az functionapp create   --name $APP_NAME   --resource-group $RG   --storage-acco
 
 ## Sources
 
-- [Supported languages in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/supported-languages)
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
+- [Supported languages in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)

--- a/docs/language-guides/java/platform-limits.md
+++ b/docs/language-guides/java/platform-limits.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/functionapp
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # Platform Limits
 
@@ -44,5 +43,5 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/cli/azure/functionapp)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)

--- a/docs/language-guides/java/recipes/blob-storage.md
+++ b/docs/language-guides/java/recipes/blob-storage.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+      verified: true
 ---
 # Blob Storage Integration
 
@@ -140,5 +139,5 @@ public class BlobFunctions {
 
 ## Sources
 
-- [Azure Blob storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob)
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
+- [Azure Blob storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)

--- a/docs/language-guides/java/recipes/cosmosdb.md
+++ b/docs/language-guides/java/recipes/cosmosdb.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+      verified: true
 ---
 # Cosmos DB Integration
 
@@ -202,5 +201,5 @@ public class CosmosFunctions {
 
 ## Sources
 
-- [Azure Functions Cosmos DB bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2)
-- [Identity-based connections in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
+- [Azure Functions Cosmos DB bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2)
+- [Identity-based connections in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection)

--- a/docs/language-guides/java/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/java/recipes/custom-domain-certificates.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-custom-domain
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-ssl-certificate
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-custom-domain
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+      verified: true
 ---
 # Custom Domain and Certificates
 
@@ -111,5 +110,5 @@ az functionapp config ssl bind \
 
 ## Sources
 
-- [Map an existing custom DNS name to Azure App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-custom-domain)
-- [Add and manage TLS/SSL certificates in Azure App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/configure-ssl-certificate)
+- [Map an existing custom DNS name to Azure App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain)
+- [Add and manage TLS/SSL certificates in Azure App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate)

--- a/docs/language-guides/java/recipes/durable-orchestration.md
+++ b/docs/language-guides/java/recipes/durable-orchestration.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+      verified: true
 ---
 # Durable Orchestration
 
@@ -140,5 +139,5 @@ public class DurableFunctions {
 
 ## Sources
 
-- [Durable Functions overview (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview)
-- [Durable Functions bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-bindings)
+- [Durable Functions overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview)
+- [Durable Functions bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings)

--- a/docs/language-guides/java/recipes/event-grid.md
+++ b/docs/language-guides/java/recipes/event-grid.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid-trigger
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
+      verified: true
 ---
 # Event Grid Trigger
 
@@ -100,5 +99,5 @@ public class EventGridFunctions {
 
 ## Sources
 
-- [Event Grid trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid-trigger)
-- [Create event subscriptions with Azure CLI (Microsoft Learn)](https://learn.microsoft.com/cli/azure/eventgrid/event-subscription?view=azure-cli-latest)
+- [Event Grid trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger)
+- [Create event subscriptions with Azure CLI (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest)

--- a/docs/language-guides/java/recipes/http-api.md
+++ b/docs/language-guides/java/recipes/http-api.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
+      verified: true
 ---
 # HTTP API Patterns
 
@@ -181,5 +180,5 @@ curl --request POST "http://localhost:7071/api/orders/1001" \
 
 ## Sources
 
-- [Azure Functions HTTP trigger for Java (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger)
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
+- [Azure Functions HTTP trigger for Java (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)

--- a/docs/language-guides/java/recipes/http-auth.md
+++ b/docs/language-guides/java/recipes/http-auth.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger#working-with-client-identities
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger#working-with-client-identities
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+      verified: true
 ---
 # HTTP Authentication
 
@@ -127,5 +126,5 @@ public class EasyAuthFunction {
 
 ## Sources
 
-- [Authentication and authorization in Azure App Service and Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-authentication-authorization)
-- [Work with client identities in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger#working-with-client-identities)
+- [Authentication and authorization in Azure App Service and Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization)
+- [Work with client identities in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger#working-with-client-identities)

--- a/docs/language-guides/java/recipes/index.md
+++ b/docs/language-guides/java/recipes/index.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+      verified: true
 ---
 # Recipes
 
@@ -44,4 +43,4 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/java/recipes/key-vault.md
+++ b/docs/language-guides/java/recipes/key-vault.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/key-vault/secrets/quick-create-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+      verified: true
 ---
 # Key Vault Integration
 
@@ -145,5 +144,5 @@ public class KeyVaultFunctions {
 
 ## Sources
 
-- [Use Key Vault references for App Service and Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references)
-- [Quickstart: Azure Key Vault secrets client library for Java (Microsoft Learn)](https://learn.microsoft.com/azure/key-vault/secrets/quick-create-java)
+- [Use Key Vault references for App Service and Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+- [Quickstart: Azure Key Vault secrets client library for Java (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-java)

--- a/docs/language-guides/java/recipes/managed-identity.md
+++ b/docs/language-guides/java/recipes/managed-identity.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/java/api/overview/azure/identity-readme
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+      verified: true
 ---
 # Managed Identity
 
@@ -165,5 +164,5 @@ public class ManagedIdentityFunctions {
 
 ## Sources
 
-- [Use managed identities in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
-- [Azure Identity client library for Java (Microsoft Learn)](https://learn.microsoft.com/java/api/overview/azure/identity-readme)
+- [Use managed identities in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Azure Identity client library for Java (Microsoft Learn)](https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme)

--- a/docs/language-guides/java/recipes/queue.md
+++ b/docs/language-guides/java/recipes/queue.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+      verified: true
 ---
 # Queue Storage Integration
 
@@ -142,5 +141,5 @@ az storage message peek \
 
 ## Sources
 
-- [Azure Queue storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue)
-- [Azure Functions host.json reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [Azure Queue storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue)
+- [Azure Functions host.json reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/language-guides/java/recipes/timer.md
+++ b/docs/language-guides/java/recipes/timer.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+      verified: true
 ---
 # Timer Trigger
 
@@ -95,5 +94,5 @@ public class TimerFunctions {
 
 ## Sources
 
-- [Timer trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer)
-- [App settings reference for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
+- [Timer trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer)
+- [App settings reference for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)

--- a/docs/language-guides/java/troubleshooting.md
+++ b/docs/language-guides/java/troubleshooting.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/functionapp
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # Troubleshooting
 
@@ -60,5 +59,5 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/cli/azure/functionapp)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions CLI reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)

--- a/docs/language-guides/java/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/java/tutorial/consumption/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 01 - Run Locally (Consumption)
 
@@ -194,9 +193,9 @@ Confirm that the Functions host starts, HTTP functions are listed in the endpoin
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)
 
 !!! warning "Legacy hosting path"
     Consumption plan (Y1) content is provided for existing workloads and compatibility scenarios. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/java/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/consumption/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 02 - First Deploy (Consumption)
 
@@ -300,6 +299,6 @@ Info endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/java/tutorial/consumption/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 03 - Configuration (Consumption)
 
@@ -215,6 +214,6 @@ EventHubConnection                      Endpoint=sb://placeholder.servicebus.win
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/consumption/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 04 - Logging and Monitoring (Consumption)
 
@@ -240,6 +239,6 @@ LogLevels endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/consumption/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 05 - Infrastructure as Code (Consumption)
 
@@ -214,6 +213,6 @@ func-jcon-04100022      Running  rg-func-java-con-demo    func-jcon-04100022.azu
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/consumption/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 06 - CI/CD (Consumption)
 
@@ -206,6 +205,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/consumption/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 07 - Extending with Triggers (Consumption)
 
@@ -339,6 +338,6 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/java/tutorial/dedicated/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 01 - Run Locally (Dedicated)
 
@@ -195,6 +194,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/dedicated/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 02 - First Deploy (Dedicated)
 
@@ -372,6 +371,6 @@ Info endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/java/tutorial/dedicated/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 03 - Configuration (Dedicated)
 
@@ -250,6 +249,6 @@ EventHubConnection                      Endpoint=sb://placeholder.servicebus.win
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/dedicated/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 04 - Logging and Monitoring (Dedicated)
 
@@ -232,6 +231,6 @@ Application started. Press Ctrl+C to shut down.
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md
@@ -10,23 +10,22 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/templates/microsoft.web/sites
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 05 - Infrastructure as Code (Dedicated)
 
@@ -276,7 +275,7 @@ Running  True        Java|17
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
-- [Bicep reference for Microsoft.Web/sites (Microsoft Learn)](https://learn.microsoft.com/azure/templates/microsoft.web/sites)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)
+- [Bicep reference for Microsoft.Web/sites (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites)

--- a/docs/language-guides/java/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/dedicated/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 06 - CI/CD (Dedicated)
 
@@ -234,6 +233,6 @@ Smoke test passed (HTTP 200)
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/dedicated/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 07 - Extending with Triggers (Dedicated)
 
@@ -260,6 +259,6 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 01 - Run Locally (Flex Consumption)
 
@@ -171,6 +170,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/java/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 02 - First Deploy (Flex Consumption)
 
@@ -390,6 +389,6 @@ Identity probe (confirms managed identity is active on Flex Consumption):
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/java/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -1,30 +1,29 @@
 ---
 validation:
   az_cli:
-    last_tested: null
+    last_tested:
     cli_version: 2.83.0
     core_tools_version: 4.8.0
     result: not_tested
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 
@@ -956,6 +955,6 @@ Endpoint test results from the Korea Central deployment (all returned HTTP 200):
 
 ## Sources
 
-- [Azure Functions Java developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Flex Consumption plan hosting](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Create and manage Flex Consumption apps](https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to)
+- [Azure Functions Java developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Flex Consumption plan hosting](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Create and manage Flex Consumption apps](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to)

--- a/docs/language-guides/java/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 03 - Configuration (Flex Consumption)
 
@@ -210,6 +209,6 @@ EventHubConnection                      Endpoint=sb://placeholder.servicebus.win
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/java/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 04 - Logging and Monitoring (Flex Consumption)
 
@@ -242,6 +241,6 @@ LogLevels endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 05 - Infrastructure as Code (Flex Consumption)
 
@@ -280,6 +279,6 @@ func-jflex-04100144     Running  rg-func-java-flex-demo   func-jflex-04100144.az
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/java/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-continuous-deployment
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 06 - CI/CD (Flex Consumption)
 
@@ -233,6 +232,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Continuous deployment for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-continuous-deployment)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Continuous deployment for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/java/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 07 - Extending with Triggers (Flex Consumption)
 
@@ -367,6 +366,6 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/java/tutorial/index.md
+++ b/docs/language-guides/java/tutorial/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-scale
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+      verified: true
 ---
 # Tutorial — Choose Your Hosting Plan
 
@@ -90,5 +89,5 @@ Fixed-capacity hosting for teams already operating App Service footprints.
 
 ## Sources
 
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)

--- a/docs/language-guides/java/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/java/tutorial/premium/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 01 - Run Locally (Premium)
 
@@ -203,6 +202,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/premium/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 02 - First Deploy (Premium)
 
@@ -354,6 +353,6 @@ Info endpoint response:
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/java/tutorial/premium/02a-first-deploy-private-egress.md
@@ -1,32 +1,31 @@
 ---
 validation:
   az_cli:
-    last_tested: null
+    last_tested:
     cli_version: 2.83.0
     core_tools_version: 4.8.0
     result: not_tested
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 
@@ -785,6 +784,6 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable)
-- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/azure/app-service/networking/private-endpoint)
+- [Azure Functions Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable)
+- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint)

--- a/docs/language-guides/java/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/java/tutorial/premium/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 03 - Configuration (Premium)
 
@@ -252,6 +251,6 @@ WEBSITE_CONTENTAZUREFILECONNECTIONSTRING DefaultEndpointsProtocol=https;AccountN
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/premium/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 04 - Logging and Monitoring (Premium)
 
@@ -270,6 +269,6 @@ Application started. Press Ctrl+C to shut down.
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/premium/05-infrastructure-as-code.md
@@ -10,23 +10,22 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/templates/microsoft.web/sites
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 05 - Infrastructure as Code (Premium)
 
@@ -247,7 +246,7 @@ log-jprem-demo          Microsoft.OperationalInsights/workspaces  koreacentral
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
-- [Bicep reference for Microsoft.Web/sites (Microsoft Learn)](https://learn.microsoft.com/azure/templates/microsoft.web/sites)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)
+- [Bicep reference for Microsoft.Web/sites (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites)

--- a/docs/language-guides/java/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/premium/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 06 - CI/CD (Premium)
 
@@ -236,6 +235,6 @@ Smoke test passed (HTTP 200)
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/java/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/premium/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+      verified: true
 ---
 # 07 - Extending with Triggers (Premium)
 
@@ -257,6 +256,6 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-java)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Create a Java function with Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java)

--- a/docs/language-guides/nodejs/cli-cheatsheet.md
+++ b/docs/language-guides/nodejs/cli-cheatsheet.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/functionapp
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+      verified: true
 ---
 # CLI Cheatsheet
 
@@ -80,5 +79,5 @@ az deployment group create --resource-group $RG --template-file infra/main.bicep
 - [Operations: Deployment](../../operations/deployment.md)
 
 ## Sources
-- [Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Azure CLI functionapp reference (Microsoft Learn)](https://learn.microsoft.com/cli/azure/functionapp)
+- [Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure CLI functionapp reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)

--- a/docs/language-guides/nodejs/environment-variables.md
+++ b/docs/language-guides/nodejs/environment-variables.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+      verified: true
 ---
 # Environment Variables
 
@@ -68,4 +67,4 @@ az functionapp config set --name $APP_NAME --resource-group $RG --linux-fx-versi
 - [Troubleshooting](troubleshooting.md)
 
 ## Sources
-- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
+- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)

--- a/docs/language-guides/nodejs/host-json.md
+++ b/docs/language-guides/nodejs/host-json.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-host-json
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+      verified: true
 ---
 # host.json Reference
 
@@ -64,4 +63,4 @@ flowchart TD
 - [Troubleshooting](troubleshooting.md)
 
 ## Sources
-- [host.json reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [host.json reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/language-guides/nodejs/index.md
+++ b/docs/language-guides/nodejs/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # Node.js Language Guide
 
@@ -112,5 +111,5 @@ The following content is planned for the Node.js track:
 
 ## Sources
 
-- [Azure Functions Node.js developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions JavaScript SDK v4 reference](https://learn.microsoft.com/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4)
+- [Azure Functions Node.js developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions JavaScript SDK v4 reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4)

--- a/docs/language-guides/nodejs/nodejs-runtime.md
+++ b/docs/language-guides/nodejs/nodejs-runtime.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # Node.js Runtime
 
@@ -101,6 +100,6 @@ az functionapp config set --name $APP_NAME --resource-group $RG --linux-fx-versi
 - [Troubleshooting](troubleshooting.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/nodejs/platform-limits.md
+++ b/docs/language-guides/nodejs/platform-limits.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-scale
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+      verified: true
 ---
 # Platform Limits
 
@@ -49,4 +48,4 @@ flowchart TD
 - [Platform: Scaling](../../platform/scaling.md)
 
 ## Sources
-- [Azure Functions scale and hosting (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions scale and hosting (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/recipes/blob-storage.md
+++ b/docs/language-guides/nodejs/recipes/blob-storage.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+      verified: true
 ---
 # Blob Storage Patterns
 
@@ -140,5 +139,5 @@ app.http("getIncomingBlobMetadata", {
 - [Node.js v4 Programming Model](../v4-programming-model.md)
 
 ## Sources
-- [Azure Blob Storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob)
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
+- [Azure Blob Storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)

--- a/docs/language-guides/nodejs/recipes/cosmosdb.md
+++ b/docs/language-guides/nodejs/recipes/cosmosdb.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+      verified: true
 ---
 # Cosmos DB Integration
 
@@ -185,5 +184,5 @@ app.http("createOrder", {
 - [HTTP API Patterns](http-api.md)
 
 ## Sources
-- [Azure Cosmos DB bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2)
-- [Identity-based connections for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
+- [Azure Cosmos DB bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2)
+- [Identity-based connections for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection)

--- a/docs/language-guides/nodejs/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/nodejs/recipes/custom-domain-certificates.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-custom-domain
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-ssl-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-custom-domain
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+      verified: true
 ---
 # Custom Domains and Certificates
 
@@ -163,5 +162,5 @@ app.http("healthz", {
 - [HTTP Authentication](http-auth.md)
 
 ## Sources
-- [Tutorial: Map an existing custom DNS name to Azure App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-custom-domain)
-- [Secure a custom DNS name with TLS/SSL binding in App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/configure-ssl-bindings)
+- [Tutorial: Map an existing custom DNS name to Azure App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain)
+- [Secure a custom DNS name with TLS/SSL binding in App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings)

--- a/docs/language-guides/nodejs/recipes/durable-orchestration.md
+++ b/docs/language-guides/nodejs/recipes/durable-orchestration.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-node-model-upgrade
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-node-model-upgrade
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade
+      verified: true
 ---
 # Durable Orchestration
 
@@ -135,5 +134,5 @@ df.app.activity("emitConfirmation", {
 - [Node.js v4 Programming Model](../v4-programming-model.md)
 
 ## Sources
-- [Migrate Durable Functions app to Node.js v4 model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-node-model-upgrade)
-- [Durable Functions overview (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview)
+- [Migrate Durable Functions app to Node.js v4 model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade)
+- [Durable Functions overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview)

--- a/docs/language-guides/nodejs/recipes/event-grid.md
+++ b/docs/language-guides/nodejs/recipes/event-grid.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid-trigger
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
+      verified: true
 ---
 # Event Grid Events
 
@@ -101,5 +100,5 @@ app.eventGrid("processStorageEvent", {
 - [Queue Processing](queue.md)
 
 ## Sources
-- [Event Grid trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid-trigger)
-- [Create Event Grid subscriptions with Azure CLI (Microsoft Learn)](https://learn.microsoft.com/cli/azure/eventgrid/event-subscription?view=azure-cli-latest)
+- [Event Grid trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger)
+- [Create Event Grid subscriptions with Azure CLI (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest)

--- a/docs/language-guides/nodejs/recipes/http-api.md
+++ b/docs/language-guides/nodejs/recipes/http-api.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # HTTP API Patterns
 
@@ -157,5 +156,5 @@ curl --request POST "http://localhost:7071/api/orders?customerId=c-1001" \
 - [Node.js v4 Programming Model](../v4-programming-model.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions HTTP trigger (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions HTTP trigger (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)

--- a/docs/language-guides/nodejs/recipes/http-auth.md
+++ b/docs/language-guides/nodejs/recipes/http-auth.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+      verified: true
 ---
 # HTTP Authentication
 
@@ -136,5 +135,5 @@ app.http("profile", {
 - [Node.js v4 Programming Model](../v4-programming-model.md)
 
 ## Sources
-- [Authentication and authorization in Azure App Service and Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-authentication-authorization)
-- [Azure Functions HTTP trigger authorization level (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger)
+- [Authentication and authorization in Azure App Service and Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization)
+- [Azure Functions HTTP trigger authorization level (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)

--- a/docs/language-guides/nodejs/recipes/index.md
+++ b/docs/language-guides/nodejs/recipes/index.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+      verified: true
 ---
 # Node.js Recipes
 
@@ -41,4 +40,4 @@ flowchart TD
 - [Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Azure Functions trigger and binding concepts (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions trigger and binding concepts (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/nodejs/recipes/key-vault.md
+++ b/docs/language-guides/nodejs/recipes/key-vault.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/javascript/api/overview/azure/keyvault-secrets-readme
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/keyvault-secrets-readme
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+      verified: true
 ---
 # Key Vault Access
 
@@ -158,5 +157,5 @@ app.http("secretsHealth", {
 - [HTTP Authentication](http-auth.md)
 
 ## Sources
-- [Use Key Vault references for App Service and Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references)
-- [Azure Key Vault Secrets client library for JavaScript (Microsoft Learn)](https://learn.microsoft.com/javascript/api/overview/azure/keyvault-secrets-readme)
+- [Use Key Vault references for App Service and Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+- [Azure Key Vault Secrets client library for JavaScript (Microsoft Learn)](https://learn.microsoft.com/en-us/javascript/api/overview/azure/keyvault-secrets-readme)

--- a/docs/language-guides/nodejs/recipes/managed-identity.md
+++ b/docs/language-guides/nodejs/recipes/managed-identity.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview
+      verified: true
 ---
 # Managed Identity
 
@@ -198,5 +197,5 @@ app.http("identityProbe", {
 - [Cosmos DB Integration](cosmosdb.md)
 
 ## Sources
-- [Managed identities for Azure resources (Microsoft Learn)](https://learn.microsoft.com/entra/identity/managed-identities-azure-resources/overview)
-- [Use managed identities in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Managed identities for Azure resources (Microsoft Learn)](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview)
+- [Use managed identities in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)

--- a/docs/language-guides/nodejs/recipes/queue.md
+++ b/docs/language-guides/nodejs/recipes/queue.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+      verified: true
 ---
 # Queue Processing
 
@@ -117,5 +116,5 @@ When the handler keeps failing for the same message, Azure Functions moves the m
 - [Troubleshooting Guide](../troubleshooting.md)
 
 ## Sources
-- [Azure Queue Storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue)
-- [Azure Functions error handling and retries (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages)
+- [Azure Queue Storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue)
+- [Azure Functions error handling and retries (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages)

--- a/docs/language-guides/nodejs/recipes/timer.md
+++ b/docs/language-guides/nodejs/recipes/timer.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+      verified: true
 ---
 # Timer Jobs
 
@@ -106,5 +105,5 @@ app.timer("nightlyReconciliation", {
 - [Node.js Troubleshooting](../troubleshooting.md)
 
 ## Sources
-- [Timer trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer)
-- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
+- [Timer trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer)
+- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)

--- a/docs/language-guides/nodejs/troubleshooting.md
+++ b/docs/language-guides/nodejs/troubleshooting.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # Troubleshooting
 
@@ -80,5 +79,5 @@ az functionapp config show --name $APP_NAME --resource-group $RG --query "linuxF
 - [Operations: Monitoring](../../operations/monitoring.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions diagnostics (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions diagnostics (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)

--- a/docs/language-guides/nodejs/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 01 - Run Locally (Consumption)
 
@@ -160,9 +159,9 @@ You now have local parity and can deploy to Azure Consumption (Y1).
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
 
 !!! warning "Legacy hosting path"
     Consumption plan (Y1) content is provided for existing workloads and compatibility scenarios. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/nodejs/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 02 - First Deploy (Consumption)
 
@@ -268,6 +267,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 03 - Configuration (Consumption)
 
@@ -218,6 +217,6 @@ Node|20
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/configure-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 04 - Logging and Monitoring (Consumption)
 
@@ -233,6 +232,6 @@ The `traces | take 5` query should return rows with log messages:
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Application Insights for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/configure-monitoring)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Application Insights for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring)

--- a/docs/language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 05 - Infrastructure as Code (Consumption)
 
@@ -268,6 +267,6 @@ Deployment output shows `Succeeded`:
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-continuous-deployment
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 06 - CI/CD (Consumption)
 
@@ -199,6 +198,6 @@ az monitor app-insights query \
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Continuous deployment for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-continuous-deployment)
-- [Azure Functions GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Continuous deployment for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment)
+- [Azure Functions GitHub Actions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)

--- a/docs/language-guides/nodejs/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/07-extending-triggers.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 07 - Extending Triggers (Consumption)
 
@@ -257,7 +256,7 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Queue storage trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger)
-- [Azure Blob storage trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Queue storage trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger)
+- [Azure Blob storage trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger)

--- a/docs/language-guides/nodejs/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 01 - Run Locally (Dedicated)
 
@@ -151,6 +150,6 @@ Confirm that the host lists `helloHttp`, then run `curl --request GET "http://lo
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 02 - First Deploy (Dedicated)
 
@@ -667,6 +666,6 @@ The output confirms that Azure indexed your function definitions and the app ser
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 03 - Configuration (Dedicated)
 
@@ -175,6 +174,6 @@ The table confirms required Node.js worker settings are applied to the deployed 
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 04 - Logging and Monitoring (Dedicated)
 
@@ -214,6 +213,6 @@ The query result proves telemetry ingestion is active for your Function App. Ver
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 05 - Infrastructure as Code (Dedicated)
 
@@ -216,6 +215,6 @@ A `Succeeded` provisioning state confirms the Bicep deployment completed. Verify
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 06 - CI/CD (Dedicated)
 
@@ -190,6 +189,6 @@ The log stream confirms the deployed function starts and handles requests succes
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 07 - Extending Triggers (Dedicated)
 
@@ -233,6 +232,6 @@ The host output confirms all triggers are indexed and available. Verify:
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 01 - Run Locally (Flex Consumption)
 
@@ -155,6 +154,6 @@ HTTP response example:
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 02 - First Deploy (Flex Consumption)
 
@@ -292,6 +291,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -1,30 +1,29 @@
 ---
 validation:
   az_cli:
-    last_tested: null
+    last_tested:
     cli_version: 2.83.0
     core_tools_version: 4.8.0
     result: not_tested
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 
@@ -952,6 +951,6 @@ Endpoint test results from the Korea Central deployment (all returned HTTP 200):
 
 ## Sources
 
-- [Azure Functions Node.js developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Flex Consumption plan hosting](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Create and manage Flex Consumption apps](https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to)
+- [Azure Functions Node.js developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Flex Consumption plan hosting](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Create and manage Flex Consumption apps](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to)

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 03 - Configuration (Flex Consumption)
 
@@ -172,6 +171,6 @@ APPLICATIONINSIGHTS_CONNECTION_STRING  InstrumentationKey=...
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions app settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 04 - Logging and Monitoring (Flex Consumption)
 
@@ -199,6 +198,6 @@ The `traces | take 5` query should return rows with log messages:
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: pass
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 05 - Infrastructure as Code (Flex Consumption)
 
@@ -253,6 +252,6 @@ Deployment output shows `Succeeded`:
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Automate resource deployment with Bicep (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-continuous-deployment
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 06 - CI/CD (Flex Consumption)
 
@@ -205,6 +204,6 @@ az monitor app-insights query \
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Continuous deployment for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-continuous-deployment)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Continuous deployment for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 07 - Extending Triggers (Flex Consumption)
 
@@ -254,6 +253,6 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/nodejs/tutorial/index.md
+++ b/docs/language-guides/nodejs/tutorial/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-scale
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+      verified: true
 ---
 # Tutorial - Choose Your Hosting Plan
 
@@ -68,5 +67,5 @@ flowchart TD
 - [Platform: Hosting Plans](../../../platform/hosting.md)
 
 ## Sources
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/nodejs/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/premium/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 01 - Run Locally (Premium)
 
@@ -170,6 +169,6 @@ Confirm that the host lists `helloHttp`, then run `curl --request GET "http://lo
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/premium/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 02 - First Deploy (Premium)
 
@@ -364,6 +363,6 @@ The output confirms that Azure indexed your function definitions and the app ser
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/nodejs/tutorial/premium/02a-first-deploy-private-egress.md
@@ -1,32 +1,31 @@
 ---
 validation:
   az_cli:
-    last_tested: null
+    last_tested:
     cli_version: 2.83.0
     core_tools_version: 4.8.0
     result: not_tested
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 
@@ -770,6 +769,6 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable)
-- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/azure/app-service/networking/private-endpoint)
+- [Azure Functions Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable)
+- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint)

--- a/docs/language-guides/nodejs/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/premium/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 03 - Configuration (Premium)
 
@@ -223,6 +222,6 @@ The table confirms required Node.js worker settings are applied to the deployed 
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/premium/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 04 - Logging and Monitoring (Premium)
 
@@ -229,6 +228,6 @@ Verify that:
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Monitor Azure Functions with Application Insights (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 05 - Infrastructure as Code (Premium)
 
@@ -250,6 +249,6 @@ A `Succeeded` provisioning state confirms the Bicep deployment completed for the
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Bicep overview (Microsoft Learn)](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Bicep overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/premium/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-continuous-deployment
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 06 - CI/CD (Premium)
 
@@ -194,6 +193,6 @@ Confirm:
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Continuous deployment for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-continuous-deployment)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Continuous deployment for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/premium/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # 07 - Extending Triggers (Premium)
 
@@ -390,6 +389,6 @@ Confirm:
 - [Recipes Index](../../recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/nodejs/v4-programming-model.md
+++ b/docs/language-guides/nodejs/v4-programming-model.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+      verified: true
 ---
 # Node.js v4 Programming Model
 
@@ -163,6 +162,6 @@ func start
 - [Recipes Index](recipes/index.md)
 
 ## Sources
-- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/python/cli-cheatsheet.md
+++ b/docs/language-guides/python/cli-cheatsheet.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/functionapp
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+      verified: true
 ---
 # CLI Cheatsheet
 
@@ -440,6 +439,6 @@ az monitor metrics list \
 - [Deployments](../../operations/deployment.md)
 
 ## Sources
-- [Azure Functions Core Tools Reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Azure Functions CLI Reference (Microsoft Learn)](https://learn.microsoft.com/cli/azure/functionapp)
-- [Develop Azure Functions Locally (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
+- [Azure Functions Core Tools Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure Functions CLI Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)
+- [Develop Azure Functions Locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)

--- a/docs/language-guides/python/environment-variables.md
+++ b/docs/language-guides/python/environment-variables.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # Environment Variables
 
@@ -276,4 +275,4 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
 - [Troubleshooting](troubleshooting.md)
 
 ## Sources
-- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
+- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)

--- a/docs/language-guides/python/host-json.md
+++ b/docs/language-guides/python/host-json.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-host-json
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+      verified: true
 ---
 # host.json Reference
 
@@ -288,4 +287,4 @@ The `host.json` file is deployed with your code and applies in both local and pr
 - [Cost Optimization](../../operations/configuration.md)
 
 ## Sources
-- [host.json Reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [host.json Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/language-guides/python/index.md
+++ b/docs/language-guides/python/index.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # Python Language Guide
 
@@ -135,6 +134,6 @@ Use [Language Guides Overview](../index.md) for a side-by-side worker/programmin
 ## Sources
 
 - [Python reference application (`apps/python/`)](https://github.com/yeongseon/azure-functions-practical-guide/tree/main/apps/python)
-- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/python/platform-limits.md
+++ b/docs/language-guides/python/platform-limits.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale#service-limits
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/storage/common/scalability-targets-standard-account
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-scale#service-limits
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
+      verified: true
 ---
 # Platform Limits
 
@@ -221,5 +220,5 @@ For high-throughput scenarios, consider using a dedicated storage account for `A
 - [host.json Reference](host-json.md)
 
 ## Sources
-- [Azure Functions Scale and Service Limits (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale#service-limits)
-- [Azure Storage Scalability and Performance Targets (Microsoft Learn)](https://learn.microsoft.com/azure/storage/common/scalability-targets-standard-account)
+- [Azure Functions Scale and Service Limits (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits)
+- [Azure Storage Scalability and Performance Targets (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account)

--- a/docs/language-guides/python/python-runtime.md
+++ b/docs/language-guides/python/python-runtime.md
@@ -1,23 +1,22 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/supported-languages
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/supported-languages
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+      verified: true
 ---
 # Python Runtime
 
@@ -45,7 +44,7 @@ Azure Functions v4 runtime supports the following Python versions:
 | **3.11** | ✅ GA | October 2027 |
 | **3.10** | ✅ GA | October 2026 |
 
-The reference application uses **Python 3.11**, which benefits from CPython's specializing adaptive interpreter introduced in that release. For the latest supported versions and plan-specific availability, check the [Azure Functions supported languages](https://learn.microsoft.com/azure/azure-functions/supported-languages) page.
+The reference application uses **Python 3.11**, which benefits from CPython's specializing adaptive interpreter introduced in that release. For the latest supported versions and plan-specific availability, check the [Azure Functions supported languages](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages) page.
 
 > **Note:** Linux Consumption supports Python 3.10–3.12. Flex Consumption, Premium, and Dedicated support Python 3.10–3.13 (GA) and 3.14 (Preview). Remote build support for Python 3.14 is not yet available on the Flex Consumption plan. Python 3.8 and 3.9 have reached end of support and are no longer available.
 
@@ -73,7 +72,7 @@ az functionapp create \
 | Expected result | Azure CLI returns provisioning details; confirm the resource name and successful provisioning state before continuing. |
 
 
-> **Flex Consumption:** The `--consumption-plan-location` flag creates a classic Consumption plan. To create a Flex Consumption app, use `az functionapp create` with a pre-created Flex Consumption plan (`--plan`), or use the Bicep template in `infra/main.bicep`. See [Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to) for CLI details.
+> **Flex Consumption:** The `--consumption-plan-location` flag creates a classic Consumption plan. To create a Flex Consumption app, use `az functionapp create` with a pre-created Flex Consumption plan (`--plan`), or use the Bicep template in `infra/main.bicep`. See [Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to) for CLI details.
 
 > **Important:** Azure Functions for Python only runs on Linux. The `--os-type linux` flag is required.
 
@@ -293,5 +292,5 @@ If your function app uses large packages (ML libraries like `scikit-learn`, `ten
 - [Scaling](../../platform/scaling.md)
 
 ## Sources
-- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Azure Functions Overview (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-overview)
+- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Azure Functions Overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)

--- a/docs/language-guides/python/recipes/blob-storage.md
+++ b/docs/language-guides/python/recipes/blob-storage.md
@@ -1,23 +1,22 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan#trigger-support
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan#trigger-support
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
+      verified: true
 ---
 # Blob Storage
 
@@ -298,9 +297,9 @@ cat /tmp/result.txt   # Expected: HELLO WORLD
 | Expected result | Azure CLI completes successfully and returns JSON, table, or no output depending on the command; verify the next documented check before continuing. |
 
 
-> **Polling vs. Event Grid:** The default blob trigger uses a polling mechanism, which can have delays of up to several minutes in production depending on storage activity. For low-latency, event-driven processing use the [Event Grid-based blob trigger (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger) instead.
+> **Polling vs. Event Grid:** The default blob trigger uses a polling mechanism, which can have delays of up to several minutes in production depending on storage activity. For low-latency, event-driven processing use the [Event Grid-based blob trigger (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger) instead.
 >
-> **Flex Consumption:** The default polling blob trigger is **not supported** on the Flex Consumption plan. Flex Consumption requires the Event Grid-based blob trigger. See [Supported triggers on Flex Consumption (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan#trigger-support) for details.
+> **Flex Consumption:** The default polling blob trigger is **not supported** on the Flex Consumption plan. Flex Consumption requires the Event Grid-based blob trigger. See [Supported triggers on Flex Consumption (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan#trigger-support) for details.
 
 ## SDK Approach: azure-storage-blob
 
@@ -421,5 +420,5 @@ See the [Managed Identity recipe](managed-identity.md) for a full walkthrough.
 - [HTTP API Patterns](http-api.md)
 
 ## Sources
-- [Azure Functions Blob Storage Bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob)
-- [Managed Identity Tutorial (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Azure Functions Blob Storage Bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob)
+- [Managed Identity Tutorial (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)

--- a/docs/language-guides/python/recipes/cosmosdb.md
+++ b/docs/language-guides/python/recipes/cosmosdb.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+      verified: true
 ---
 # Cosmos DB Integration
 
@@ -329,5 +328,5 @@ The binding now uses the Managed Identity automatically — no connection string
 - [HTTP API Patterns](http-api.md)
 
 ## Sources
-- [Azure Functions Cosmos DB Bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb-v2)
-- [Managed Identity Tutorial (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Azure Functions Cosmos DB Bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2)
+- [Managed Identity Tutorial (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)

--- a/docs/language-guides/python/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/python/recipes/custom-domain-certificates.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-ssl-certificate
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+      verified: true
 ---
 # Custom Domains and Certificates
 
@@ -201,4 +200,4 @@ curl --head https://api.contoso.com
 
 ## Sources
 - [Map a custom domain to App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain)
-- [Add and manage TLS/SSL certificates in App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/configure-ssl-certificate)
+- [Add and manage TLS/SSL certificates in App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate)

--- a/docs/language-guides/python/recipes/durable-orchestration.md
+++ b/docs/language-guides/python/recipes/durable-orchestration.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+      verified: true
 ---
 # Durable Functions
 
@@ -300,5 +299,5 @@ async def get_status(req: func.HttpRequest, client: df.DurableOrchestrationClien
 - [Queue Recipe](queue.md)
 
 ## Sources
-- [Durable Functions Overview (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview)
-- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
+- [Durable Functions Overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview)
+- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)

--- a/docs/language-guides/python/recipes/event-grid.md
+++ b/docs/language-guides/python/recipes/event-grid.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid
+      verified: true
 ---
 # Event Grid Trigger
 
@@ -307,5 +306,5 @@ def handle_blob_event(event: func.EventGridEvent) -> None:
 - [Queue Recipe](queue.md)
 
 ## Sources
-- [Azure Functions Event Grid Bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-grid)
-- [Azure Functions Triggers and Bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions Event Grid Bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid)
+- [Azure Functions Triggers and Bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)

--- a/docs/language-guides/python/recipes/http-api.md
+++ b/docs/language-guides/python/recipes/http-api.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
+      verified: true
 ---
 # HTTP API Patterns
 
@@ -354,5 +353,5 @@ def delete_item(req: func.HttpRequest) -> func.HttpResponse:
 - [Cosmos DB Integration](cosmosdb.md)
 
 ## Sources
-- [Azure Functions HTTP Trigger (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook)
-- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
+- [Azure Functions HTTP Trigger (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook)
+- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)

--- a/docs/language-guides/python/recipes/http-auth.md
+++ b/docs/language-guides/python/recipes/http-auth.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/security-concepts
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/security-concepts
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
+      verified: true
 ---
 # HTTP Authentication
 
@@ -324,5 +323,5 @@ curl --header "Authorization: Bearer $TOKEN" \
 - [Security Operations](../../../operations/security.md) — key rotation, RBAC audit, CORS, TLS enforcement
 
 ## Sources
-- [Azure Functions Security Concepts (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/security-concepts)
-- [Easy Auth Overview (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-authentication-authorization)
+- [Azure Functions Security Concepts (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts)
+- [Easy Auth Overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization)

--- a/docs/language-guides/python/recipes/index.md
+++ b/docs/language-guides/python/recipes/index.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # Python Recipes
 
@@ -84,6 +83,6 @@ graph TD
 
 ## Sources
 
-- [Python developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Azure Functions trigger and binding concepts](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Functions best practices](https://learn.microsoft.com/azure/azure-functions/functions-best-practices)
+- [Python developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Azure Functions trigger and binding concepts](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions best practices](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)

--- a/docs/language-guides/python/recipes/key-vault.md
+++ b/docs/language-guides/python/recipes/key-vault.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+      verified: true
 ---
 # Key Vault Integration
 
@@ -303,5 +302,5 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
 - [Security Operations](../../../operations/security.md) — key rotation, RBAC audit, CORS, TLS enforcement
 
 ## Sources
-- [Key Vault References in App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references)
-- [Managed Identity Tutorial (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Key Vault References in App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+- [Managed Identity Tutorial (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)

--- a/docs/language-guides/python/recipes/managed-identity.md
+++ b/docs/language-guides/python/recipes/managed-identity.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+      verified: true
 ---
 # Managed Identity
 
@@ -319,4 +318,4 @@ resource storageRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-
 - [Blob Storage Recipe](blob-storage.md)
 
 ## Sources
-- [Managed Identity Tutorial (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Managed Identity Tutorial (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)

--- a/docs/language-guides/python/recipes/queue.md
+++ b/docs/language-guides/python/recipes/queue.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+      verified: true
 ---
 # Queue Storage
 
@@ -279,4 +278,4 @@ def schedule_delayed(req: func.HttpRequest) -> func.HttpResponse:
 - [Managed Identity Recipe](managed-identity.md)
 
 ## Sources
-- [Azure Functions Queue Storage Bindings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue)
+- [Azure Functions Queue Storage Bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue)

--- a/docs/language-guides/python/recipes/timer.md
+++ b/docs/language-guides/python/recipes/timer.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+      verified: true
 ---
 # Timer Trigger
 
@@ -195,4 +194,4 @@ Timer triggers require Azure Storage (`AzureWebJobsStorage`) to maintain schedul
 - [Scaling](../../../platform/scaling.md)
 
 ## Sources
-- [Azure Functions Timer Trigger (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer)
+- [Azure Functions Timer Trigger (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer)

--- a/docs/language-guides/python/troubleshooting.md
+++ b/docs/language-guides/python/troubleshooting.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # Troubleshooting
 
@@ -572,5 +571,5 @@ See also: [Networking operations](../../platform/networking.md) for the full Pri
 - [Networking Operations](../../platform/networking.md)
 
 ## Sources
-- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Develop Azure Functions Locally (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
+- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Develop Azure Functions Locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)

--- a/docs/language-guides/python/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/python/tutorial/consumption/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+      verified: true
 ---
 # 01 - Run Locally (Consumption)
 
@@ -153,9 +152,9 @@ You now have local parity and can deploy to Azure Consumption (Y1).
 
 ## Sources
 
-- [Run Functions locally with Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Azure Functions Consumption plan](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
-- [Python developer guide for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
+- [Run Functions locally with Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure Functions Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Python developer guide for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
 
 !!! warning "Legacy hosting path"
     Consumption plan (Y1) content is provided for existing workloads and compatibility scenarios. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/python/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/consumption/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: fail
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
+      verified: true
 ---
 # 02 - First Deploy (Consumption)
 
@@ -304,6 +303,6 @@ Next, configure settings and behavior specific to Consumption using classic app 
 
 ## Sources
 
-- [Create a function app in Azure using CLI](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python)
-- [Azure Functions deployment technologies](https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies)
-- [Deployment slots in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots)
+- [Create a function app in Azure using CLI](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python)
+- [Azure Functions deployment technologies](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies)
+- [Deployment slots in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots)

--- a/docs/language-guides/python/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/python/tutorial/consumption/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+      verified: true
 ---
 # 03 - Configuration (Consumption)
 
@@ -239,6 +238,6 @@ Now enable operational visibility with logs and monitoring.
 
 ## Sources
 
-- [App settings reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Identity-based host storage for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity)
-- [host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [App settings reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Identity-based host storage for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity)
+- [host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/language-guides/python/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/consumption/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/monitor/app-insights?view=azure-cli-latest
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/webapp/log
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/monitor/app-insights?view=azure-cli-latest
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/webapp/log
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/monitor-functions
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
+      verified: true
 ---
 # 04 - Logging and Monitoring (Consumption)
 
@@ -215,6 +214,6 @@ Use Infrastructure as Code to make this setup repeatable.
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/monitor-functions)
-- [Application Insights query with Azure CLI](https://learn.microsoft.com/cli/azure/monitor/app-insights?view=azure-cli-latest)
-- [Stream logs with Azure CLI](https://learn.microsoft.com/cli/azure/webapp/log)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions)
+- [Application Insights query with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/monitor/app-insights?view=azure-cli-latest)
+- [Stream logs with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/webapp/log)

--- a/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-infrastructure-as-code
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-infrastructure-as-code
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code
+      verified: true
 ---
 # 05 - Infrastructure as Code (Consumption)
 
@@ -246,6 +245,6 @@ Automate deployments in CI/CD with GitHub Actions.
 
 ## Sources
 
-- [Bicep for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-infrastructure-as-code)
-- [Bicep language reference](https://learn.microsoft.com/azure/azure-resource-manager/bicep/)
-- [Azure Functions Consumption plan](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
+- [Bicep for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code)
+- [Bicep language reference](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/)
+- [Azure Functions Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)

--- a/docs/language-guides/python/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/consumption/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/deployment-zip-push
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions#download-your-publish-profile
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions#download-your-publish-profile
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+      verified: true
 ---
 # 06 - CI/CD (Consumption)
 
@@ -195,6 +194,6 @@ Add non-HTTP triggers and verify scaling behavior for Consumption.
 
 ## Sources
 
-- [Use GitHub Actions to deploy a function app](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
-- [Deploy Azure Functions with Zip Deploy](https://learn.microsoft.com/azure/azure-functions/deployment-zip-push)
-- [Manage app-level deployment credentials in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions#download-your-publish-profile)
+- [Use GitHub Actions to deploy a function app](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)
+- [Deploy Azure Functions with Zip Deploy](https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push)
+- [Manage app-level deployment credentials in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions#download-your-publish-profile)

--- a/docs/language-guides/python/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/consumption/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+      verified: true
 ---
 # 07 - Extending Triggers (Consumption)
 
@@ -232,6 +231,6 @@ You completed the Consumption tutorial track. Continue with core runtime concept
 
 ## Sources
 
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Queue Storage trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger)
-- [Azure Blob Storage trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Queue Storage trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger)
+- [Azure Blob Storage trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger)

--- a/docs/language-guides/python/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/python/tutorial/dedicated/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+      verified: true
 ---
 # 01 - Run Locally (Dedicated)
 
@@ -188,6 +187,6 @@ You now have a working local baseline. Next you will provision a Basic (B1) Dedi
 
 ## Sources
 
-- [Run functions locally (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [App Service plan overview (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-hosting-plans)
+- [Run functions locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [App Service plan overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)

--- a/docs/language-guides/python/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/dedicated/02-first-deploy.md
@@ -6,27 +6,26 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-common
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-common
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings
+      verified: true
 ---
 # 02 - First Deploy (Dedicated)
 
@@ -545,6 +544,6 @@ Your first Dedicated deployment is live. Next you will configure app settings, s
 
 ## Sources
 
-- [Work with Azure Functions app settings (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings)
-- [App Service Always On (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/configure-common)
-- [Use private endpoints for Azure App Service apps (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/networking/private-endpoint)
+- [Work with Azure Functions app settings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings)
+- [App Service Always On (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/configure-common)
+- [Use private endpoints for Azure App Service apps (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint)

--- a/docs/language-guides/python/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/python/tutorial/dedicated/03-configuration.md
@@ -6,29 +6,28 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-common
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-common
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+      verified: true
 ---
 # 03 - Configuration (Dedicated)
 
@@ -291,6 +290,6 @@ You now have a correctly configured Dedicated app with explicit runtime settings
 
 ## Sources
 
-- [App settings reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Configure App Service app settings](https://learn.microsoft.com/azure/app-service/configure-common)
-- [Functions scale and hosting behavior](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [App settings reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Configure App Service app settings](https://learn.microsoft.com/en-us/azure/app-service/configure-common)
+- [Functions scale and hosting behavior](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/python/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/dedicated/04-logging-monitoring.md
@@ -6,29 +6,28 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring#application-insights
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-metric-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring#application-insights
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-metric-overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+      verified: true
 ---
 # 04 - Logging & Monitoring (Dedicated)
 
@@ -315,6 +314,6 @@ Monitoring is now in place with logs, queries, and alerts. Next you will codify 
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Application Insights for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring#application-insights)
-- [Azure Monitor metrics alerts](https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-metric-overview)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Application Insights for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring#application-insights)
+- [Azure Monitor metrics alerts](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-metric-overview)

--- a/docs/language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md
@@ -10,25 +10,24 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/templates/microsoft.web/serverfarms
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/templates/microsoft.web/sites
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/serverfarms
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-resource-manager/bicep/
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/
+      verified: true
 ---
 # 05 - Infrastructure as Code (Dedicated)
 
@@ -693,6 +692,6 @@ You now have reproducible Dedicated infrastructure in Bicep. Next you will autom
 
 ## Sources
 
-- [Bicep documentation](https://learn.microsoft.com/azure/azure-resource-manager/bicep/)
-- [Microsoft.Web/serverfarms resource reference](https://learn.microsoft.com/azure/templates/microsoft.web/serverfarms)
-- [Microsoft.Web/sites resource reference](https://learn.microsoft.com/azure/templates/microsoft.web/sites)
+- [Bicep documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/)
+- [Microsoft.Web/serverfarms resource reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.web/serverfarms)
+- [Microsoft.Web/sites resource reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites)

--- a/docs/language-guides/python/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/dedicated/06-ci-cd.md
@@ -6,29 +6,28 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/deployment-zip-push
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/deployment-zip-push
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push
+      verified: true
 ---
 # 06 - CI/CD (Dedicated)
 
@@ -293,6 +292,6 @@ You now have a repeatable Dedicated deployment pipeline with optional slot-based
 
 ## Sources
 
-- [Zip deployment for Azure Functions](https://learn.microsoft.com/azure/azure-functions/deployment-zip-push)
-- [Deploy Azure Functions with GitHub Actions](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
-- [Deployment slots in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots)
+- [Zip deployment for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push)
+- [Deploy Azure Functions with GitHub Actions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)
+- [Deployment slots in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots)

--- a/docs/language-guides/python/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/dedicated/07-extending-triggers.md
@@ -6,31 +6,30 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+      verified: true
 ---
 # 07 - Extending with Triggers (Dedicated)
 
@@ -289,7 +288,7 @@ You now have a full Dedicated track implementation with HTTP, timer, blob, and q
 
 ## Sources
 
-- [Azure Functions triggers and bindings concepts](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Timer trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer)
-- [Blob trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger)
-- [Queue trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger)
+- [Azure Functions triggers and bindings concepts](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Timer trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer)
+- [Blob trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger)
+- [Queue trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger)

--- a/docs/language-guides/python/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+      verified: true
 ---
 # 01 - Run Locally (Flex Consumption)
 
@@ -224,6 +223,6 @@ Expected output:
 
 ## Sources
 
-- [Run Azure Functions locally](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Event Grid blob trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger)
+- [Run Azure Functions locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Event Grid blob trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger)

--- a/docs/language-guides/python/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # 02 - First Deploy (Flex Consumption)
 
@@ -335,6 +334,6 @@ Hello endpoint response:
 
 ## Sources
 
-- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/language-guides/python/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 
@@ -961,6 +960,6 @@ Endpoint test results from the Korea Central deployment (all returned HTTP 200):
 
 ## Sources
 
-- [Flex Consumption plan hosting](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Create and manage Flex Consumption apps](https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to)
-- [Azure Functions deployment technologies](https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies)
+- [Flex Consumption plan hosting](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Create and manage Flex Consumption apps](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to)
+- [Azure Functions deployment technologies](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies)

--- a/docs/language-guides/python/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+      verified: true
 ---
 # 03 - Configuration (Flex Consumption)
 
@@ -324,6 +323,6 @@ Expected output:
 
 ## Sources
 
-- [App settings reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Flex Consumption how-to](https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to)
-- [Identity-based connections for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity)
+- [App settings reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Flex Consumption how-to](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to)
+- [Identity-based connections for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity)

--- a/docs/language-guides/python/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/04-logging-monitoring.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/monitor-functions
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
+      verified: true
 ---
 # 04 - Logging and Monitoring (Flex Consumption)
 
@@ -304,6 +303,6 @@ Expected output:
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/monitor-functions)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions)
 - [Azure Monitor Logs query overview](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview)
-- [Application Insights overview](https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview)
+- [Application Insights overview](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)

--- a/docs/language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
+      verified: true
 ---
 # 05 - Infrastructure as Code (Flex Consumption)
 
@@ -659,6 +658,6 @@ az network vnet subnet show \
 
 ## Sources
 
-- [Bicep overview](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview)
-- [Flex Consumption plan hosting](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
+- [Bicep overview](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview)
+- [Flex Consumption plan hosting](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)

--- a/docs/language-guides/python/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/developer/github/connect-from-azure-openid-connect
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure-openid-connect
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+      verified: true
 ---
 # 06 - CI/CD (Flex Consumption)
 
@@ -310,6 +309,6 @@ Expected output:
 
 ## Sources
 
-- [Deploy Azure Functions with GitHub Actions](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
-- [Use OIDC with GitHub Actions and Azure](https://learn.microsoft.com/azure/developer/github/connect-from-azure-openid-connect)
-- [Azure Functions deployment technologies](https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies)
+- [Deploy Azure Functions with GitHub Actions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)
+- [Use OIDC with GitHub Actions and Azure](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure-openid-connect)
+- [Azure Functions deployment technologies](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies)

--- a/docs/language-guides/python/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+      verified: true
 ---
 # 07 - Extending Triggers (Flex Consumption)
 
@@ -374,6 +373,6 @@ Expected output:
 
 ## Sources
 
-- [Azure Functions trigger and binding concepts](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Event Grid blob trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger)
-- [Queue storage trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue)
+- [Azure Functions trigger and binding concepts](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Event Grid blob trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger)
+- [Queue storage trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue)

--- a/docs/language-guides/python/tutorial/index.md
+++ b/docs/language-guides/python/tutorial/index.md
@@ -1,25 +1,24 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/migration/migrate-plan-consumption-to-flex
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/pricing
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/migration/migrate-plan-consumption-to-flex
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/pricing
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/migration/migrate-plan-consumption-to-flex
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/migration/migrate-plan-consumption-to-flex
+      verified: true
 ---
 # Tutorial — Choose Your Hosting Plan
 
@@ -55,7 +54,7 @@ flowchart TD
     style DEDI fill:#5c2d91,color:#fff
 ```
 
-> **Not sure yet?** Start with **Flex Consumption** — it offers the broadest feature set (VNet, scale-to-zero, configurable memory) and is Microsoft's recommended default for new projects. You can migrate between plans later, though some migrations have limitations — see [Migrate apps from Consumption to Flex Consumption](https://learn.microsoft.com/azure/azure-functions/migration/migrate-plan-consumption-to-flex).
+> **Not sure yet?** Start with **Flex Consumption** — it offers the broadest feature set (VNet, scale-to-zero, configurable memory) and is Microsoft's recommended default for new projects. You can migrate between plans later, though some migrations have limitations — see [Migrate apps from Consumption to Flex Consumption](https://learn.microsoft.com/en-us/azure/azure-functions/migration/migrate-plan-consumption-to-flex).
 
 ## Plan Comparison at a Glance
 
@@ -338,7 +337,7 @@ Traditional App Service hosting with predictable pricing. Best when you already 
 
 ## Sources
 
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Azure Functions pricing (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/pricing)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Azure Functions pricing (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/pricing)

--- a/docs/language-guides/python/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/python/tutorial/premium/01-local-run.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+      verified: true
 ---
 # 01 - Run Locally (Premium)
 
@@ -169,6 +168,6 @@ Functions:
 
 ## Sources
 
-- [Run Azure Functions locally](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Run Azure Functions locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure Functions Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/language-guides/python/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/premium/02-first-deploy.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.6.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # 02 - First Deploy (Premium)
 
@@ -352,6 +351,6 @@ The output confirms that Azure indexed your function definitions and the app ser
 
 ## Sources
 
-- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
+- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Create your first Azure Function with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)

--- a/docs/language-guides/python/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/python/tutorial/premium/02a-first-deploy-private-egress.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 
@@ -1348,6 +1347,6 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable)
-- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/azure/app-service/networking/private-endpoint)
+- [Azure Functions Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Integrate your app with an Azure virtual network](https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable)
+- [Use private endpoints for Azure App Service apps](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint)

--- a/docs/language-guides/python/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/python/tutorial/premium/03-configuration.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+      verified: true
 ---
 # 03 - Configuration (Premium)
 
@@ -310,6 +309,6 @@ flowchart TD
 
 ## Sources
 
-- [App settings reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Functions scale and hosting](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
+- [App settings reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)

--- a/docs/language-guides/python/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/premium/04-logging-monitoring.md
@@ -6,23 +6,22 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/monitor/app-insights?view=azure-cli-latest
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/monitor/app-insights?view=azure-cli-latest
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/monitor-functions
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
+      verified: true
 ---
 # 04 - Logging and Monitoring (Premium)
 
@@ -288,6 +287,6 @@ Timestamp                  Name    ResultCode    Duration
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/monitor-functions)
-- [Application Insights query with Azure CLI](https://learn.microsoft.com/cli/azure/monitor/app-insights?view=azure-cli-latest)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions)
+- [Application Insights query with Azure CLI](https://learn.microsoft.com/en-us/cli/azure/monitor/app-insights?view=azure-cli-latest)
 - [Kudu service overview](https://github.com/projectkudu/kudu/wiki)

--- a/docs/language-guides/python/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/premium/05-infrastructure-as-code.md
@@ -10,21 +10,20 @@ validation:
     result: syntax_validated
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-infrastructure-as-code
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/private-link/private-endpoint-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-infrastructure-as-code
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code
+      verified: true
 ---
 # 05 - Infrastructure as Code (Premium)
 
@@ -777,6 +776,6 @@ pe-func-premium-demo              Microsoft.Network/privateEndpoints
 
 ## Sources
 
-- [Azure Functions infrastructure as code](https://learn.microsoft.com/azure/azure-functions/functions-infrastructure-as-code)
-- [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Azure private endpoints](https://learn.microsoft.com/azure/private-link/private-endpoint-overview)
+- [Azure Functions infrastructure as code](https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code)
+- [Azure Functions Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Azure private endpoints](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview)

--- a/docs/language-guides/python/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/premium/06-ci-cd.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots#swap-slots
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots#swap-slots
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+      verified: true
 ---
 # 06 - CI/CD (Premium)
 
@@ -352,6 +351,6 @@ Syncing triggers...
 
 ## Sources
 
-- [Deploy to Azure Functions using GitHub Actions](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
-- [Deployment slots for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots)
-- [Swap deployment slots](https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots#swap-slots)
+- [Deploy to Azure Functions using GitHub Actions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)
+- [Deployment slots for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots)
+- [Swap deployment slots](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots#swap-slots)

--- a/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
@@ -6,25 +6,24 @@ validation:
     core_tools_version: 4.8.0
     result: pass
   bicep:
-    last_tested: null
+    last_tested:
     result: not_tested
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+      verified: true
 ---
 # 07 - Extending Triggers (Premium)
 
@@ -232,6 +231,6 @@ Functions in func-premium-demo:
 
 ## Sources
 
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Blob trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger)
-- [Event Grid-based blob trigger](https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Blob trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger)
+- [Event Grid-based blob trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger)

--- a/docs/language-guides/python/v2-programming-model.md
+++ b/docs/language-guides/python/v2-programming-model.md
@@ -1,23 +1,22 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # Python v2 Programming Model
 
@@ -399,7 +398,7 @@ This creates three endpoints:
 - [Recipes Index](recipes/index.md)
 
 ## Sources
-- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Azure Functions Overview (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-overview)
-- [HTTP Trigger Reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook)
-- [Create Your First Function with CLI (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python)
+- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Azure Functions Overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)
+- [HTTP Trigger Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook)
+- [Create Your First Function with CLI (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python)

--- a/docs/operations/alerts.md
+++ b/docs/operations/alerts.md
@@ -1,31 +1,31 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/alerts/action-groups
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-metric
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-metric
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-log
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-log
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-create-log-alert-rule
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-create-log-alert-rule
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/alerts/proactive-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/proactive-diagnostics
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Action groups should be created before alert rules so alerts route consistently to the right receivers."
-      source: https://learn.microsoft.com/azure/azure-monitor/alerts/action-groups
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups
       verified: true
     - claim: "Metric alerts are best suited for fast platform symptoms such as 5xx bursts and short evaluation windows."
-      source: https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-metric
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-metric
       verified: true
     - claim: "Log query alerts are appropriate when the alert condition depends on KQL-based context or scoped failure patterns."
-      source: https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-log
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-log
       verified: true
     - claim: "Smart detection and proactive diagnostics should be treated as supplemental anomaly signals rather than the only paging mechanism."
-      source: https://learn.microsoft.com/azure/azure-monitor/alerts/proactive-diagnostics
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/proactive-diagnostics
       verified: true
 ---
 
@@ -492,8 +492,8 @@ az monitor metrics alert update \
 - [Recovery](recovery.md)
 - [Troubleshooting Playbooks](../troubleshooting/playbooks/index.md)
 ## Sources
-- [Create and manage action groups](https://learn.microsoft.com/azure/azure-monitor/alerts/action-groups)
-- [Create metric alerts in Azure Monitor](https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-metric)
-- [Create log search alerts in Azure Monitor](https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-log)
-- [Manage scheduled query rules with Azure CLI](https://learn.microsoft.com/azure/azure-monitor/alerts/alerts-create-log-alert-rule)
-- [Smart detection in Application Insights](https://learn.microsoft.com/azure/azure-monitor/alerts/proactive-diagnostics)
+- [Create and manage action groups](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups)
+- [Create metric alerts in Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-metric)
+- [Create log search alerts in Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-log)
+- [Manage scheduled query rules with Azure CLI](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-create-log-alert-rule)
+- [Smart detection in Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/proactive-diagnostics)

--- a/docs/operations/cold-start.md
+++ b/docs/operations/cold-start.md
@@ -1,31 +1,31 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Cold start includes worker allocation, host startup, language worker startup, and application initialization phases."
-      source: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
       verified: true
     - claim: "Flex Consumption supports always-ready instances to reduce cold-start frequency for selected functions or app behavior."
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
     - claim: "Premium plan provides always-ready and pre-warmed instances to reduce startup latency."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
       verified: true
     - claim: "Dedicated plans use Always On to keep workers active and reduce cold-start effects."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
 ---
 
@@ -431,8 +431,8 @@ Escalate to platform diagnostics if startup remains unstable after rollback and 
 - [Platform Hosting](../platform/hosting.md)
 
 ## Sources
-- [Azure Functions hosting options and scaling](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Flex Consumption plan for Azure Functions](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Improve performance and reliability of Azure Functions](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data)
+- [Azure Functions hosting options and scaling](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Flex Consumption plan for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Improve performance and reliability of Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data)

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1,31 +1,31 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "App settings are the correct layer for environment-specific values, secrets, and feature flags in Azure Functions."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
       verified: true
     - claim: "host.json controls host-wide runtime behavior such as logging, retries, extension tuning, and sampling."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
       verified: true
     - claim: "Key Vault references can be used to back app settings with secrets managed outside the Function App configuration itself."
-      source: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
       verified: true
     - claim: "Identity-based connections are supported for Azure Functions configuration instead of storing connection secrets directly."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
       verified: true
 ---
 
@@ -419,8 +419,8 @@ az functionapp deployment slot swap \
 - [Cost Optimization](cost-optimization.md)
 - [Platform Security](../platform/security.md)
 ## Sources
-- [App settings reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [host.json reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Use Key Vault references in App Service and Functions](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references)
-- [Azure Functions identity-based connections](https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
-- [How to manage Azure Functions app settings](https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings)
+- [App settings reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [host.json reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Use Key Vault references in App Service and Functions](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+- [Azure Functions identity-based connections](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
+- [How to manage Azure Functions app settings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings)

--- a/docs/operations/cost-optimization.md
+++ b/docs/operations/cost-optimization.md
@@ -1,31 +1,31 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/logs/cost-logs
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "The Consumption plan billing model charges for executions and GB-seconds of resource consumption."
-      source: https://learn.microsoft.com/azure/azure-functions/consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
       verified: true
     - claim: "The legacy Consumption plan includes a monthly free grant for executions and GB-seconds at the subscription level."
-      source: https://learn.microsoft.com/azure/azure-functions/consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
       verified: true
     - claim: "Flex Consumption adds optional always-ready baseline cost behavior in addition to consumption-based execution billing."
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
     - claim: "Application Insights and Log Analytics ingestion and retention can materially affect overall Azure Functions operating cost."
-      source: https://learn.microsoft.com/azure/azure-monitor/logs/cost-logs
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs
       verified: true
 ---
 
@@ -369,8 +369,8 @@ union requests, traces, exceptions, dependencies
 
 ## Sources
 
-- [Consumption Plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
-- [Premium Plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Azure Functions Scaling (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Flex Consumption Plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Application Insights pricing (Microsoft Learn)](https://learn.microsoft.com/azure/azure-monitor/logs/cost-logs)
+- [Consumption Plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Premium Plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Azure Functions Scaling (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Flex Consumption Plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Application Insights pricing (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs)

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,29 +1,29 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Running a function app from a deployment package supports immutable artifact deployment behavior."
-      source: https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
       verified: true
     - claim: "GitHub Actions is a supported CI/CD deployment method for Azure Functions."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
       verified: true
     - claim: "Deployment slots are used for safer releases and rollback on supported Azure Functions hosting plans."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
       verified: true
     - claim: "Local validation with Azure Functions Core Tools is part of the supported deployment workflow before publishing."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-run-local
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
       verified: true
 ---
 
@@ -520,7 +520,7 @@ verify runtime compatibility, and validate trigger dependency identity/access.
 - [Recovery](recovery.md)
 
 ## Sources
-- [Deploy Azure Functions from package files](https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package)
-- [Deploy Azure Functions with GitHub Actions](https://learn.microsoft.com/azure/azure-functions/functions-how-to-github-actions)
-- [Deployment slots in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots)
-- [Functions Core Tools reference](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
+- [Deploy Azure Functions from package files](https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package)
+- [Deploy Azure Functions with GitHub Actions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions)
+- [Deployment slots in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots)
+- [Functions Core Tools reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+      verified: true
 ---
 # Operations
 
@@ -74,4 +73,4 @@ flowchart TD
 
 - [Microsoft Learn source 1](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)
 - [Microsoft Learn source 2](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
-- [Microsoft Learn source 3](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
+- [Microsoft Learn source 3](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,29 +1,29 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/visualize/workbooks-overview
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions monitoring combines Azure Monitor platform metrics with Application Insights telemetry."
-      source: https://learn.microsoft.com/azure/azure-functions/monitor-functions
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
       verified: true
     - claim: "Application Insights provides requests, dependencies, traces, and exceptions for operational analysis."
-      source: https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
       verified: true
     - claim: "Control-plane and platform logs are available through Azure Monitor logs for operational investigations."
       source: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs
       verified: true
     - claim: "Azure Monitor workbooks are used to build dashboards and visual operational views over collected telemetry."
-      source: https://learn.microsoft.com/azure/azure-monitor/visualize/workbooks-overview
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview
       verified: true
 ---
 
@@ -464,7 +464,7 @@ Rollback:
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/monitor-functions)
-- [Application Insights overview](https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions)
+- [Application Insights overview](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview)
 - [Logs in Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs)
-- [Create and share Azure Monitor workbooks](https://learn.microsoft.com/azure/azure-monitor/visualize/workbooks-overview)
+- [Create and share Azure Monitor workbooks](https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview)

--- a/docs/operations/recovery.md
+++ b/docs/operations/recovery.md
@@ -1,33 +1,33 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/architecture/framework/resiliency/disaster-recovery
+    url: https://learn.microsoft.com/en-us/azure/architecture/framework/resiliency/disaster-recovery
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/storage/common/storage-redundancy
+    url: https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring
+    url: https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/frontdoor/health-probes
+    url: https://learn.microsoft.com/en-us/azure/frontdoor/health-probes
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions recovery planning should define RTO and RPO before incidents occur."
-      source: https://learn.microsoft.com/azure/architecture/framework/resiliency/disaster-recovery
+      source: https://learn.microsoft.com/en-us/azure/architecture/framework/resiliency/disaster-recovery
       verified: true
     - claim: "Deployment slots provide a fast rollback path for supported Azure Functions hosting plans."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
       verified: true
     - claim: "Regional recovery design depends on storage redundancy and multi-region resiliency planning."
-      source: https://learn.microsoft.com/azure/storage/common/storage-redundancy
+      source: https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy
       verified: true
     - claim: "Traffic Manager and Front Door health probes can be used to monitor and steer traffic during failover."
-      source: https://learn.microsoft.com/azure/frontdoor/health-probes
+      source: https://learn.microsoft.com/en-us/azure/frontdoor/health-probes
       verified: true
 ---
 
@@ -403,9 +403,9 @@ If recovery does not stabilize service, apply these controls.
 - [Troubleshooting Methodology](../troubleshooting/methodology.md)
 
 ## Sources
-- [Reliability in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-best-practices)
-- [Business continuity and disaster recovery for Azure applications](https://learn.microsoft.com/azure/architecture/framework/resiliency/disaster-recovery)
-- [Azure Storage redundancy options](https://learn.microsoft.com/azure/storage/common/storage-redundancy)
-- [Deployment slots in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-deployment-slots)
-- [Azure Traffic Manager endpoint monitoring](https://learn.microsoft.com/azure/traffic-manager/traffic-manager-monitoring)
-- [Azure Front Door health probes](https://learn.microsoft.com/azure/frontdoor/health-probes)
+- [Reliability in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)
+- [Business continuity and disaster recovery for Azure applications](https://learn.microsoft.com/en-us/azure/architecture/framework/resiliency/disaster-recovery)
+- [Azure Storage redundancy options](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy)
+- [Deployment slots in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots)
+- [Azure Traffic Manager endpoint monitoring](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring)
+- [Azure Front Door health probes](https://learn.microsoft.com/en-us/azure/frontdoor/health-probes)

--- a/docs/operations/retries-and-poison-handling.md
+++ b/docs/operations/retries-and-poison-handling.md
@@ -1,29 +1,29 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions reliability for event triggers depends on trigger delivery semantics, retry behavior, and poison or dead-letter handling after retries are exhausted."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
       verified: true
     - claim: "For Storage Queue triggers, maxDequeueCount determines when a message is treated as poison and moved to the poison queue."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
       verified: true
     - claim: "Service Bus triggers expose extension and client retry settings that affect transport and message-processing behavior."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
       verified: true
     - claim: "Event Hubs trigger clientRetryOptions control SDK transport retries and are distinct from Azure Functions invocation retry policy."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger
       verified: true
 ---
 
@@ -403,7 +403,7 @@ Common anti-patterns:
 - [Platform Reliability](../platform/reliability.md)
 
 ## Sources
-- [Azure Functions error handling and retries](https://learn.microsoft.com/azure/azure-functions/functions-bindings-error-pages)
-- [Azure Queue Storage trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger)
-- [Azure Service Bus trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus-trigger)
-- [Azure Event Hubs trigger for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs-trigger)
+- [Azure Functions error handling and retries](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages)
+- [Azure Queue Storage trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger)
+- [Azure Service Bus trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger)
+- [Azure Event Hubs trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger)

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -1,37 +1,37 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/security-concepts
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/function-keys-how-to
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/role-based-access-control/overview
+    url: https://learn.microsoft.com/en-us/azure/role-based-access-control/overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-rest-api#app-service-cors-versus-your-cors
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-rest-api#app-service-cors-versus-your-cors
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/configure-ssl-bindings
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/app-service-ip-restrictions
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/essentials/platform-logs-overview
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/platform-logs-overview
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions security operations include rotating function and host keys when secrets are exposed or on a scheduled basis."
-      source: https://learn.microsoft.com/azure/azure-functions/function-keys-how-to
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
       verified: true
     - claim: "RBAC should be used to audit and control access to Azure resources instead of relying only on shared secrets."
-      source: https://learn.microsoft.com/azure/role-based-access-control/overview
+      source: https://learn.microsoft.com/en-us/azure/role-based-access-control/overview
       verified: true
     - claim: "Identity-based connections are supported for Azure Functions so apps can access services without storing connection secrets in configuration."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
       verified: true
     - claim: "IP restrictions, TLS/HTTPS configuration, and platform logs are core operational controls for securing Function Apps."
-      source: https://learn.microsoft.com/azure/app-service/app-service-ip-restrictions
+      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions
       verified: true
 ---
 
@@ -565,11 +565,11 @@ Use this minimum operating cadence and tighten based on risk and regulation.
 - [Troubleshooting Methodology](../troubleshooting/methodology.md)
 
 ## Sources
-- [Azure Functions security concepts](https://learn.microsoft.com/azure/azure-functions/security-concepts)
-- [Work with access keys in Azure Functions](https://learn.microsoft.com/azure/azure-functions/function-keys-how-to)
-- [Azure role-based access control overview](https://learn.microsoft.com/azure/role-based-access-control/overview)
-- [Use managed identities with Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
-- [Configure CORS for App Service](https://learn.microsoft.com/azure/app-service/app-service-web-tutorial-rest-api#app-service-cors-versus-your-cors)
-- [Configure TLS/SSL bindings in App Service](https://learn.microsoft.com/azure/app-service/configure-ssl-bindings)
-- [Set up access restrictions for App Service](https://learn.microsoft.com/azure/app-service/app-service-ip-restrictions)
-- [Azure Monitor platform logs overview](https://learn.microsoft.com/azure/azure-monitor/essentials/platform-logs-overview)
+- [Azure Functions security concepts](https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts)
+- [Work with access keys in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to)
+- [Azure role-based access control overview](https://learn.microsoft.com/en-us/azure/role-based-access-control/overview)
+- [Use managed identities with Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Configure CORS for App Service](https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-rest-api#app-service-cors-versus-your-cors)
+- [Configure TLS/SSL bindings in App Service](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings)
+- [Set up access restrictions for App Service](https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions)
+- [Azure Monitor platform logs overview](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/platform-logs-overview)

--- a/docs/platform/architecture/index.md
+++ b/docs/platform/architecture/index.md
@@ -2,92 +2,92 @@
 content_sources:
   references:
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-overview
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-custom-handlers
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers
   diagrams:
     - id: functions-architecture-overview
       type: flowchart
       source: self-generated
       justification: "Synthesized end-to-end runtime view from Azure Functions overview, hosting, and networking documentation"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-overview
-        - https://learn.microsoft.com/azure/azure-functions/functions-scale
-        - https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - id: control-data-plane
       type: flowchart
       source: self-generated
       justification: "Synthesized control plane versus runtime execution model from Azure Functions management, scale, and networking documentation"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-overview
-        - https://learn.microsoft.com/azure/azure-functions/functions-scale
-        - https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - id: runtime-execution-path
       type: flowchart
       source: self-generated
       justification: "Summarizes the documented trigger-to-host-to-worker execution model"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-overview
-        - https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
     - id: detailed-host-worker-communication-sequence
       type: sequenceDiagram
       source: self-generated
       justification: "Expanded invocation sequence based on Functions host, worker, and binding concepts"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-overview
-        - https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
     - id: core-resource-relationships
       type: flowchart
       source: self-generated
       justification: "Synthesizes core Function App dependencies around hosting, storage, identity, and monitoring"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-overview
-        - https://learn.microsoft.com/azure/azure-functions/functions-scale
-        - https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - id: configuration-layers-diagram
       type: flowchart
       source: self-generated
       justification: "Shows the configuration hierarchy described across hosting, app settings, host.json, and bindings documentation"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-overview
-        - https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
     - id: pattern-b-active-active-with-regional-affinity
       type: flowchart
       source: self-generated
       justification: "Adapted multi-region pattern based on Azure traffic management and replicated dependency guidance"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-overview
-        - https://learn.microsoft.com/azure/azure-functions/functions-scale
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
     - id: durable-functions-orchestration-architecture
       type: flowchart
       source: self-generated
       justification: "Summarizes Durable Functions orchestration, activities, timers, and state persistence"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions uses a host/worker architecture so multiple languages can run on one platform"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-overview
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
       verified: true
     - claim: "The Function App is the primary deployment and configuration boundary in Azure Functions"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-overview
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
       verified: true
     - claim: "Flex Consumption supports VNet integration and inbound private endpoints"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "Flex Consumption requires identity-based host storage and uses Event Grid for blob triggers"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
 ---
 
@@ -588,9 +588,9 @@ Platform architecture is consistent, but implementation details vary by language
 - [Language Guides Home](../../language-guides/index.md)
 
 ## Sources
-- [Microsoft Learn: Azure Functions overview](https://learn.microsoft.com/azure/azure-functions/functions-overview)
-- [Microsoft Learn: Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Microsoft Learn: Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Microsoft Learn: Azure Functions triggers and bindings concepts](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Microsoft Learn: Durable Functions overview](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview)
-- [Microsoft Learn: Azure Functions custom handlers](https://learn.microsoft.com/azure/azure-functions/functions-custom-handlers)
+- [Microsoft Learn: Azure Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)
+- [Microsoft Learn: Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Microsoft Learn: Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Microsoft Learn: Azure Functions triggers and bindings concepts](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Microsoft Learn: Durable Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview)
+- [Microsoft Learn: Azure Functions custom handlers](https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers)

--- a/docs/platform/deployment-scenarios.md
+++ b/docs/platform/deployment-scenarios.md
@@ -1,33 +1,33 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-create-vnet
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference?tabs=blob#configure-an-identity-based-connection
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob#configure-an-identity-based-connection
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Consumption plan does not support VNet integration, while Flex Consumption, Premium, and Dedicated do"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "Flex Consumption uses blob-container deployment through functionAppConfig instead of Kudu/SCM"
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
     - claim: "Premium and Dedicated plans can host multiple apps per plan"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
     - claim: "Identity-based binding connections use app settings with service URIs instead of a single connection string secret"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-reference?tabs=blob#configure-an-identity-based-connection
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob#configure-an-identity-based-connection
       verified: true
 ---
 
@@ -290,9 +290,9 @@ Before deploying any scenario, verify:
 
 ## Sources
 
-- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Secure Azure Functions with virtual networks (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-create-vnet)
-- [Azure Functions deployment technologies (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies)
-- [Identity-based connections for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference?tabs=blob#configure-an-identity-based-connection)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Secure Azure Functions with virtual networks (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet)
+- [Azure Functions deployment technologies (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies)
+- [Identity-based connections for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob#configure-an-identity-based-connection)

--- a/docs/platform/functions-vs-app-service.md
+++ b/docs/platform/functions-vs-app-service.md
@@ -1,31 +1,31 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-overview
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/overview
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/architecture/guide/technology-choices/compute-decision-tree
+    url: https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions and Azure App Service both run on the underlying App Service platform infrastructure"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-overview
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
       verified: true
     - claim: "Azure Functions supports scale-to-zero on Consumption and Flex Consumption plans, while App Service does not"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
     - claim: "Azure Functions provides trigger and binding-based event-driven execution, while App Service is centered on web app hosting"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-overview
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
       verified: true
     - claim: "App Service supports native WebSocket hosting, unlike Azure Functions"
-      source: https://learn.microsoft.com/azure/app-service/overview
+      source: https://learn.microsoft.com/en-us/azure/app-service/overview
       verified: true
 ---
 
@@ -332,8 +332,8 @@ During migration from one service to the other, run both side by side with traff
 
 ## Sources
 
-- [Azure Functions overview — Microsoft Learn](https://learn.microsoft.com/azure/azure-functions/functions-overview)
-- [Azure App Service overview — Microsoft Learn](https://learn.microsoft.com/azure/app-service/overview)
-- [Azure Functions hosting options — Microsoft Learn](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Choose an Azure compute service — Microsoft Learn](https://learn.microsoft.com/azure/architecture/guide/technology-choices/compute-decision-tree)
-- [App Service, Functions, and Logic Apps comparison — Microsoft Learn](https://learn.microsoft.com/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs)
+- [Azure Functions overview — Microsoft Learn](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)
+- [Azure App Service overview — Microsoft Learn](https://learn.microsoft.com/en-us/azure/app-service/overview)
+- [Azure Functions hosting options — Microsoft Learn](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Choose an Azure compute service — Microsoft Learn](https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree)
+- [App Service, Functions, and Logic Apps comparison — Microsoft Learn](https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs)

--- a/docs/platform/hosting.md
+++ b/docs/platform/hosting.md
@@ -1,31 +1,31 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Consumption plan scales to zero and bills per execution"
-      source: https://learn.microsoft.com/azure/azure-functions/consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
       verified: true
     - claim: "Flex Consumption supports VNet integration with identity-based storage"
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
     - claim: "Premium plan provides pre-warmed instances to avoid cold starts"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
       verified: true
     - claim: "Dedicated plan runs on App Service infrastructure with always-on support"
-      source: https://learn.microsoft.com/azure/app-service/overview-hosting-plans
+      source: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
       verified: true
 ---
 
@@ -94,7 +94,7 @@ Azure Functions supports four main hosting models:
 !!! tip "Decision rule"
     Start with Flex Consumption for most new serverless workloads, then choose Premium when you need permanently warm behavior and advanced App Service premium features.
 
-> **Last verified**: 2026-06-06 | **Primary source**: [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+> **Last verified**: 2026-06-06 | **Primary source**: [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
 >
 > Key values subject to change: Flex Consumption max instances, function timeout defaults/maximums, Linux Consumption retirement timeline, deployment slot support, Kudu/SCM availability, private endpoint and VNet integration support, scale behavior by trigger type.
 
@@ -426,8 +426,8 @@ Use conceptual formulas to compare plan behavior before detailed calculator mode
 
 ## Sources
 
-- [Microsoft Learn: Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Microsoft Learn: Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Microsoft Learn: Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Microsoft Learn: App Service plan](https://learn.microsoft.com/azure/app-service/overview-hosting-plans)
-- [Microsoft Learn: Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
+- [Microsoft Learn: Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Microsoft Learn: Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Microsoft Learn: Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Microsoft Learn: App Service plan](https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans)
+- [Microsoft Learn: Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -1,25 +1,24 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/reliability/reliability-functions
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/reliability/reliability-functions
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+      verified: true
 ---
 # Platform
 

--- a/docs/platform/networking-scenarios/fixed-outbound-nat.md
+++ b/docs/platform/networking-scenarios/fixed-outbound-nat.md
@@ -2,40 +2,40 @@
 content_sources:
   sources:
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/app-service/overview-nat-gateway-integration
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+      url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/nat-gateway/nat-overview
+      url: https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview
   diagrams:
     - id: nat-gateway-architecture
       type: flowchart
       source: self-generated
       justification: "NAT Gateway integration pattern from MSLearn documentation"
       based_on:
-        - https://learn.microsoft.com/azure/app-service/overview-nat-gateway-integration
+        - https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration
     - id: full-isolation-with-nat
       type: flowchart
       source: self-generated
       justification: "Full private ingress and NAT egress pattern synthesized from MSLearn networking documentation"
       based_on:
-        - https://learn.microsoft.com/azure/app-service/networking/private-endpoint
-        - https://learn.microsoft.com/azure/app-service/overview-nat-gateway-integration
+        - https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
+        - https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions plans without VNet integration cannot use NAT Gateway for outbound egress control"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "App Service VNet integration can route outbound traffic through a NAT Gateway attached to the integration subnet"
-      source: https://learn.microsoft.com/azure/app-service/overview-nat-gateway-integration
+      source: https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration
       verified: true
     - claim: "NAT Gateway provides stable outbound public IP addresses for internet egress"
-      source: https://learn.microsoft.com/azure/nat-gateway/nat-overview
+      source: https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview
       verified: true
 ---
 
@@ -358,7 +358,7 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [NAT Gateway integration with App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-nat-gateway-integration)
-- [Use private endpoints for Azure App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/networking/private-endpoint)
-- [What is Azure NAT Gateway? (Microsoft Learn)](https://learn.microsoft.com/azure/nat-gateway/nat-overview)
+- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [NAT Gateway integration with App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration)
+- [Use private endpoints for Azure App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint)
+- [What is Azure NAT Gateway? (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview)

--- a/docs/platform/networking-scenarios/index.md
+++ b/docs/platform/networking-scenarios/index.md
@@ -2,33 +2,33 @@
 content_sources:
   sources:
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
   diagrams:
     - id: network-scenario-decision-tree
       type: flowchart
       source: self-generated
       justification: "Decision tree synthesized from MSLearn networking options documentation"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
 content_validation:
   status: verified
   last_reviewed: 2026-05-21
   reviewer: agent
   core_claims:
     - claim: "Azure Functions supports different networking capabilities depending on the hosting plan."
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "Flex Consumption has plan-specific networking behavior documented separately from classic Consumption and Dedicated plans."
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
     - claim: "App Service VNet integration is available on Basic and higher dedicated compute tiers."
-      source: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
+      source: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
       verified: true
 ---
 
@@ -134,7 +134,7 @@ Each scenario guide provides:
 
 ## Sources
 
-- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Integrate your app with an Azure virtual network (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-vnet-integration)
+- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Integrate your app with an Azure virtual network (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration)

--- a/docs/platform/networking-scenarios/private-egress.md
+++ b/docs/platform/networking-scenarios/private-egress.md
@@ -2,34 +2,34 @@
 content_sources:
   sources:
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-create-vnet
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
   diagrams:
     - id: private-egress-architecture
       type: flowchart
       source: self-generated
       justification: "VNet integration pattern from MSLearn networking documentation"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/functions-create-vnet
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Consumption plan does not support VNet integration for Azure Functions"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "Flex Consumption requires Microsoft.App/environments subnet delegation for VNet integration"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-create-vnet
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
       verified: true
     - claim: "Premium and Dedicated plans use Microsoft.Web/serverFarms subnet delegation for VNet integration"
-      source: https://learn.microsoft.com/azure/app-service/overview-vnet-integration
+      source: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
       verified: true
     - claim: "Private endpoints let a function app reach storage over private network paths instead of public endpoints"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-create-vnet
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
       verified: true
 ---
 
@@ -555,6 +555,6 @@ curl --request GET "https://$APP_NAME.azurewebsites.net/api/health"
 
 ## Sources
 
-- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Create a function with VNet integration (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-create-vnet)
-- [Integrate your app with an Azure virtual network (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/overview-vnet-integration)
+- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Create a function with VNet integration (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet)
+- [Integrate your app with an Azure virtual network (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration)

--- a/docs/platform/networking-scenarios/private-ingress.md
+++ b/docs/platform/networking-scenarios/private-ingress.md
@@ -2,34 +2,34 @@
 content_sources:
   sources:
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+      url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/private-link/private-endpoint-overview
+      url: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview
   diagrams:
     - id: private-ingress-architecture
       type: flowchart
       source: self-generated
       justification: "Private endpoint ingress pattern from MSLearn networking documentation"
       based_on:
-        - https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+        - https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions private endpoints are supported on Flex Consumption, Premium, and Dedicated plans, but not classic Consumption"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "App Service private endpoints use the sites group for the main app endpoint"
-      source: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+      source: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
       verified: true
     - claim: "Private endpoints provide private IP-based access to the app through Azure Private Link"
-      source: https://learn.microsoft.com/azure/private-link/private-endpoint-overview
+      source: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview
       verified: true
     - claim: "Disabling public network access prevents public ingress to the function app"
-      source: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+      source: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
       verified: true
 ---
 
@@ -491,6 +491,6 @@ az functionapp update \
 
 ## Sources
 
-- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Use private endpoints for Azure App Service (Microsoft Learn)](https://learn.microsoft.com/azure/app-service/networking/private-endpoint)
-- [What is Azure Private Endpoint? (Microsoft Learn)](https://learn.microsoft.com/azure/private-link/private-endpoint-overview)
+- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Use private endpoints for Azure App Service (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint)
+- [What is Azure Private Endpoint? (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview)

--- a/docs/platform/networking-scenarios/public-only.md
+++ b/docs/platform/networking-scenarios/public-only.md
@@ -2,29 +2,29 @@
 content_sources:
   sources:
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted
-      url: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
   diagrams:
     - id: public-only-architecture
       type: flowchart
       source: self-generated
       justification: "Standard public deployment pattern from MSLearn quickstarts"
       based_on:
-        - https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
+        - https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Classic Consumption is the default serverless public deployment option and does not provide VNet integration"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "Flex Consumption, Premium, and Dedicated plans can be deployed without VNet integration"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "A basic Azure Functions deployment can be created publicly with Azure CLI without extra networking resources"
-      source: https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
       verified: true
 ---
 
@@ -265,5 +265,5 @@ To add VNet integration later, see:
 
 ## Sources
 
-- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Create a function app using Azure CLI (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python)
+- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Create a function app using Azure CLI (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python)

--- a/docs/platform/networking.md
+++ b/docs/platform/networking.md
@@ -1,26 +1,26 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable
+    url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/overview-nat-gateway-integration
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "VNet integration controls outbound traffic routing"
-      source: https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable
+      source: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
       verified: true
     - claim: "Private endpoints control inbound access"
-      source: https://learn.microsoft.com/azure/app-service/networking/private-endpoint
+      source: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
       verified: true
     - claim: "Consumption plan does not support VNet integration"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
 ---
 
@@ -441,7 +441,7 @@ Runtime focus areas:
 - [Deployment Scenarios](deployment-scenarios.md) — Cross-plan comparison of VNet, PE, identity, and deployment patterns
 
 ## Sources
-- [Microsoft Learn: Networking options in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Microsoft Learn: Integrate your app with an Azure virtual network](https://learn.microsoft.com/azure/app-service/configure-vnet-integration-enable)
-- [Microsoft Learn: Use private endpoints for Azure App Service apps](https://learn.microsoft.com/azure/app-service/networking/private-endpoint)
-- [Microsoft Learn: NAT Gateway integration with App Service](https://learn.microsoft.com/azure/app-service/overview-nat-gateway-integration)
+- [Microsoft Learn: Networking options in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Microsoft Learn: Integrate your app with an Azure virtual network](https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable)
+- [Microsoft Learn: Use private endpoints for Azure App Service apps](https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint)
+- [Microsoft Learn: NAT Gateway integration with App Service](https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration)

--- a/docs/platform/reliability.md
+++ b/docs/platform/reliability.md
@@ -1,31 +1,31 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/reliability/reliability-functions
+    url: https://learn.microsoft.com/en-us/azure/reliability/reliability-functions
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Reliable Azure Functions designs depend on trigger semantics, function behavior, platform behavior, and dependency behavior"
-      source: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
       verified: true
     - claim: "Azure Functions supports built-in retries for supported triggers and retries should target transient failures"
-      source: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
       verified: true
     - claim: "Storage Queue triggers move messages to a poison queue after maxDequeueCount is exceeded"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
       verified: true
     - claim: "Service Bus trigger reliability behavior includes dead-letter handling after delivery failures"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
       verified: true
 ---
 
@@ -453,8 +453,8 @@ Use language-specific guidance for runtime nuances, extension bundles, and host 
 - [Troubleshooting methodology](../troubleshooting/methodology.md)
 
 ## Sources
-- [Microsoft Learn: Design reliable Azure Functions applications](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
-- [Microsoft Learn: Azure Functions reliability in Azure Well-Architected Framework](https://learn.microsoft.com/azure/reliability/reliability-functions)
-- [Microsoft Learn: Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Microsoft Learn: Azure Queue Storage trigger and bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue)
-- [Microsoft Learn: Azure Service Bus trigger and bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus)
+- [Microsoft Learn: Design reliable Azure Functions applications](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)
+- [Microsoft Learn: Azure Functions reliability in Azure Well-Architected Framework](https://learn.microsoft.com/en-us/azure/reliability/reliability-functions)
+- [Microsoft Learn: Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Microsoft Learn: Azure Queue Storage trigger and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue)
+- [Microsoft Learn: Azure Service Bus trigger and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus)

--- a/docs/platform/scaling.md
+++ b/docs/platform/scaling.md
@@ -1,30 +1,30 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/event-driven-scaling
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-concurrency
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-perf-and-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-perf-and-scale
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Scaling is trigger-specific with plan-dependent limits"
-      source: https://learn.microsoft.com/azure/azure-functions/event-driven-scaling
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
       verified: true
     - claim: "Consumption plan can scale to 200 instances (Linux) or 100 (Windows)"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
     - claim: "HTTP triggers scale based on concurrent request rate"
-      source: https://learn.microsoft.com/azure/azure-functions/event-driven-scaling
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
       verified: true
 ---
 
@@ -443,9 +443,9 @@ Cross-reference for implementation decisions:
 - [Troubleshooting: Playbooks](../troubleshooting/playbooks/index.md)
 
 ## Sources
-- [Microsoft Learn: Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Microsoft Learn: Event-driven scaling in Azure Functions](https://learn.microsoft.com/azure/azure-functions/event-driven-scaling)
-- [Microsoft Learn: Azure Functions Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Microsoft Learn: Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Microsoft Learn: Concurrency in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-concurrency)
-- [Microsoft Learn: Durable Functions performance and scale](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-perf-and-scale)
+- [Microsoft Learn: Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Microsoft Learn: Event-driven scaling in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling)
+- [Microsoft Learn: Azure Functions Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Microsoft Learn: Azure Functions Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Microsoft Learn: Concurrency in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency)
+- [Microsoft Learn: Durable Functions performance and scale](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-perf-and-scale)

--- a/docs/platform/security.md
+++ b/docs/platform/security.md
@@ -1,29 +1,29 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/security-concepts
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/api-management/api-management-howto-protect-backend-with-aad
+    url: https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-protect-backend-with-aad
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Azure Functions HTTP triggers support anonymous, function, and admin authorization levels"
-      source: https://learn.microsoft.com/azure/azure-functions/security-concepts
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
       verified: true
     - claim: "App Service Authentication runs before function code and can validate identity-provider tokens"
-      source: https://learn.microsoft.com/azure/app-service/overview-authentication-authorization
+      source: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
       verified: true
     - claim: "Managed identity is the preferred pattern for Azure-to-Azure service authentication"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
       verified: true
     - claim: "API Management can protect backend functions with Microsoft Entra ID token validation"
-      source: https://learn.microsoft.com/azure/api-management/api-management-howto-protect-backend-with-aad
+      source: https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-protect-backend-with-aad
       verified: true
 ---
 
@@ -394,7 +394,7 @@ Defense-in-depth baseline:
 - [Architecture](architecture/index.md)
 
 ## Sources
-- [Microsoft Learn: Security concepts](https://learn.microsoft.com/azure/azure-functions/security-concepts)
-- [Microsoft Learn: App Service authentication and authorization](https://learn.microsoft.com/azure/app-service/overview-authentication-authorization)
-- [Microsoft Learn: Identity-based connections tutorial](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
-- [Microsoft Learn: Protect API backend with OAuth in API Management](https://learn.microsoft.com/azure/api-management/api-management-howto-protect-backend-with-aad)
+- [Microsoft Learn: Security concepts](https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts)
+- [Microsoft Learn: App Service authentication and authorization](https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization)
+- [Microsoft Learn: Identity-based connections tutorial](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Microsoft Learn: Protect API backend with OAuth in API Management](https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-protect-backend-with-aad)

--- a/docs/platform/triggers-and-bindings.md
+++ b/docs/platform/triggers-and-bindings.md
@@ -1,33 +1,33 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/event-driven-scaling
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Each Azure Function has exactly one trigger and can also use input and output bindings"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
       verified: true
     - claim: "Flex Consumption uses the Event Grid-based blob trigger model instead of polling"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
       verified: true
     - claim: "Bindings can use identity-based connections configured with service URIs and managed identity settings"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
       verified: true
     - claim: "Azure Functions scaling is driven by the trigger type and workload signal"
-      source: https://learn.microsoft.com/azure/azure-functions/event-driven-scaling
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
       verified: true
 ---
 
@@ -428,9 +428,9 @@ Use language guides for runtime-specific syntax, decorators/attributes, and pack
 - [Hosting Plans](hosting.md)
 - [Networking](networking.md)
 ## Sources
-- [Microsoft Learn: Azure Functions triggers and bindings concepts](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Microsoft Learn: Azure Functions Blob storage trigger](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger)
-- [Microsoft Learn: Azure Functions Event Grid Blob trigger](https://learn.microsoft.com/azure/azure-functions/functions-event-grid-blob-trigger)
-- [Microsoft Learn: host.json reference for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Microsoft Learn: Azure Functions identity-based connections](https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
-- [Microsoft Learn: Azure Functions scale and hosting behavior](https://learn.microsoft.com/azure/azure-functions/event-driven-scaling)
+- [Microsoft Learn: Azure Functions triggers and bindings concepts](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Microsoft Learn: Azure Functions Blob storage trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger)
+- [Microsoft Learn: Azure Functions Event Grid Blob trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger)
+- [Microsoft Learn: host.json reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Microsoft Learn: Azure Functions identity-based connections](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
+- [Microsoft Learn: Azure Functions scale and hosting behavior](https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling)

--- a/docs/reference/cli-cheatsheet.md
+++ b/docs/reference/cli-cheatsheet.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/cli/azure/functionapp
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-run-local
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+      verified: true
 ---
 # CLI Cheatsheet
 
@@ -442,6 +441,6 @@ az monitor metrics list \
 - [Deployments](../operations/deployment.md)
 
 ## Sources
-- [Azure Functions Core Tools Reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
-- [Azure Functions CLI Reference (Microsoft Learn)](https://learn.microsoft.com/cli/azure/functionapp)
-- [Develop Azure Functions Locally (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
+- [Azure Functions Core Tools Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure Functions CLI Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)
+- [Develop Azure Functions Locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)

--- a/docs/reference/content-validation-status.md
+++ b/docs/reference/content-validation-status.md
@@ -1,32 +1,16 @@
 ---
 content_sources:
-  sources:
   - type: self-generated
     justification: Auto-generated dashboard tracking content validation status
-  diagrams:
-  - id: content-validation-status-pie
-    type: pie
-    source: self-generated
-    justification: Auto-generated dashboard chart from repository validation metadata.
-    based_on:
-    - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-  - claim: This generated dashboard summarizes repository validation metadata and
-      links back to Microsoft Learn as the source basis for Azure content checks.
-    source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-    verified: true
 ---
+
 # Content Validation Status
 
 This page tracks the source validation status of all documentation content. All content must be traceable to official Microsoft Learn documentation.
 
 ## Summary
 
-*Generated: 2026-05-23*
+*Generated: 2026-06-09*
 
 | Content Type | Total | Verified | Pending | Unverified | No Metadata |
 |---|---:|---:|---:|---:|---:|
@@ -36,7 +20,6 @@ This page tracks the source validation status of all documentation content. All 
 !!! success "All Content Verified"
     All text documents have verified Microsoft Learn sources for core claims.
 
-<!-- diagram-id: content-validation-status-pie -->
 ```mermaid
 pie title Document Validation Status
     "Verified" : 68
@@ -112,8 +95,8 @@ pie title Document Validation Status
 | [Flex Consumption Deployment](../troubleshooting/playbooks/flex-consumption-deployment.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Functions Failing](../troubleshooting/playbooks/functions-failing.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Functions Not Executing](../troubleshooting/playbooks/functions-not-executing.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [High Latency](../troubleshooting/playbooks/high-latency.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [High Latency](../troubleshooting/first-10-minutes/high-latency.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
+| [High Latency](../troubleshooting/playbooks/high-latency.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Hosting Plan Comparison Matrix](../troubleshooting/lab-guides/hosting-plan-comparison-matrix.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Hosting Plan Security Matrix](../troubleshooting/lab-guides/hosting-plan-security-matrix.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Managed Identity Auth](../troubleshooting/lab-guides/managed-identity-auth.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
@@ -160,14 +143,14 @@ Add a `content_validation` block to your document's frontmatter:
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/...
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/...
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Flex Consumption supports VNet integration"
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
 ---
 ```
@@ -182,7 +165,3 @@ python3 scripts/generate_content_validation_status.py
 
 - [Tutorial Validation Status](validation-status.md)
 - [CLI Cheatsheet](cli-cheatsheet.md)
-
-## Sources
-
-- [Microsoft Learn overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # Environment Variables
 
@@ -268,4 +267,4 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
 - [Troubleshooting](troubleshooting.md)
 
 ## Sources
-- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
+- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)

--- a/docs/reference/host-json.md
+++ b/docs/reference/host-json.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-host-json
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+      verified: true
 ---
 # host.json Reference
 
@@ -285,4 +284,4 @@ The `host.json` file is deployed with your code and applies in both local and pr
 - [Cost Optimization](../operations/configuration.md)
 
 ## Sources
-- [host.json Reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [host.json Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,23 +1,22 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-core-tools-reference
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-core-tools-reference
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/
+      verified: true
 ---
 # Reference
 
@@ -75,7 +74,7 @@ Reference documents currently cover Python-specific content. As additional langu
 
 ## Sources
 
-- [Azure Functions Documentation (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/)
-- [Azure Functions host.json Reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Azure Functions CLI Reference (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-core-tools-reference)
-- [Azure Functions Scale and Hosting (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions Documentation (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/)
+- [Azure Functions host.json Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Azure Functions CLI Reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-core-tools-reference)
+- [Azure Functions Scale and Hosting (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/reference/platform-limits.md
+++ b/docs/reference/platform-limits.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale#service-limits
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-scale#service-limits
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
+      verified: true
 ---
 # Platform Limits
 
@@ -228,4 +227,4 @@ For high-throughput scenarios, consider using a dedicated storage account for `A
 - [host.json Reference](host-json.md)
 
 ## Sources
-- [Azure Functions Scale and Service Limits (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-scale#service-limits)
+- [Azure Functions Scale and Service Limits (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits)

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-develop-local
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
 ---
 # Troubleshooting
 
@@ -567,5 +566,5 @@ See also: [Networking operations](../platform/networking.md) for the full Privat
 - [Networking Operations](../platform/networking.md)
 
 ## Sources
-- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Develop Azure Functions Locally (Microsoft Learn)](https://learn.microsoft.com/azure/azure-functions/functions-develop-local)
+- [Python v2 Programming Model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Develop Azure Functions Locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)

--- a/docs/reference/validation-status.md
+++ b/docs/reference/validation-status.md
@@ -1,24 +1,23 @@
 ---
 content_sources:
   sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
   diagrams:
-  - id: tutorial-validation-status-pie
-    type: pie
-    source: self-generated
-    justification: Auto-generated dashboard chart from repository validation metadata.
-    based_on:
-    - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - id: tutorial-validation-status-pie
+      type: pie
+      source: self-generated
+      justification: Auto-generated dashboard chart from repository validation metadata.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This generated dashboard summarizes repository validation metadata and
-      links back to Microsoft Learn as the source basis for Azure content checks.
-    source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-    verified: true
+    - claim: This generated dashboard summarizes repository validation metadata and links back to Microsoft Learn as the source basis for Azure content checks.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+      verified: true
 ---
 # Tutorial Validation Status
 

--- a/docs/start-here/hosting-options.md
+++ b/docs/start-here/hosting-options.md
@@ -1,25 +1,24 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-premium-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/dedicated-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-scale
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+      verified: true
 ---
 # Hosting Options
 
@@ -60,7 +59,7 @@ The App Service plan blade shows plan details for a live Consumption (Y1) deploy
 
 Reference:
 
-- [Azure Functions scale and hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions scale and hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
 
 ## Decision matrix
 
@@ -90,7 +89,7 @@ Important Microsoft Learn notes:
 
 Reference:
 
-- [Consumption plan (legacy)](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
+- [Consumption plan (legacy)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
 
 ### Flex Consumption (FC1)
 
@@ -106,7 +105,7 @@ Strengths:
 
 Reference:
 
-- [Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
 
 ### Premium (EP)
 
@@ -121,7 +120,7 @@ Strengths:
 
 Reference:
 
-- [Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
+- [Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
 
 ### Dedicated (App Service Plan)
 
@@ -135,7 +134,7 @@ Strengths:
 
 Reference:
 
-- [Dedicated plan](https://learn.microsoft.com/azure/azure-functions/dedicated-plan)
+- [Dedicated plan](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
 
 ## Decision flow
 
@@ -230,8 +229,8 @@ Use official pricing tools:
 
 ## Sources
 
-- [Azure Functions scale and hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Consumption plan (legacy)](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
-- [Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan)
-- [Dedicated plan](https://learn.microsoft.com/azure/azure-functions/dedicated-plan)
+- [Azure Functions scale and hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Consumption plan (legacy)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Premium plan](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Dedicated plan](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+      verified: true
 ---
 # Start Here
 

--- a/docs/start-here/learning-paths.md
+++ b/docs/start-here/learning-paths.md
@@ -1,27 +1,26 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/supported-languages
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+      verified: true
 ---
 # Learning Paths
 
@@ -68,9 +67,9 @@ Choose the track that matches your immediate goal:
 
 ### Microsoft Learn references
 
-- [Azure Functions overview](https://learn.microsoft.com/azure/azure-functions/functions-overview)
-- [Triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Functions scale and hosting](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)
+- [Triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
 
 ## Track 2: Core Path (2-3 hrs)
 
@@ -98,9 +97,9 @@ Choose the track that matches your immediate goal:
 
 ### Microsoft Learn references
 
-- [Azure Functions developer guides](https://learn.microsoft.com/azure/azure-functions/)
-- [Supported languages](https://learn.microsoft.com/azure/azure-functions/supported-languages)
-- [Performance and reliability guidance](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
+- [Azure Functions developer guides](https://learn.microsoft.com/en-us/azure/azure-functions/)
+- [Supported languages](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+- [Performance and reliability guidance](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)
 
 ## Track 3: Production Path (4-6 hrs)
 
@@ -182,9 +181,9 @@ Choose the track that matches your immediate goal:
 
 ## Sources
 
-- [Azure Functions overview](https://learn.microsoft.com/azure/azure-functions/functions-overview)
-- [Triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Functions scale and hosting](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions developer guides](https://learn.microsoft.com/azure/azure-functions/)
-- [Supported languages](https://learn.microsoft.com/azure/azure-functions/supported-languages)
-- [Performance and reliability guidance](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
+- [Azure Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)
+- [Triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions developer guides](https://learn.microsoft.com/en-us/azure/azure-functions/)
+- [Supported languages](https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages)
+- [Performance and reliability guidance](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)

--- a/docs/start-here/overview.md
+++ b/docs/start-here/overview.md
@@ -1,37 +1,36 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/consumption-plan
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scenarios
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/architecture/guide/technology-choices/compute-comparison
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-node
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-reference-java
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-comparison
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+      verified: true
 ---
 # Overview: What is Azure Functions
 
@@ -74,8 +73,8 @@ At a high level:
 
 Microsoft Learn references:
 
-- [Azure Functions overview](https://learn.microsoft.com/azure/azure-functions/functions-overview)
-- [Triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)
+- [Triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
 
 ## Triggers and bindings in practice
 
@@ -107,7 +106,7 @@ Microsoft Learn also documents **Container Apps** hosting for containerized func
 
 Primary comparison:
 
-- [Azure Functions scale and hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Azure Functions scale and hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
 
 Important lifecycle note from Learn:
 
@@ -117,7 +116,7 @@ Important lifecycle note from Learn:
 
 Reference:
 
-- [Consumption plan (legacy)](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
+- [Consumption plan (legacy)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
 
 ## What Azure Functions is best at
 
@@ -131,7 +130,7 @@ From Microsoft Learn scenarios, Functions is a strong fit for:
 
 Scenario reference:
 
-- [Azure Functions scenarios](https://learn.microsoft.com/azure/azure-functions/functions-scenarios)
+- [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios)
 
 ## When to choose Functions vs other Azure options
 
@@ -150,11 +149,11 @@ Consider **App Service WebJobs** only in narrower cases where existing App Servi
 
 Comparison reference:
 
-- [Integration and automation platform options](https://learn.microsoft.com/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs)
+- [Integration and automation platform options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs)
 
 For broader compute trade-offs:
 
-- [Choose an Azure compute service](https://learn.microsoft.com/azure/architecture/guide/technology-choices/compute-comparison)
+- [Choose an Azure compute service](https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-comparison)
 
 ## Language and development model
 
@@ -169,10 +168,10 @@ Each language has a programming model and runtime-specific guidance on Microsoft
 
 Start here:
 
-- [Python developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Node.js developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [.NET developer guide](https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library)
-- [Java developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
+- [Python developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Node.js developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [.NET developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library)
+- [Java developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
 
 !!! tip "Language Guide"
     For guide-specific implementation flow, see [Language Guides](../language-guides/index.md).
@@ -213,14 +212,14 @@ Those decisions influence architecture, cost profile, cold-start behavior, and o
 
 ## Sources
 
-- [Azure Functions overview](https://learn.microsoft.com/azure/azure-functions/functions-overview)
-- [Triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Functions scale and hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Consumption plan (legacy)](https://learn.microsoft.com/azure/azure-functions/consumption-plan)
-- [Azure Functions scenarios](https://learn.microsoft.com/azure/azure-functions/functions-scenarios)
-- [Integration and automation platform options](https://learn.microsoft.com/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs)
-- [Choose an Azure compute service](https://learn.microsoft.com/azure/architecture/guide/technology-choices/compute-comparison)
-- [Python developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-python)
-- [Node.js developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-node)
-- [.NET developer guide](https://learn.microsoft.com/azure/azure-functions/functions-dotnet-class-library)
-- [Java developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-java)
+- [Azure Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)
+- [Triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions scale and hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Consumption plan (legacy)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Azure Functions scenarios](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios)
+- [Integration and automation platform options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs)
+- [Choose an Azure compute service](https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-comparison)
+- [Python developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Node.js developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [.NET developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library)
+- [Java developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)

--- a/docs/start-here/repository-map.md
+++ b/docs/start-here/repository-map.md
@@ -1,17 +1,16 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/
+      verified: true
 ---
 # Repository Map
 
@@ -152,4 +151,4 @@ These repositories are linked resources, not vendored into this guide.
 
 ## Sources
 
-- [Microsoft Learn: Azure Functions documentation](https://learn.microsoft.com/azure/azure-functions/)
+- [Microsoft Learn: Azure Functions documentation](https://learn.microsoft.com/en-us/azure/azure-functions/)

--- a/docs/troubleshooting/architecture.md
+++ b/docs/troubleshooting/architecture.md
@@ -1,15 +1,15 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/data-model
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
@@ -282,8 +282,8 @@ flowchart TD
 
 ## Sources
 
-- [Azure Functions monitoring](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Azure Functions scale and hosting](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Application Insights data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model)
-- [Azure Monitor Activity Log](https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log)
+- [Azure Functions monitoring](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Azure Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Application Insights data model](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model)
+- [Azure Monitor Activity Log](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log)

--- a/docs/troubleshooting/decision-tree.md
+++ b/docs/troubleshooting/decision-tree.md
@@ -1,13 +1,13 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
@@ -230,7 +230,7 @@ az monitor activity-log list \
 
 ## Sources
 
-- [Azure Functions diagnostics overview](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Troubleshoot Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [Azure Functions diagnostics overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Troubleshoot Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/troubleshooting/evidence-map.md
+++ b/docs/troubleshooting/evidence-map.md
@@ -1,15 +1,15 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/service-health/overview
+    url: https://learn.microsoft.com/en-us/azure/service-health/overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
@@ -279,8 +279,8 @@ dependencies
 
 ## Sources
 
-- [Azure Functions monitoring](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Monitor Azure Functions with Application Insights](https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data)
+- [Azure Functions monitoring](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Monitor Azure Functions with Application Insights](https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data)
 - [Azure Monitor Logs query overview](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview)
-- [Azure Service Health overview](https://learn.microsoft.com/azure/service-health/overview)
-- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
+- [Azure Service Health overview](https://learn.microsoft.com/en-us/azure/service-health/overview)
+- [Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)

--- a/docs/troubleshooting/first-10-minutes/high-latency.md
+++ b/docs/troubleshooting/first-10-minutes/high-latency.md
@@ -1,18 +1,18 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "First 10 Minutes: High Latency 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
 ---
 
@@ -293,6 +293,6 @@ Correlate deployment timestamps with latency onset.
 
 ## Sources
 
-- [Azure Functions scale and hosting](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
+- [Azure Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)

--- a/docs/troubleshooting/first-10-minutes/index.md
+++ b/docs/troubleshooting/first-10-minutes/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/service-health/overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/service-health/overview
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+      verified: true
 ---
 # Checklists
 
@@ -83,5 +82,5 @@ Regardless of which checklist you follow, always start with these three checks:
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Service Health overview](https://learn.microsoft.com/azure/service-health/overview)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Service Health overview](https://learn.microsoft.com/en-us/azure/service-health/overview)

--- a/docs/troubleshooting/first-10-minutes/scaling-issues.md
+++ b/docs/troubleshooting/first-10-minutes/scaling-issues.md
@@ -1,18 +1,18 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "First 10 Minutes: Scaling Issues 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
 ---
 
@@ -365,6 +365,6 @@ Correlate configuration changes (especially host.json, concurrency settings) wit
 
 ## Sources
 
-- [Azure Functions scale and hosting](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Azure Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/troubleshooting/first-10-minutes/triggers-not-firing.md
+++ b/docs/troubleshooting/first-10-minutes/triggers-not-firing.md
@@ -1,18 +1,18 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "First 10 Minutes: Triggers Not Firing 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
       verified: true
 ---
 
@@ -302,6 +302,6 @@ az functionapp config appsettings list \
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Functions diagnostics](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions diagnostics](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -1,27 +1,26 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring#application-insights
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/configure-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring#application-insights
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/
+      verified: true
 ---
 # Troubleshooting
 
@@ -136,10 +135,10 @@ If you also operate App Service or Container Apps with container-based continuou
 
 ## Sources
 
-- [Azure Functions documentation](https://learn.microsoft.com/azure/azure-functions/)
-- [Azure Functions diagnostics](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Application Insights for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring#application-insights)
-- [Scale and hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Troubleshoot Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
-- [Application Insights for Azure Functions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring)
+- [Azure Functions documentation](https://learn.microsoft.com/en-us/azure/azure-functions/)
+- [Azure Functions diagnostics](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Application Insights for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring#application-insights)
+- [Scale and hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Troubleshoot Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
+- [Application Insights for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring)

--- a/docs/troubleshooting/kql/correlation/index.md
+++ b/docs/troubleshooting/kql/correlation/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-monitor/app/correlation
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/correlation
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-monitor/app/correlation
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/app/correlation
+      verified: true
 ---
 # Correlation Queries
 
@@ -162,5 +161,5 @@ restarts
 
 ## Sources
 
-- [Application Insights telemetry correlation](https://learn.microsoft.com/azure/azure-monitor/app/correlation)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Application Insights telemetry correlation](https://learn.microsoft.com/en-us/azure/azure-monitor/app/correlation)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/troubleshooting/kql/dependencies/index.md
+++ b/docs/troubleshooting/kql/dependencies/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/storage-considerations
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/storage-considerations
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
+      verified: true
 ---
 # Dependency Queries
 
@@ -156,5 +155,5 @@ Storage is critical infrastructure for Azure Functions (leases, triggers, Durabl
 
 ## Sources
 
-- [Azure Functions storage considerations](https://learn.microsoft.com/azure/azure-functions/storage-considerations)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Azure Functions storage considerations](https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/troubleshooting/kql/execution/index.md
+++ b/docs/troubleshooting/kql/execution/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/data-explorer/kusto/query/
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/data-explorer/kusto/query/
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
+      verified: true
 ---
 # Execution Queries
 
@@ -174,5 +173,5 @@ AppExceptions
 
 ## Sources
 
-- [Kusto Query Language overview](https://learn.microsoft.com/azure/data-explorer/kusto/query/)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Kusto Query Language overview](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/troubleshooting/kql/index.md
+++ b/docs/troubleshooting/kql/index.md
@@ -1,25 +1,24 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-monitor/app/data-model
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/data-explorer/kusto/query/
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
+      verified: true
 ---
 # KQL Query Library for Azure Functions
 
@@ -110,7 +109,7 @@ graph TD
 ## Sources
 
 - [Azure Monitor Logs query overview](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview)
-- [Application Insights data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model)
-- [Kusto Query Language overview](https://learn.microsoft.com/azure/data-explorer/kusto/query/)
-- [Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Application Insights data model](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model)
+- [Kusto Query Language overview](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/)
+- [Application Insights telemetry data model](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/troubleshooting/kql/scaling/index.md
+++ b/docs/troubleshooting/kql/scaling/index.md
@@ -1,19 +1,18 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-scale
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-scale
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+      verified: true
 ---
 # Scaling Queries
 
@@ -179,5 +178,5 @@ AppTraces
 
 ## Sources
 
-- [Azure Functions scale and hosting](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Azure Functions scale and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/troubleshooting/lab-guides/code-storage-verification.md
+++ b/docs/troubleshooting/lab-guides/code-storage-verification.md
@@ -1,28 +1,28 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/storage-considerations
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/data-model
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli
+    url: https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Code Storage Verification (All Hosting Plans) 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/storage-considerations
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
       verified: true
 ---
 
@@ -2772,11 +2772,11 @@ graph TD
 
 ## Sources
 
-- [Azure Functions storage considerations](https://learn.microsoft.com/azure/azure-functions/storage-considerations)
-- [How to use identity-based connections in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
-- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Azure Functions Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Run your functions from a package file in Azure](https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model)
-- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli)
+- [Azure Functions storage considerations](https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations)
+- [How to use identity-based connections in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
+- [Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Azure Functions Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Run your functions from a package file in Azure](https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Application Insights telemetry data model](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model)
+- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli)

--- a/docs/troubleshooting/lab-guides/cold-start.md
+++ b/docs/troubleshooting/lab-guides/cold-start.md
@@ -1,24 +1,24 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/configure-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/data-explorer/kusto/query/
+    url: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Cold Start on Azure Functions 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
 ---
 
@@ -838,9 +838,9 @@ rm -rf "labs/cold-start/artifacts"
 - [Lab Guides Index](index.md)
 - [Azure Functions Cold Start Guide](../../operations/cold-start.md)
 ## Sources
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Improve Azure Functions performance and reliability](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Configure monitoring for Azure Functions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring)
-- [Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete)
-- [Kusto Query Language overview](https://learn.microsoft.com/azure/data-explorer/kusto/query/)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Improve Azure Functions performance and reliability](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Configure monitoring for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring)
+- [Application Insights telemetry data model](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete)
+- [Kusto Query Language overview](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/)

--- a/docs/troubleshooting/lab-guides/deployment-not-running.md
+++ b/docs/troubleshooting/lab-guides/deployment-not-running.md
@@ -1,13 +1,13 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/configure-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
 content_validation:
@@ -16,7 +16,7 @@ content_validation:
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Deployment Succeeded but Function Not Running 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
       verified: true
 ---
 
@@ -627,8 +627,8 @@ az group delete --name "$RG" --yes --no-wait --output table
 
 ## Sources
 
-- https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
-- https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- https://learn.microsoft.com/azure/azure-functions/configure-monitoring
-- https://learn.microsoft.com/azure/azure-functions/monitor-functions
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+- https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
+- https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
 - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview

--- a/docs/troubleshooting/lab-guides/dns-vnet-resolution.md
+++ b/docs/troubleshooting/lab-guides/dns-vnet-resolution.md
@@ -1,24 +1,24 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/private-link/private-endpoint-dns
+    url: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/storage-considerations
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/dns/private-dns-overview
+    url: https://learn.microsoft.com/en-us/azure/dns/private-dns-overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/cli/azure/network/private-dns
+    url: https://learn.microsoft.com/en-us/cli/azure/network/private-dns
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: DNS and VNet Resolution Failure 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
 ---
 
@@ -854,9 +854,9 @@ az group delete \
 
 ## Sources
 
-- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Azure private endpoint DNS configuration](https://learn.microsoft.com/azure/private-link/private-endpoint-dns)
-- [Azure Functions storage considerations](https://learn.microsoft.com/azure/azure-functions/storage-considerations)
-- [Azure Private DNS overview](https://learn.microsoft.com/azure/dns/private-dns-overview)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure DNS private zones CLI reference](https://learn.microsoft.com/cli/azure/network/private-dns)
+- [Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Azure private endpoint DNS configuration](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns)
+- [Azure Functions storage considerations](https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations)
+- [Azure Private DNS overview](https://learn.microsoft.com/en-us/azure/dns/private-dns-overview)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure DNS private zones CLI reference](https://learn.microsoft.com/en-us/cli/azure/network/private-dns)

--- a/docs/troubleshooting/lab-guides/durable-replay-storm.md
+++ b/docs/troubleshooting/lab-guides/durable-replay-storm.md
@@ -1,15 +1,15 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-orchestrations
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-orchestrations
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-best-practice-reference
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-best-practice-reference
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/storage-considerations
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
 content_validation:
@@ -18,7 +18,7 @@ content_validation:
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Durable Functions Replay Storm on Azure Functions Premium EP1 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-orchestrations
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-orchestrations
       verified: true
 ---
 
@@ -884,9 +884,9 @@ If this is a shared EP1 lab environment, skip deletion and only stop test traffi
 
 ## Sources
 
-- https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-orchestrations
-- https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-best-practice-reference
-- https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-eternal-orchestrations
-- https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- https://learn.microsoft.com/azure/azure-functions/storage-considerations
+- https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-orchestrations
+- https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-best-practice-reference
+- https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+- https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
 - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview

--- a/docs/troubleshooting/lab-guides/event-hub-checkpoint-lag.md
+++ b/docs/troubleshooting/lab-guides/event-hub-checkpoint-lag.md
@@ -1,13 +1,13 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/event-hubs/event-hubs-scalability
+    url: https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
 content_validation:
@@ -16,7 +16,7 @@ content_validation:
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Event Hub Checkpoint Lag on Azure Functions Premium EP1 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
       verified: true
 ---
 
@@ -969,8 +969,8 @@ If this is a shared troubleshooting environment, keep resources and only disable
 
 ## Sources
 
-- https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs
-- https://learn.microsoft.com/azure/azure-functions/functions-host-json
-- https://learn.microsoft.com/azure/azure-functions/functions-best-practices
-- https://learn.microsoft.com/azure/event-hubs/event-hubs-scalability
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+- https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability
 - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview

--- a/docs/troubleshooting/lab-guides/hosting-plan-comparison-matrix.md
+++ b/docs/troubleshooting/lab-guides/hosting-plan-comparison-matrix.md
@@ -1,20 +1,20 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/storage/common/storage-private-endpoints
+    url: https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Hosting Plan Security Comparison Matrix 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
 ---
 
@@ -239,7 +239,7 @@ flowchart TD
 
 ## Sources
 
-- [Microsoft Learn: Azure Functions networking](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [Microsoft Learn: Azure Functions managed identity](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
-- [Microsoft Learn: Private endpoints for Azure Storage](https://learn.microsoft.com/azure/storage/common/storage-private-endpoints)
-- [Microsoft Learn: Azure Functions hosting plans](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Microsoft Learn: Azure Functions networking](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Microsoft Learn: Azure Functions managed identity](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Microsoft Learn: Private endpoints for Azure Storage](https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints)
+- [Microsoft Learn: Azure Functions hosting plans](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/troubleshooting/lab-guides/hosting-plan-security-matrix.md
+++ b/docs/troubleshooting/lab-guides/hosting-plan-security-matrix.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/storage/common/storage-private-endpoints
+    url: https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/configure-networking-how-to
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-networking-how-to
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Hosting Plan Security Matrix — Private Endpoint + Managed Identity Fault Injection 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-networking-options
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
 ---
 
@@ -1380,8 +1380,8 @@ az group delete --name "$RG_S1" --yes --no-wait
 
 ## Sources
 
-- [Azure Functions networking options](https://learn.microsoft.com/azure/azure-functions/functions-networking-options)
-- [How to use managed identities in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
-- [Private endpoints for Azure Storage](https://learn.microsoft.com/azure/storage/common/storage-private-endpoints)
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Secure storage account access from Azure Functions](https://learn.microsoft.com/azure/azure-functions/configure-networking-how-to)
+- [Azure Functions networking options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [How to use managed identities in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Private endpoints for Azure Storage](https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Secure storage account access from Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/configure-networking-how-to)

--- a/docs/troubleshooting/lab-guides/index.md
+++ b/docs/troubleshooting/lab-guides/index.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/configure-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+      verified: true
 ---
 # Hands-on Labs
 
@@ -193,6 +192,6 @@ Each lab trains specific diagnostic skills:
 
 ## Sources
 
-- [Azure Functions monitoring](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Application Insights for Azure Functions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring)
-- [Troubleshoot Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
+- [Azure Functions monitoring](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Application Insights for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring)
+- [Troubleshoot Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)

--- a/docs/troubleshooting/lab-guides/managed-identity-auth.md
+++ b/docs/troubleshooting/lab-guides/managed-identity-auth.md
@@ -1,24 +1,24 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli
+    url: https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/storage/blobs/authorize-access-azure-active-directory
+    url: https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Managed Identity Authentication Failure 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
       verified: true
 ---
 
@@ -891,9 +891,9 @@ If recovery occurs before role restoration, the hypothesis is falsified for that
 
 ## Sources
 
-- [Use managed identities in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
-- [Configure identity-based connections in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
-- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli)
-- [Azure Blob Storage authorization with Microsoft Entra ID](https://learn.microsoft.com/azure/storage/blobs/authorize-access-azure-active-directory)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Monitor activity log](https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log)
+- [Use managed identities in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Configure identity-based connections in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
+- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli)
+- [Azure Blob Storage authorization with Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/storage/blobs/authorize-access-azure-active-directory)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Monitor activity log](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log)

--- a/docs/troubleshooting/lab-guides/out-of-memory-crash.md
+++ b/docs/troubleshooting/lab-guides/out-of-memory-crash.md
@@ -1,13 +1,13 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference-python
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
 content_validation:
@@ -16,7 +16,7 @@ content_validation:
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Out of Memory Crash Under Blob Processing Load 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
 ---
 
@@ -678,8 +678,8 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- https://learn.microsoft.com/azure/azure-functions/functions-scale
-- https://learn.microsoft.com/azure/azure-functions/functions-reference-python
-- https://learn.microsoft.com/azure/azure-functions/functions-monitoring
-- https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+- https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
 - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview

--- a/docs/troubleshooting/lab-guides/queue-backlog-scaling.md
+++ b/docs/troubleshooting/lab-guides/queue-backlog-scaling.md
@@ -1,13 +1,13 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
 content_validation:
@@ -16,7 +16,7 @@ content_validation:
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Queue Backlog Scaling on Y1 Consumption (Real Evidence) 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
       verified: true
 ---
 
@@ -597,8 +597,8 @@ If using shared resources (`rg-lab-y1-shared`), skip deletion and only clear tes
 
 ## Sources
 
-- https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
-- https://learn.microsoft.com/azure/azure-functions/functions-host-json
-- https://learn.microsoft.com/azure/azure-functions/functions-scale
-- https://learn.microsoft.com/azure/azure-functions/monitor-functions
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+- https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
 - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview

--- a/docs/troubleshooting/lab-guides/storage-access-failure.md
+++ b/docs/troubleshooting/lab-guides/storage-access-failure.md
@@ -1,24 +1,24 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/storage-considerations
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/data-model
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli
+    url: https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Storage Access Failure (AzureWebJobsStorage) 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/storage-considerations
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
       verified: true
 ---
 
@@ -961,9 +961,9 @@ az group delete \
 
 ## Sources
 
-- [Azure Functions storage considerations](https://learn.microsoft.com/azure/azure-functions/storage-considerations)
-- [Azure Functions trigger and binding concepts](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Enable managed identity for Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-identity-based-connections-tutorial)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Application Insights data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model)
-- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli)
+- [Azure Functions storage considerations](https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations)
+- [Azure Functions trigger and binding concepts](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Enable managed identity for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Application Insights data model](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model)
+- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli)

--- a/docs/troubleshooting/lab-guides/timer-missed-schedules.md
+++ b/docs/troubleshooting/lab-guides/timer-missed-schedules.md
@@ -1,13 +1,13 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/monitor-functions
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
 content_validation:
@@ -16,7 +16,7 @@ content_validation:
   reviewer: agent
   core_claims:
     - claim: "Lab Guide: Timer Trigger Missed Schedules 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
       verified: true
 ---
 
@@ -455,8 +455,8 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- https://learn.microsoft.com/azure/azure-functions/functions-bindings-timer
-- https://learn.microsoft.com/azure/azure-functions/functions-host-json
-- https://learn.microsoft.com/azure/azure-functions/functions-reference
-- https://learn.microsoft.com/azure/azure-functions/monitor-functions
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+- https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference
+- https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
 - https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview

--- a/docs/troubleshooting/mental-model.md
+++ b/docs/troubleshooting/mental-model.md
@@ -1,11 +1,11 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
@@ -302,6 +302,6 @@ sequenceDiagram
 
 ## Sources
 
-- [Azure Functions diagnostics overview](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Troubleshoot Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
+- [Azure Functions diagnostics overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Troubleshoot Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)

--- a/docs/troubleshooting/methodology.md
+++ b/docs/troubleshooting/methodology.md
@@ -1,13 +1,13 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/configure-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/overview
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/overview
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
@@ -195,7 +195,7 @@ flowchart TD
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Configure monitoring for Azure Functions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring)
-- [Troubleshoot Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
-- [Azure Monitor overview](https://learn.microsoft.com/azure/azure-monitor/overview)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Configure monitoring for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring)
+- [Troubleshoot Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
+- [Azure Monitor overview](https://learn.microsoft.com/en-us/azure/azure-monitor/overview)

--- a/docs/troubleshooting/methodology/detector-map.md
+++ b/docs/troubleshooting/methodology/detector-map.md
@@ -1,11 +1,11 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/essentials/data-platform-metrics
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/data-platform-metrics
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
@@ -161,6 +161,6 @@ az monitor metrics list \
 
 ## Sources
 
-- [Azure Functions diagnostics overview](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Azure Monitor metrics overview](https://learn.microsoft.com/azure/azure-monitor/essentials/data-platform-metrics)
+- [Azure Functions diagnostics overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Azure Monitor metrics overview](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/data-platform-metrics)

--- a/docs/troubleshooting/methodology/troubleshooting-method.md
+++ b/docs/troubleshooting/methodology/troubleshooting-method.md
@@ -1,11 +1,11 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/configure-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
@@ -196,6 +196,6 @@ flowchart TD
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Configure monitoring for Azure Functions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring)
-- [Troubleshoot Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Configure monitoring for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring)
+- [Troubleshoot Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)

--- a/docs/troubleshooting/playbooks/auth-config/app-settings-misconfiguration.md
+++ b/docs/troubleshooting/playbooks/auth-config/app-settings-misconfiguration.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/app-service-key-vault-references
+    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-versions
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "App Settings Misconfiguration 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
       verified: true
 ---
 
@@ -509,8 +509,8 @@ timestamp                    message
 - [Storage Access Failure Lab](../../lab-guides/storage-access-failure.md)
 
 ## Sources
-- [Azure Functions app settings reference](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Azure Functions best practices for performance and reliability](https://learn.microsoft.com/azure/azure-functions/functions-best-practices)
-- [Key Vault references for App Service and Azure Functions](https://learn.microsoft.com/azure/app-service/app-service-key-vault-references)
-- [Monitor Azure Functions with Application Insights](https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data)
-- [Azure Functions host versions and runtime support](https://learn.microsoft.com/azure/azure-functions/functions-versions)
+- [Azure Functions app settings reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Azure Functions best practices for performance and reliability](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)
+- [Key Vault references for App Service and Azure Functions](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+- [Monitor Azure Functions with Application Insights](https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data)
+- [Azure Functions host versions and runtime support](https://learn.microsoft.com/en-us/azure/azure-functions/functions-versions)

--- a/docs/troubleshooting/playbooks/auth-config/managed-identity-rbac-failure.md
+++ b/docs/troubleshooting/playbooks/auth-config/managed-identity-rbac-failure.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/app-service/overview-managed-identity
+    url: https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli
+    url: https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/key-vault/general/rbac-guide
+    url: https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential
+    url: https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Managed Identity and RBAC Authentication Failure 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
       verified: true
 ---
 
@@ -508,8 +508,8 @@ timeline
 - [App Settings Misconfiguration Playbook](./app-settings-misconfiguration.md)
 
 ## Sources
-- [Azure Functions identity-based connections](https://learn.microsoft.com/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
-- [Use managed identities for App Service and Azure Functions](https://learn.microsoft.com/azure/app-service/overview-managed-identity)
-- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/azure/role-based-access-control/role-assignments-cli)
-- [Authorize access to Key Vault secrets](https://learn.microsoft.com/azure/key-vault/general/rbac-guide)
-- [DefaultAzureCredential authentication flow](https://learn.microsoft.com/dotnet/api/azure.identity.defaultazurecredential)
+- [Azure Functions identity-based connections](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection)
+- [Use managed identities for App Service and Azure Functions](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity)
+- [Assign Azure roles using Azure CLI](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli)
+- [Authorize access to Key Vault secrets](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide)
+- [DefaultAzureCredential authentication flow](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.defaultazurecredential)

--- a/docs/troubleshooting/playbooks/blob-trigger-not-firing.md
+++ b/docs/troubleshooting/playbooks/blob-trigger-not-firing.md
@@ -1,13 +1,13 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/event-grid/concepts
+    url: https://learn.microsoft.com/en-us/azure/event-grid/concepts
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
 content_validation:
@@ -16,7 +16,7 @@ content_validation:
   reviewer: agent
   core_claims:
     - claim: "Blob Trigger Not Firing 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
       verified: true
 ---
 
@@ -556,8 +556,8 @@ az monitor log-analytics query \
 
 ## Sources
 
-- [Azure Functions Blob trigger](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-blob-trigger)
-- [Azure Functions Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Azure Event Grid concepts](https://learn.microsoft.com/azure/event-grid/concepts)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
+- [Azure Functions Blob trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger)
+- [Azure Functions Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Azure Event Grid concepts](https://learn.microsoft.com/en-us/azure/event-grid/concepts)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
 - [Azure Monitor log query overview](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview)

--- a/docs/troubleshooting/playbooks/deployment-failures.md
+++ b/docs/troubleshooting/playbooks/deployment-failures.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Deployment Failures 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
       verified: true
 ---
 
@@ -573,8 +573,8 @@ az functionapp restart \
 - [Deployment and release patterns](../../best-practices/deployment.md)
 - Related Labs: [Cold Start Lab](../lab-guides/cold-start.md)
 ## Sources
-- [Troubleshoot Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
-- [Deployment technologies in Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies)
-- [Run your functions from a package file](https://learn.microsoft.com/azure/azure-functions/run-functions-from-deployment-package)
-- [Azure Functions app settings reference](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Troubleshoot Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
+- [Deployment technologies in Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies)
+- [Run your functions from a package file](https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package)
+- [Azure Functions app settings reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/troubleshooting/playbooks/flex-consumption-deployment.md
+++ b/docs/troubleshooting/playbooks/flex-consumption-deployment.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/storage/common/storage-network-security
+    url: https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-app-settings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Flex Consumption Deployment Gotchas 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
 ---
 
@@ -607,8 +607,8 @@ az functionapp config appsettings list \
 
 ## Sources
 
-- [Flex Consumption plan hosting](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
-- [Create and manage Flex Consumption apps](https://learn.microsoft.com/azure/azure-functions/flex-consumption-how-to)
-- [Azure Functions deployment technologies](https://learn.microsoft.com/azure/azure-functions/functions-deployment-technologies)
-- [Azure Storage firewalls and virtual networks](https://learn.microsoft.com/azure/storage/common/storage-network-security)
-- [Azure Functions app settings reference](https://learn.microsoft.com/azure/azure-functions/functions-app-settings)
+- [Flex Consumption plan hosting](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Create and manage Flex Consumption apps](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to)
+- [Azure Functions deployment technologies](https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies)
+- [Azure Storage firewalls and virtual networks](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security)
+- [Azure Functions app settings reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)

--- a/docs/troubleshooting/playbooks/functions-failing.md
+++ b/docs/troubleshooting/playbooks/functions-failing.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/role-based-access-control/overview
+    url: https://learn.microsoft.com/en-us/azure/role-based-access-control/overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/data-explorer/kusto/query/
+    url: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Functions Failing with Errors 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
       verified: true
 ---
 
@@ -570,8 +570,8 @@ az functionapp restart --resource-group "$RG" --name "$APP_NAME"
 
 ## Sources
 
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Investigate Azure Functions errors with Application Insights](https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Azure RBAC documentation](https://learn.microsoft.com/azure/role-based-access-control/overview)
-- [Kusto Query Language overview](https://learn.microsoft.com/azure/data-explorer/kusto/query/)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Investigate Azure Functions errors with Application Insights](https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Azure RBAC documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/overview)
+- [Kusto Query Language overview](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/)

--- a/docs/troubleshooting/playbooks/functions-not-executing.md
+++ b/docs/troubleshooting/playbooks/functions-not-executing.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/data-explorer/kusto/query/
+    url: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Functions Not Executing 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
       verified: true
 ---
 
@@ -540,8 +540,8 @@ Recovery criteria:
 - [Troubleshooting Lab Guides](../lab-guides/index.md)
 
 ## Sources
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Troubleshoot Azure Functions with Azure Monitor logs](https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data)
-- [Azure Functions trigger and binding concepts](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Kusto Query Language overview](https://learn.microsoft.com/azure/data-explorer/kusto/query/)
-- [Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Troubleshoot Azure Functions with Azure Monitor logs](https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data)
+- [Azure Functions trigger and binding concepts](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Kusto Query Language overview](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/)
+- [Application Insights telemetry data model](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete)

--- a/docs/troubleshooting/playbooks/high-latency.md
+++ b/docs/troubleshooting/playbooks/high-latency.md
@@ -1,20 +1,20 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/data-explorer/kusto/query/
+    url: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "High Latency / Slow Responses 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
       verified: true
 ---
 
@@ -517,7 +517,7 @@ union isfuzzy=true
 - [KQL Query Library](../kql/index.md)
 - [Troubleshooting Playbooks](../playbooks/index.md)
 ## Sources
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Application Insights telemetry data model](https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete)
-- [Kusto Query Language overview](https://learn.microsoft.com/azure/data-explorer/kusto/query/)
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Application Insights telemetry data model](https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete)
+- [Kusto Query Language overview](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/troubleshooting/playbooks/index.md
+++ b/docs/troubleshooting/playbooks/index.md
@@ -1,21 +1,20 @@
 ---
 content_sources:
 
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-- type: mslearn-adapted
-  url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  - type: mslearn-adapted
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 content_validation:
   status: verified
   last_reviewed: '2026-05-23'
   reviewer: agent
   core_claims:
-  - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific
-      guidance.
-    source: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
-    verified: true
+    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
+      verified: true
 ---
 # Incident Playbooks
 
@@ -118,6 +117,6 @@ graph TD
 
 ## Sources
 
-- [Microsoft Learn source 1](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
+- [Microsoft Learn source 1](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
 - [Microsoft Learn source 2](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
 - [Microsoft Learn source 3](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)

--- a/docs/troubleshooting/playbooks/queue-piling-up.md
+++ b/docs/troubleshooting/playbooks/queue-piling-up.md
@@ -1,24 +1,24 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/storage/common/monitor-storage
+    url: https://learn.microsoft.com/en-us/azure/storage/common/monitor-storage
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-monitor/app/analytics
+    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/analytics
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Queue Messages Piling Up 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
       verified: true
 ---
 
@@ -497,9 +497,9 @@ az monitor log-analytics query \
 - [Queue Backlog Scaling Lab](../lab-guides/queue-backlog-scaling.md)
 
 ## Sources
-- [Azure Functions queue trigger](https://learn.microsoft.com/azure/azure-functions/functions-bindings-storage-queue-trigger)
-- [Azure Functions scaling and hosting](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Improve Azure Functions performance and reliability](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Monitor Azure Storage with Azure Monitor metrics](https://learn.microsoft.com/azure/storage/common/monitor-storage)
-- [Analyze telemetry in Application Insights](https://learn.microsoft.com/azure/azure-monitor/app/analytics)
+- [Azure Functions queue trigger](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger)
+- [Azure Functions scaling and hosting](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Improve Azure Functions performance and reliability](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Monitor Azure Storage with Azure Monitor metrics](https://learn.microsoft.com/en-us/azure/storage/common/monitor-storage)
+- [Analyze telemetry in Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/analytics)

--- a/docs/troubleshooting/playbooks/scaling/durable-orchestration-stuck.md
+++ b/docs/troubleshooting/playbooks/scaling/durable-orchestration-stuck.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-code-constraints
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-code-constraints
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-http-api
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-troubleshooting-guide
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-troubleshooting-guide
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Durable Functions Orchestration Stuck Playbook 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
       verified: true
 ---
 
@@ -499,8 +499,8 @@ flowchart TD
 - [Out of memory / worker crash playbook](./out-of-memory-worker-crash.md)
 
 ## Sources
-- [Durable Functions overview](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview)
-- [Durable orchestrations and deterministic code constraints](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-code-constraints)
-- [Durable Functions instance management APIs](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-http-api)
-- [Diagnose and troubleshoot Durable Functions](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-troubleshooting-guide)
-- [Azure Functions scale and hosting guidance](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Durable Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview)
+- [Durable orchestrations and deterministic code constraints](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-code-constraints)
+- [Durable Functions instance management APIs](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-http-api)
+- [Diagnose and troubleshoot Durable Functions](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-troubleshooting-guide)
+- [Azure Functions scale and hosting guidance](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)

--- a/docs/troubleshooting/playbooks/scaling/out-of-memory-worker-crash.md
+++ b/docs/troubleshooting/playbooks/scaling/out-of-memory-worker-crash.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-best-practices
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Out of Memory / Worker Crash Playbook 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
 ---
 
@@ -484,8 +484,8 @@ Plan memory guidance for escalation decisions:
 - [Durable orchestration stuck playbook](./durable-orchestration-stuck.md)
 
 ## Sources
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions best practices](https://learn.microsoft.com/azure/azure-functions/functions-best-practices)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions best practices](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data)
 - [Azure Monitor Logs query in Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview)
-- [Performance and reliability for Azure Functions](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
+- [Performance and reliability for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)

--- a/docs/troubleshooting/playbooks/triggers/event-hub-service-bus-lag.md
+++ b/docs/troubleshooting/playbooks/triggers/event-hub-service-bus-lag.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/event-hubs/event-hubs-features
+    url: https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-features
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-exceptions
+    url: https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-exceptions
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Event Hub / Service Bus Trigger Lag 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
       verified: true
 ---
 
@@ -498,8 +498,8 @@ az functionapp deployment source config-zip --name <app-name> --resource-group <
 - [Timeout / Execution Time Limit Exceeded](./timeout-execution-limit.md)
 
 ## Sources
-- [Azure Functions Event Hubs trigger and bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-event-hubs)
-- [Azure Functions Service Bus trigger and bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-service-bus)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data)
-- [Azure Event Hubs features and performance](https://learn.microsoft.com/azure/event-hubs/event-hubs-features)
-- [Azure Service Bus messaging exceptions and handling](https://learn.microsoft.com/azure/service-bus-messaging/service-bus-messaging-exceptions)
+- [Azure Functions Event Hubs trigger and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs)
+- [Azure Functions Service Bus trigger and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data)
+- [Azure Event Hubs features and performance](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-features)
+- [Azure Service Bus messaging exceptions and handling](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-exceptions)

--- a/docs/troubleshooting/playbooks/triggers/timeout-execution-limit.md
+++ b/docs/troubleshooting/playbooks/triggers/timeout-execution-limit.md
@@ -1,22 +1,22 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/performance-reliability
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
     - claim: "Timeout / Execution Time Limit Exceeded 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/azure/azure-functions/functions-scale
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
       verified: true
 ---
 
@@ -476,8 +476,8 @@ az functionapp deployment source config-zip --name <app-name> --resource-group <
 - [Event Hub / Service Bus Trigger Lag](./event-hub-service-bus-lag.md)
 
 ## Sources
-- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Improve performance and reliability of Azure Functions](https://learn.microsoft.com/azure/azure-functions/performance-reliability)
-- [Azure Functions HTTP trigger and bindings](https://learn.microsoft.com/azure/azure-functions/functions-bindings-http-webhook-trigger)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/analyze-telemetry-data)
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Improve performance and reliability of Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability)
+- [Azure Functions HTTP trigger and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data)

--- a/docs/troubleshooting/quick-diagnosis-cards.md
+++ b/docs/troubleshooting/quick-diagnosis-cards.md
@@ -1,19 +1,19 @@
 ---
 content_sources:
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-diagnostics
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/configure-monitoring
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-scale
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-host-json
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
   - type: mslearn-adapted
-    url: https://learn.microsoft.com/azure/azure-functions/functions-recover-storage-account
+    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-recover-storage-account
 content_validation:
   status: verified
   last_reviewed: 2026-04-12
@@ -468,10 +468,10 @@ exceptions
 
 ## Sources
 
-- [Azure Functions diagnostics](https://learn.microsoft.com/azure/azure-functions/functions-diagnostics)
-- [Monitor Azure Functions](https://learn.microsoft.com/azure/azure-functions/functions-monitoring)
-- [Configure monitoring for Azure Functions](https://learn.microsoft.com/azure/azure-functions/configure-monitoring)
-- [Azure Functions scale and hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
-- [Azure Functions triggers and bindings concepts](https://learn.microsoft.com/azure/azure-functions/functions-triggers-bindings)
-- [Azure Functions host.json reference](https://learn.microsoft.com/azure/azure-functions/functions-host-json)
-- [Recover Azure Functions from errors related to an inaccessible storage account](https://learn.microsoft.com/azure/azure-functions/functions-recover-storage-account)
+- [Azure Functions diagnostics](https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics)
+- [Monitor Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)
+- [Configure monitoring for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring)
+- [Azure Functions scale and hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions triggers and bindings concepts](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions host.json reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [Recover Azure Functions from errors related to an inaccessible storage account](https://learn.microsoft.com/en-us/azure/azure-functions/functions-recover-storage-account)

--- a/scripts/generate_content_validation_status.py
+++ b/scripts/generate_content_validation_status.py
@@ -283,7 +283,7 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
     lines.append("---")
     lines.append("content_sources:")
     lines.append("  - type: mslearn-adapted")
-    lines.append("    url: https://learn.microsoft.com/azure/azure-functions/...")
+    lines.append("    url: https://learn.microsoft.com/en-us/azure/azure-functions/...")
     lines.append("content_validation:")
     lines.append("  status: verified")
     lines.append("  last_reviewed: 2026-04-12")
@@ -291,7 +291,7 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
     lines.append("  core_claims:")
     lines.append('    - claim: "Flex Consumption supports VNet integration"')
     lines.append(
-        "      source: https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan"
+        "      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan"
     )
     lines.append("      verified: true")
     lines.append("---")

--- a/scripts/lib/__init__.py
+++ b/scripts/lib/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helper modules for `scripts/`."""

--- a/scripts/lib/content_scope.py
+++ b/scripts/lib/content_scope.py
@@ -1,0 +1,133 @@
+"""Shared scope policy for ``content_validation`` enforcement.
+
+Defines which markdown files in ``docs/`` are required to carry the
+``content_validation:`` frontmatter block (factual-claim pages) versus those
+that are out of scope for the dashboard and cleanup tool (navigation indexes,
+KQL packs, lab guides, tutorials, reference look-ups, and other non-claim
+content).
+
+Out-of-scope pages are not counted by
+``scripts/generate_content_validation_status.py`` and are not required to
+carry a ``content_validation`` block. Legacy blocks may still exist on some
+out-of-scope pages from before this scope policy was formalized; they are
+accepted but not tracked, and will be reviewed in a follow-up editorial pass.
+New out-of-scope pages should not add the block.
+
+Imported by:
+
+- ``scripts/generate_content_validation_status.py``
+- ``scripts/remove_out_of_scope_validation.py``
+
+The policy MUST stay in sync with ``AGENTS.md`` §Text Content Validation.
+If you change the rules here, update ``AGENTS.md`` in the same commit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+SCANNED_SECTIONS: frozenset[str] = frozenset(
+    {
+        "platform",
+        "best-practices",
+        "operations",
+        "troubleshooting",
+    }
+)
+
+EXCLUDED_SUBPATHS: tuple[str, ...] = (
+    "troubleshooting/kql/",
+    "troubleshooting/lab-guides/",
+)
+
+NAVIGATION_INDEXES: frozenset[str] = frozenset(
+    {
+        "platform/index.md",
+        "best-practices/index.md",
+        "operations/index.md",
+        "troubleshooting/index.md",
+        "troubleshooting/first-10-minutes/index.md",
+        "troubleshooting/playbooks/index.md",
+    }
+)
+
+TAUTOLOGICAL_CLAIM_MARKER: str = "primary source basis"
+
+
+def is_in_scope(rel_path: Union[Path, str]) -> bool:
+    """Return ``True`` if ``rel_path`` requires a ``content_validation`` block.
+
+    ``rel_path`` must be relative to ``docs/``. The policy is applied in this
+    order:
+
+    1. The first path component must be a ``SCANNED_SECTION``.
+    2. The path must NOT start with any ``EXCLUDED_SUBPATHS`` prefix.
+    3. The path must NOT be a ``NAVIGATION_INDEXES`` entry.
+
+    Examples:
+
+    >>> from pathlib import Path
+    >>> is_in_scope("platform/scaling.md")
+    True
+    >>> is_in_scope("platform/architecture/index.md")  # factual subsection landing
+    True
+    >>> is_in_scope("platform/networking-scenarios/index.md")  # factual subsection landing
+    True
+    >>> is_in_scope("platform/index.md")  # navigation
+    False
+    >>> is_in_scope("troubleshooting/playbooks/high-latency.md")
+    True
+    >>> is_in_scope("troubleshooting/kql/scaling/index.md")  # excluded subpath
+    False
+    >>> is_in_scope("troubleshooting/lab-guides/cold-start.md")
+    False
+    >>> is_in_scope("language-guides/python/tutorial/01-deploy.md")  # outside sections
+    False
+    >>> is_in_scope("start-here/overview.md")  # outside sections
+    False
+    """
+    rel = Path(rel_path)
+    parts = rel.parts
+    if not parts or parts[0] not in SCANNED_SECTIONS:
+        return False
+
+    posix = rel.as_posix()
+    if any(posix.startswith(prefix) for prefix in EXCLUDED_SUBPATHS):
+        return False
+
+    if posix in NAVIGATION_INDEXES:
+        return False
+
+    return True
+
+
+def is_tautological_text(text: object) -> bool:
+    """Return ``True`` if ``text`` contains the tautological marker.
+
+    The match is case-insensitive (uses :py:meth:`str.casefold`) so variants
+    like ``"Primary Source Basis"`` or ``"PRIMARY SOURCE BASIS"`` are caught.
+    Non-string inputs return ``False``.
+
+    >>> is_tautological_text("uses Microsoft Learn as the primary source basis")
+    True
+    >>> is_tautological_text("PRIMARY SOURCE BASIS")
+    True
+    >>> is_tautological_text("Azure Functions supports Flex Consumption hosting")
+    False
+    >>> is_tautological_text(None)
+    False
+    """
+    if not isinstance(text, str):
+        return False
+    return TAUTOLOGICAL_CLAIM_MARKER.casefold() in text.casefold()
+
+
+__all__ = [
+    "SCANNED_SECTIONS",
+    "EXCLUDED_SUBPATHS",
+    "NAVIGATION_INDEXES",
+    "TAUTOLOGICAL_CLAIM_MARKER",
+    "is_in_scope",
+    "is_tautological_text",
+]

--- a/scripts/lib/content_scope.py
+++ b/scripts/lib/content_scope.py
@@ -2,21 +2,25 @@
 
 Defines which markdown files in ``docs/`` are required to carry the
 ``content_validation:`` frontmatter block (factual-claim pages) versus those
-that are out of scope for the dashboard and cleanup tool (navigation indexes,
-KQL packs, lab guides, tutorials, reference look-ups, and other non-claim
-content).
+that are out of scope (navigation indexes, KQL packs, lab guides, tutorials,
+reference look-ups, and other non-claim content).
 
-Out-of-scope pages are not counted by
-``scripts/generate_content_validation_status.py`` and are not required to
-carry a ``content_validation`` block. Legacy blocks may still exist on some
-out-of-scope pages from before this scope policy was formalized; they are
-accepted but not tracked, and will be reviewed in a follow-up editorial pass.
-New out-of-scope pages should not add the block.
+Out-of-scope pages are not required to carry a ``content_validation`` block.
+Legacy blocks may still exist on some out-of-scope pages from before this
+scope policy was formalized; they are accepted, and a follow-up editorial
+pass will remove them. New out-of-scope pages should not add the block.
 
 Imported by:
 
-- ``scripts/generate_content_validation_status.py``
 - ``scripts/remove_out_of_scope_validation.py``
+
+The dashboard generator (``scripts/generate_content_validation_status.py``)
+still uses its legacy local ``SCAN_SECTIONS`` list and ``index.md`` skip
+heuristic, so the current dashboard may still surface a few out-of-scope
+pages (notably lab guides under ``troubleshooting/lab-guides/``). Migrating
+the generator to ``is_in_scope`` is the strict-validator sync planned for a
+follow-up PR; until then this module is the *authoritative* scope policy and
+the dashboard's behavior is *aspirational*.
 
 The policy MUST stay in sync with ``AGENTS.md`` §Text Content Validation.
 If you change the rules here, update ``AGENTS.md`` in the same commit.

--- a/scripts/lib/yaml_style.py
+++ b/scripts/lib/yaml_style.py
@@ -1,0 +1,76 @@
+"""Canonical YAML serialization for documentation frontmatter.
+
+Centralizes the ``ruamel.yaml.YAML`` configuration used by every script that
+mutates Markdown frontmatter so the output is byte-stable across runs and
+across tools. PyYAML's ``yaml.dump()`` aggressively quotes dates, flattens
+nested sequences, and flows multi-line strings; routing all mutations through
+this module prevents that drift.
+
+Style rules (must stay in sync with ``AGENTS.md`` §Frontmatter YAML Style):
+
+- Block style for mappings and sequences (no flow style).
+- Indentation: ``mapping=2, sequence=4, offset=2`` -- each list item's hyphen
+  is at column 2 and its content at column 4, matching the historical layout.
+- Quoting: preserved from the source (``preserve_quotes=True``) so existing
+  files are normalized for *structure* without rewriting quoted dates,
+  intentionally-quoted strings, or block-scalar form.
+- Line width: practically disabled (``width = 4096``) so long ``claim`` and
+  ``summary`` strings stay on one line instead of folding.
+- Explicit document end: disabled (``explicit_end = False``) -- frontmatter
+  is delimited by ``---`` on its own, no ``...`` terminator.
+
+Consumed by:
+
+- ``scripts/normalize_yaml_frontmatter.py`` (bulk normalizer + CI check).
+- Any future generator or mutation tool MUST import :func:`dump_frontmatter`
+  (preferred, single-call) or :func:`build_yaml` (when you need to call
+  ``load`` and ``dump`` on the same instance). Direct use of PyYAML's
+  ``yaml.dump`` is banned.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from ruamel.yaml import YAML
+
+__all__ = ["build_yaml", "dump_frontmatter", "CANONICAL_INDENT"]
+
+# Captured for documentation/tests; mirror in ``AGENTS.md`` if changed.
+CANONICAL_INDENT: dict[str, int] = {
+    "mapping": 2,
+    "sequence": 4,
+    "offset": 2,
+}
+
+
+def build_yaml() -> YAML:
+    """Return a configured ``ruamel.yaml.YAML`` instance for frontmatter I/O.
+
+    Each call returns a fresh instance because ``YAML`` carries mutable state
+    (anchors, comments) across load/dump pairs; sharing one instance across
+    files would leak that state and produce inconsistent output.
+    """
+    yaml = YAML(typ="rt")
+    yaml.indent(**CANONICAL_INDENT)
+    yaml.preserve_quotes = True
+    yaml.width = 4096
+    yaml.explicit_end = False
+    return yaml
+
+
+def dump_frontmatter(data: object, *, trailing_newline: bool = True) -> str:
+    """Serialize ``data`` (a ruamel.yaml CommentedMap / dict) to canonical YAML.
+
+    Returns the YAML body only -- the caller is responsible for wrapping it in
+    the ``---`` / ``---`` frontmatter delimiters. The output always ends with
+    a single newline when ``trailing_newline`` is true so callers can splice
+    it cleanly between the closing ``---`` and the document body.
+    """
+    yaml = build_yaml()
+    buffer = StringIO()
+    yaml.dump(data, buffer)
+    text = buffer.getvalue()
+    if trailing_newline and not text.endswith("\n"):
+        text = text + "\n"
+    return text

--- a/scripts/normalize_mslearn_locale.py
+++ b/scripts/normalize_mslearn_locale.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Normalize Microsoft Learn URLs to use the ``en-us`` locale prefix.
+
+Microsoft Learn URLs accept any locale prefix (``en-us``, ``ja-jp``, ``ko-kr``)
+and ALSO accept a locale-free form that redirects to the visitor's
+geo-detected locale. This produces three problems:
+
+1. **Inconsistency.** The same article links to multiple URL shapes across
+   pages, which leaks into search indexes and confuses readers.
+2. **Implicit geo-redirect.** Locale-free URLs serve different content per
+   reader location, so screenshots, anchors, and quoted excerpts drift.
+3. **Reviewer cognitive load.** Mixed forms force reviewers to mentally
+   normalize URLs when comparing sources.
+
+This script enforces a single canonical form: every ``learn.microsoft.com``
+URL MUST include the ``en-us`` locale prefix.
+
+The script:
+
+1. Walks the project tree (defaulting to the repo root) with an explicit
+   file-type allowlist.
+2. Rewrites every Microsoft Learn URL to use the ``en-us`` locale prefix:
+
+   - URLs whose first path segment is a generic doc-tree name (such as
+     ``azure/`` or ``cli/``) get ``en-us/`` inserted between the hostname
+     and the segment.
+   - URLs whose first path segment is any non-``en-us`` locale (such as
+     ``ja-jp/``, ``zh-Hans/``, or ``en-US/``) have the locale segment
+     replaced with ``en-us/``.
+   - URLs whose first path segment is a known non-locale root (the Learn
+     catalog API root ``api/``) are left unchanged so we do not produce
+     a 404.
+
+3. Writes back when the result differs.
+
+Modes:
+
+- ``--check`` (default): exit code 1 if any file would change. Suitable
+  for CI and pre-commit hooks.
+- ``--apply``: write changes to disk.
+
+This script preserves the repo invariant of **UTF-8 without BOM, LF line
+endings**. Files outside that invariant are handled defensively: BOM is
+preserved byte-for-byte when no rewrite is needed; CRLF files would be
+re-encoded as LF on ``--apply`` (no CRLF files exist in this repo today).
+Binary files are detected via UTF-8 decode failure and skipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# Capture the first path segment after the ``learn.microsoft.com/`` hostname
+# so a per-match function can decide whether to insert, replace, or leave
+# the locale alone. A naive "insert en-us unless an xx-xx/ locale is already
+# present" regex corrupts four real-world URL shapes:
+#   1. The Learn catalog API root segment ``api/`` (no locale exists; would 404)
+#   2. Title-Case locale variants such as ``en-US/`` (old AGENTS.md guidance)
+#   3. Script-tag locale variants such as ``zh-Hans/`` (valid Learn locale)
+#   4. Non-Learn hosts whose name ends in ``learn.microsoft.com`` because of a
+#      substring (``mylearn.microsoft.com``), a hyphenated prefix
+#      (``my-learn.microsoft.com``), or a subdomain
+#      (``foo.learn.microsoft.com``). A leading ``\b`` is NOT sufficient
+#      because ``-`` and ``.`` are non-word characters and produce a word
+#      boundary before ``l``. The negative lookbehind ``(?<![\w.-])`` rejects
+#      every hostname-valid character (letters, digits, underscore, dot,
+#      hyphen) so only a non-hostname separator (``/``, ``(``, ``"``,
+#      whitespace, start-of-string, etc.) is allowed immediately before
+#      ``learn``.
+LEARN_URL_RE = re.compile(
+    r"(?<![\w.-])learn\.microsoft\.com/(?P<seg>[A-Za-z]+(?:-[A-Za-z]+)?)/"
+)
+
+# Lowercase two-letter language-region form currently used by Learn article
+# locales (``en-us``, ``ja-jp``, ``ko-kr``), broadened to also recognize
+# Title-Case script tags (``zh-Hans``, ``zh-Hant``) and mixed case (``en-US``)
+# that historical pasted URLs may still carry.
+LOCALE_SHAPE_RE = re.compile(r"^[A-Za-z]{2,3}-[A-Za-z]{2,4}$")
+
+# Path segments that legitimately appear immediately after the hostname
+# WITHOUT a locale prefix. The Learn catalog API root segment ``api/``
+# returns 404 if a locale is prepended.
+NON_LOCALE_ROOTS = frozenset({"api"})
+
+CANONICAL_LOCALE = "en-us"
+
+
+def _normalize_match(match: re.Match) -> str:
+    seg = match.group("seg")
+    if seg == CANONICAL_LOCALE:
+        return match.group(0)
+    if LOCALE_SHAPE_RE.match(seg):
+        return f"learn.microsoft.com/{CANONICAL_LOCALE}/"
+    if seg.lower() in NON_LOCALE_ROOTS:
+        return match.group(0)
+    return f"learn.microsoft.com/{CANONICAL_LOCALE}/{seg}/"
+
+
+def normalize_text(text: str) -> tuple[str, int]:
+    """Return ``(new_text, replacements_made)``.
+
+    ``replacements_made`` counts ACTUAL URL changes, not regex matches.
+    A match where ``_normalize_match`` returns the original text (e.g.
+    already-canonical ``en-us`` URL or a ``/api/`` root) does NOT count.
+    Callers rely on a zero count meaning "no rewrite needed" so they can
+    skip writing the file back to disk.
+    """
+    changes = 0
+
+    def _wrapped(match: re.Match) -> str:
+        nonlocal changes
+        original = match.group(0)
+        replacement = _normalize_match(match)
+        if replacement != original:
+            changes += 1
+        return replacement
+
+    new_text, _matches = LEARN_URL_RE.subn(_wrapped, text)
+    return new_text, changes
+
+
+EXTENSIONS = frozenset(
+    {".md", ".py", ".yml", ".yaml", ".json", ".bicep", ".tf", ".txt"}
+)
+SPECIAL_FILES = frozenset({"Dockerfile", "sshd_config", "AGENTS.md"})
+
+SKIP_DIRS = frozenset(
+    {
+        ".git",
+        ".playwright-mcp",
+        "node_modules",
+        "site",
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".pytest_cache",
+        ".mypy_cache",
+        "dist",
+        "build",
+        ".tox",
+    }
+)
+
+
+def is_scannable(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    if set(path.parts) & SKIP_DIRS:
+        return False
+    if path.suffix in EXTENSIONS:
+        return True
+    if path.name in SPECIAL_FILES:
+        return True
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scan-root",
+        type=Path,
+        default=Path("."),
+        help=(
+            "Path to scan (default: repo root). MUST be inside the project "
+            "root; absolute paths or ``..`` traversal that escape the project "
+            "are rejected."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if any file would change (CI mode, default)",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write changes to disk",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-file output",
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parent.parent
+    scan_root = (project_root / args.scan_root).resolve()
+    try:
+        scan_root.relative_to(project_root)
+    except ValueError:
+        print(
+            f"Error: --scan-root must be inside the project root "
+            f"({project_root}); refusing to scan {scan_root}",
+            file=sys.stderr,
+        )
+        return 1
+    if not scan_root.exists():
+        print(f"Error: scan root not found: {scan_root}", file=sys.stderr)
+        return 1
+
+    changed: list[Path] = []
+    skipped_binary: list[Path] = []
+    scanned = 0
+    total_replacements = 0
+
+    # os.walk + in-place dir mutation prunes descent into SKIP_DIRS. Switching
+    # to ``Path.rglob`` with a post-filter would still descend into ``.git``,
+    # ``node_modules``, and ``site`` (tens of thousands of generated files),
+    # making scans significantly slower because the walk visits every entry
+    # before the filter can reject it.
+    for current_dir, dirs, files in os.walk(scan_root):
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        for filename in sorted(files):
+            path = Path(current_dir) / filename
+            if not is_scannable(path):
+                continue
+            scanned += 1
+            try:
+                text = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                skipped_binary.append(path)
+                continue
+            except PermissionError as exc:
+                print(f"  WARN  {path}  [{exc}]", file=sys.stderr)
+                continue
+
+            new_text, count = normalize_text(text)
+            if count == 0:
+                continue
+
+            changed.append(path)
+            total_replacements += count
+            try:
+                rel = path.relative_to(project_root)
+            except ValueError:
+                rel = path
+            if args.apply:
+                path.write_text(new_text, encoding="utf-8")
+                if not args.quiet:
+                    print(f"  FIXED  {rel}  ({count} URL{'s' if count != 1 else ''})")
+            else:
+                if not args.quiet:
+                    print(f"  DRIFT  {rel}  ({count} URL{'s' if count != 1 else ''})")
+
+    print("")
+    print("Summary:")
+    print(f"  Files scanned: {scanned}")
+    print(f"  Files with locale drift: {len(changed)}")
+    print(f"  Total URLs needing en-us prefix: {total_replacements}")
+    if skipped_binary and not args.quiet:
+        print(f"  Skipped (binary/non-UTF-8): {len(skipped_binary)}")
+
+    if changed and not args.apply:
+        print("")
+        print(
+            "Drift detected. Run "
+            "`python3 scripts/normalize_mslearn_locale.py --apply` "
+            "to fix."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/normalize_yaml_frontmatter.py
+++ b/scripts/normalize_yaml_frontmatter.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Normalize Markdown frontmatter to the canonical ``ruamel.yaml`` style.
+
+PyYAML's ``yaml.dump()`` reformats frontmatter aggressively each time a tool
+touches it (quoting dates, flattening nested sequences, folding multi-line
+strings). This produces large noisy diffs and means style drifts whenever any
+automation runs. This script:
+
+1. Walks ``docs/**/*.md``.
+2. Round-trips frontmatter through the shared :mod:`lib.yaml_style`
+   configuration (block style, ``mapping=2 sequence=4 offset=2``,
+   quotes preserved, width practically disabled).
+3. Writes back when the result differs.
+
+Modes:
+
+- ``--check`` (default): exit code 1 if any file would change. Suitable for
+  CI and pre-commit hooks.
+- ``--apply``: write changes to disk.
+
+The script preserves the markdown body verbatim for the current repo
+invariant of **UTF-8 without BOM, LF line endings**. Files outside that
+invariant are handled defensively rather than transparently:
+
+- **BOM-prefixed files** are skipped silently because the leading
+  ``\ufeff`` makes the frontmatter regex miss; the file is left untouched.
+- **CRLF files** are read with Python's universal-newlines (``\r\n`` -> ``\n``)
+  and would be written back as LF on ``--apply``, which is a body change.
+  No CRLF files exist in this repo today; if that ever changes, document
+  the line-ending policy first or extend this script to preserve the
+  original line ending.
+
+The repo invariant is documented in ``AGENTS.md`` Frontmatter YAML Style.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib.yaml_style import build_yaml, dump_frontmatter  # noqa: E402
+
+# Matches a frontmatter delimiter pair: ``---\n...\n---\n``. The body is
+# captured separately so it is preserved byte-for-byte during normalization.
+#
+# Uses ``[ \t]*`` (horizontal whitespace only) rather than ``\s*`` because
+# ``\s`` includes ``\n``: greedy ``\s*\n`` would swallow a blank line that
+# follows the closing ``---``, silently deleting the conventional blank line
+# between frontmatter and the first heading.
+FRONTMATTER = re.compile(r"^---[ \t]*\n(.*?)\n---[ \t]*\n", re.DOTALL)
+
+
+def normalize_text(text: str) -> tuple[str, bool]:
+    """Return ``(new_text, changed)``.
+
+    ``changed`` is False when the file has no frontmatter or when the
+    round-trip produces byte-identical output, so callers can detect drift
+    without comparing strings themselves.
+    """
+    match = FRONTMATTER.match(text)
+    if not match:
+        return text, False
+
+    yaml_text = match.group(1)
+    body = text[match.end() :]
+
+    data = build_yaml().load(yaml_text)
+    if data is None:
+        return text, False
+
+    new_yaml = dump_frontmatter(data)
+    new_text = f"---\n{new_yaml}---\n" + body
+    return new_text, new_text != text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--docs-dir",
+        type=Path,
+        default=Path("docs"),
+        help="Path to docs directory (default: docs)",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if any file would change (CI mode, default)",
+    )
+    mode.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write changes to disk",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-file output",
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parent.parent
+    docs_dir = (project_root / args.docs_dir).resolve()
+    try:
+        docs_dir.relative_to(project_root)
+    except ValueError:
+        print(
+            f"Error: --docs-dir must be inside the project root "
+            f"({project_root}); refusing to scan {docs_dir}",
+            file=sys.stderr,
+        )
+        return 1
+    if not docs_dir.exists():
+        print(f"Error: docs directory not found: {docs_dir}", file=sys.stderr)
+        return 1
+
+    changed: list[Path] = []
+    errors: list[tuple[Path, str]] = []
+    scanned = 0
+
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        scanned += 1
+        text = md_file.read_text(encoding="utf-8")
+        try:
+            new_text, did_change = normalize_text(text)
+        except Exception as exc:
+            errors.append((md_file, str(exc)))
+            if not args.quiet:
+                rel = md_file.relative_to(project_root)
+                print(f"  ERROR  {rel}  [{exc}]")
+            continue
+
+        if not did_change:
+            continue
+
+        changed.append(md_file)
+        rel = md_file.relative_to(project_root)
+        if args.apply:
+            md_file.write_text(new_text, encoding="utf-8")
+            if not args.quiet:
+                print(f"  FIXED  {rel}")
+        else:
+            if not args.quiet:
+                print(f"  DRIFT  {rel}")
+
+    print("")
+    print("Summary:")
+    print(f"  Files scanned: {scanned}")
+    print(f"  Files with style drift: {len(changed)}")
+    print(f"  Parse errors: {len(errors)}")
+
+    if errors:
+        print("")
+        print("Parse errors (require manual review):")
+        for md_file, msg in errors:
+            print(f"  - {md_file.relative_to(project_root)}: {msg}")
+        return 1
+
+    if changed and not args.apply:
+        print("")
+        print(
+            "Drift detected. Run "
+            "`python3 scripts/normalize_yaml_frontmatter.py --apply` "
+            "to fix."
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/remove_out_of_scope_validation.py
+++ b/scripts/remove_out_of_scope_validation.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Remove ``content_validation`` blocks from out-of-scope documentation pages.
+
+A page is considered out-of-scope for ``content_validation`` when
+:func:`lib.content_scope.is_in_scope` returns ``False`` for its docs-relative
+path - that is, navigation indexes, KQL packs (``troubleshooting/kql/``),
+lab guides (``troubleshooting/lab-guides/``), tutorials
+(``language-guides/``), reference look-ups (``docs/reference/``), and any other
+section outside ``SCANNED_SECTIONS``.
+
+This script:
+
+1. Walks ``docs/`` and selects files whose path is out-of-scope.
+2. Surgically strips the ``content_validation:`` block from frontmatter using
+   the same anchored regex as :mod:`remove_tautological_validation` so that
+   all other keys, ordering, and quoting are preserved.
+
+The scope policy lives in :mod:`lib.content_scope`; this script is the
+canonical tool for one-time cleanup of legacy out-of-scope
+``content_validation`` blocks that pre-date the scope policy (the "follow-up
+editorial pass" noted in ``AGENTS.md`` §Text Content Validation).
+
+Usage:
+    python3 scripts/remove_out_of_scope_validation.py             # dry-run
+    python3 scripts/remove_out_of_scope_validation.py --apply     # write
+    python3 scripts/remove_out_of_scope_validation.py --apply --quiet
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from lib.content_scope import is_in_scope  # noqa: E402
+
+# Regex shared semantics with ``remove_tautological_validation``: anchored to a
+# top-level ``content_validation:`` key and consumes its indented YAML body
+# until the next top-level key. Duplicated literally (not imported) so each
+# script remains self-contained and easy to audit in isolation.
+CONTENT_VALIDATION_BLOCK = re.compile(
+    r"^content_validation:[ \t]*\n"
+    r"(?:[ \t]+[^\n]*\n|[ \t]*\n)*",
+    re.MULTILINE,
+)
+
+FRONTMATTER_DELIMITER = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def split_frontmatter(text: str) -> tuple[str | None, str]:
+    """Return ``(yaml_text, body)`` or ``(None, text)`` if no frontmatter."""
+    match = FRONTMATTER_DELIMITER.match(text)
+    if not match:
+        return None, text
+    return match.group(1), text[match.end() :]
+
+
+def remove_content_validation(text: str) -> tuple[str, int]:
+    """Strip the ``content_validation`` block from frontmatter.
+
+    Returns ``(new_text, n)`` where ``n`` is the number of blocks removed
+    (0 means the file was already clean and is returned unchanged).
+    """
+    yaml_text, body = split_frontmatter(text)
+    if yaml_text is None:
+        return text, 0
+
+    if not yaml_text.endswith("\n"):
+        yaml_text = yaml_text + "\n"
+
+    new_yaml, n = CONTENT_VALIDATION_BLOCK.subn("", yaml_text)
+    if n == 0:
+        return text, 0
+
+    return f"---\n{new_yaml}---\n" + body, n
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--docs-dir",
+        type=Path,
+        default=Path("docs"),
+        help="Path to docs directory (default: docs)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write changes to disk (default: dry-run)",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress per-file output",
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parent.parent
+    docs_dir = project_root / args.docs_dir
+    if not docs_dir.exists():
+        print(f"Error: docs directory not found: {docs_dir}", file=sys.stderr)
+        return 1
+
+    removed: list[Path] = []
+    scanned = 0
+
+    for md_file in sorted(docs_dir.rglob("*.md")):
+        scanned += 1
+        rel = md_file.relative_to(docs_dir)
+        if is_in_scope(rel):
+            continue
+
+        text = md_file.read_text(encoding="utf-8")
+        yaml_text, _ = split_frontmatter(text)
+        if yaml_text is None or "content_validation:" not in yaml_text:
+            continue
+
+        new_text, n = remove_content_validation(text)
+        if n == 0:
+            if not args.quiet:
+                print(f"  SKIP   {rel}  [regex did not match - manual review]")
+            continue
+
+        if args.apply:
+            md_file.write_text(new_text, encoding="utf-8")
+            if not args.quiet:
+                print(f"  REMOVE {rel}")
+        else:
+            if not args.quiet:
+                print(f"  WOULD  {rel}")
+
+        removed.append(md_file)
+
+    print("")
+    print("Summary:")
+    print(f"  Files scanned: {scanned}")
+    print(f"  Out-of-scope content_validation blocks removed: {len(removed)}")
+    if not args.apply and removed:
+        print("")
+        print("Dry-run only. Re-run with --apply to write changes.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/remove_out_of_scope_validation.py
+++ b/scripts/remove_out_of_scope_validation.py
@@ -12,8 +12,8 @@ This script:
 
 1. Walks ``docs/`` and selects files whose path is out-of-scope.
 2. Surgically strips the ``content_validation:`` block from frontmatter using
-   the same anchored regex as :mod:`remove_tautological_validation` so that
-   all other keys, ordering, and quoting are preserved.
+   an anchored regex so that all other keys, ordering, and quoting are
+   preserved.
 
 The scope policy lives in :mod:`lib.content_scope`; this script is the
 canonical tool for one-time cleanup of legacy out-of-scope
@@ -37,10 +37,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from lib.content_scope import is_in_scope  # noqa: E402
 
-# Regex shared semantics with ``remove_tautological_validation``: anchored to a
-# top-level ``content_validation:`` key and consumes its indented YAML body
-# until the next top-level key. Duplicated literally (not imported) so each
-# script remains self-contained and easy to audit in isolation.
+# Regex anchored to a top-level ``content_validation:`` key that consumes its
+# indented YAML body until the next top-level key. Kept inline (no shared
+# helper) so this script stays self-contained and auditable in isolation.
 CONTENT_VALIDATION_BLOCK = re.compile(
     r"^content_validation:[ \t]*\n"
     r"(?:[ \t]+[^\n]*\n|[ \t]*\n)*",


### PR DESCRIPTION
## Summary

Brings Functions to parity with ACA's recently merged PR #193 by adopting the same `lib/` + normalizer toolchain that App Service and ACA already use. All three sibling Azure practical guides now converge on identical canonical tooling for frontmatter normalization, MSLearn URL locale enforcement, and shared scope policy.

This is **PR 2d.1b** in the 3-PR Phase 2d roadmap. PR 2d.2 (atomic content migration + strict validator sync) and PR 2d.3 (legacy out-of-scope cleanup) are planned follow-ups.

## What This PR Does

### 1. Adds `scripts/lib/` shared helpers (3 files, 212 lines)

- **`lib/__init__.py`** — package marker
- **`lib/content_scope.py`** (135 lines) — scope policy single source of truth for `content_validation` blocks. Defines `SCANNED_SECTIONS`, `EXCLUDED_SUBPATHS`, `NAVIGATION_INDEXES`. Functions-specific NAVIGATION_INDEXES has 6 entries (no `operations/deployment/index.md` since Functions `operations/` is flat). Includes `is_in_scope()` and `is_tautological_text()` with 14 doctests (all pass).
- **`lib/yaml_style.py`** (76 lines) — byte-identical to App Service. Centralized ruamel.yaml (`typ='rt'`) configuration with `dump_frontmatter()` public API. Bans direct PyYAML `yaml.dump()` use.

### 2. Adds 3 normalization/cleanup scripts

- **`normalize_mslearn_locale.py`** — enforces `en-us/` prefix on all Microsoft Learn URLs across `.md`, `.py`, `.yml`, `.yaml`, `.json`, `.bicep`, `.tf`, `.txt` files
- **`normalize_yaml_frontmatter.py`** — enforces canonical ruamel.yaml style on all `docs/` frontmatter via `lib.yaml_style`
- **`remove_out_of_scope_validation.py`** — removes legacy `content_validation` blocks from out-of-scope pages (**NOT run in this PR** — 244 blocks deferred to follow-up editorial pass)

### 3. Applies mechanical cleanup from the new normalizers

- **300 docs files / 2309 URLs** locale-fixed (`https://learn.microsoft.com/azure/...` → `https://learn.microsoft.com/en-us/azure/...`)
- **231 docs frontmatter blocks** normalized to canonical ruamel.yaml style
- **2 hardcoded URL strings** in `generate_content_validation_status.py` also locale-fixed (mechanical side-effect, same pattern as ACA)
- `docs/reference/content-validation-status.md` regenerated

### 4. Updates `AGENTS.md`

- **Expanded Text Content Validation section** — now documents the `content_scope.py`-based scope policy with `EXCLUDED_SUBPATHS`, `NAVIGATION_INDEXES`, and out-of-scope sections. Records the 244 legacy out-of-scope blocks that will be cleaned up in a follow-up editorial pass.
- **New Frontmatter YAML Style section** — documents the canonical ruamel.yaml configuration (indent/quoting/width/explicit_end) and the workflow CI enforcement contract.

### 5. Updates `.github/workflows/validate-content-sources.yml`

- Broadens `pull_request`/`push` path filters to match the `EXTENSIONS` set in `normalize_mslearn_locale.py`. Adds `apps/**`, `labs/**`, `infra/**`, `AGENTS.md`, `README*.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `.github/workflows/**`. Includes invariant-comment block warning against narrowing back.
- Adds `'ruamel.yaml==0.19.1'` to pip install (pinned for reproducible canonical bytes across CI runs)
- Adds 2 **strict** check steps (no `continue-on-error`):
  - `normalize_yaml_frontmatter.py --check`
  - `normalize_mslearn_locale.py --check`
- Preserves all existing Functions-specific lenient steps (`validate_doc_quality --changed-only`, `validate_cli_explanations`, mermaid-block exclusions for `content-validation-status.md` / `validation-status.md`)

## What This PR Intentionally Does NOT Do

- **Does NOT modify `generate_content_validation_status.py`** to import `lib/content_scope` (validator remains lenient with hardcoded scope policy). This synchronization is deferred to PR 2d.2 along with atomic content migration of the 294 list-form + 8 partial-dict `content_validation` blocks to the strict canonical schema.
- **Does NOT remove the 244 legacy out-of-scope `content_validation` blocks** (mirror of ACA's 107 deferred blocks — both to be addressed in separate follow-up editorial passes).

## Verification

| Check | Result |
|---|---|
| `normalize_yaml_frontmatter.py --check` | 0 drift across 303 files |
| `normalize_mslearn_locale.py --check` | 0 drift across 380 files / 0 URLs needing en-us prefix |
| `content_scope.py` doctests | 14/14 pass |
| `validate_mermaid_format.py` | 303 files, 0 errors |
| `validate_mermaid_syntax.py` | 498 diagrams, 0 errors |
| `validate_content_sources.py` | 303 files, 0 errors |
| `mkdocs build --strict` | passes in 28.61s |

**Pre-existing lenient validator errors** (138 doc_quality + 44 cli_explanations) are not caused by this PR and are gated by `continue-on-error: true` in the workflow.

## Phase 2d Strategy Context

| PR | Status | Scope |
|---|---|---|
| **ACA PR 2d.1a** (#193) | MERGED (`8fb31d2`) | Adopt scripts + mechanical cleanup |
| **Functions PR 2d.1b** (this PR) | OPEN | Adopt scripts + mechanical cleanup |
| **Functions PR 2d.2** | PLANNED | Atomic content migration of 294 list-form + 8 partial-dict + strict validator sync |
| **Follow-up editorial passes** | PLANNED | 107 ACA + 244 Functions legacy out-of-scope blocks (separate PR each) |

After all three repos complete Phase 2d, Phase 3 will fully align workflows and mkdocs.yml across the sibling repos.