### PR TITLE
refactor(validation): align content validation dashboard with content_scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ Every Mermaid diagram must have source metadata in frontmatter.
 
 Factual-claim documents include a `content_validation` block in frontmatter to track the verification status of their core technical assertions.
 
-The single source of truth for "is this page in scope?" is [`scripts/lib/content_scope.py`](scripts/lib/content_scope.py) — specifically the `is_in_scope(rel_path)` function. The out-of-scope cleanup tool (`scripts/remove_out_of_scope_validation.py`) imports this helper. The dashboard generator (`scripts/generate_content_validation_status.py`) still uses its legacy local `SCAN_SECTIONS` list and `index.md` skip heuristic, and will be migrated to `content_scope.is_in_scope` in the strict-validator sync follow-up PR; until then the dashboard may surface a few out-of-scope pages (notably lab guides under `troubleshooting/lab-guides/`) that pre-date this scope policy. If you change the scope policy, update both `scripts/lib/content_scope.py` AND this section in the same commit.
+The single source of truth for "is this page in scope?" is [`scripts/lib/content_scope.py`](scripts/lib/content_scope.py) — specifically the `is_in_scope(rel_path)` function. Both the dashboard generator (`scripts/generate_content_validation_status.py`) and the out-of-scope cleanup tool (`scripts/remove_out_of_scope_validation.py`) import this helper, so the dashboard and the cleanup tool are guaranteed to agree on scope. If you change the scope policy, update both `scripts/lib/content_scope.py` AND this section in the same commit.
 
 #### Scope
 
@@ -160,7 +160,7 @@ The `content_validation` block is **required** on factual-claim pages under thes
 | `docs/operations/` | Required | Deployment, monitoring, alerts, cost optimization, recovery |
 | `docs/troubleshooting/` | Required, except for the `EXCLUDED_SUBPATHS` and `NAVIGATION_INDEXES` listed below | Playbooks, methodology pages, first-10-minutes runbooks |
 
-The block is **out of scope** on these pages — the cleanup tool does not require them, and new pages added in these locations should not introduce a `content_validation` block (the dashboard generator will be aligned with this policy in the strict-validator sync follow-up PR):
+The block is **out of scope** on these pages — the dashboard does not count them, the cleanup tool does not require them, and new pages added in these locations should not introduce a `content_validation` block:
 
 - **Out-of-scope sections** — any path that does not start with `platform/`, `best-practices/`, `operations/`, or `troubleshooting/`. This covers `docs/start-here/`, `docs/reference/`, `docs/contributing/`, `docs/language-guides/` (tutorials and recipes), and `docs/index.md`.
 - **`EXCLUDED_SUBPATHS`** under `troubleshooting/`:
@@ -176,7 +176,7 @@ The block is **out of scope** on these pages — the cleanup tool does not requi
 
 Subsection landing pages that DO make factual claims (for example `platform/architecture/index.md` and `platform/networking-scenarios/index.md`) are intentionally NOT in `NAVIGATION_INDEXES` — they are treated like any other factual-claim page.
 
-Legacy `content_validation` blocks may still exist on a number of out-of-scope pages (notably under `docs/reference/`, `docs/start-here/`, `docs/troubleshooting/kql/`, and `docs/troubleshooting/lab-guides/`) from before this scope policy was formalized. These blocks are accepted today and may still appear in the dashboard while the generator uses its legacy scan; they will be reviewed in a follow-up editorial pass and can be removed with `python3 scripts/remove_out_of_scope_validation.py --apply`.
+Legacy `content_validation` blocks may still exist on a number of out-of-scope pages (notably under `docs/reference/`, `docs/start-here/`, `docs/troubleshooting/kql/`, and `docs/troubleshooting/lab-guides/`) from before this scope policy was formalized. These blocks are accepted but are not counted by the dashboard; they will be reviewed in a follow-up editorial pass and can be removed with `python3 scripts/remove_out_of_scope_validation.py --apply`.
 
 #### Schema
 

--- a/docs/reference/content-validation-status.md
+++ b/docs/reference/content-validation-status.md
@@ -6,7 +6,7 @@ content_sources:
 
 # Content Validation Status
 
-This page tracks the source validation status of all documentation content. All content must be traceable to official Microsoft Learn documentation.
+This page tracks `content_validation` metadata for **in-scope factual-claim documents** under `docs/best-practices/`, `docs/operations/`, `docs/platform/`, `docs/troubleshooting/`. Pages outside this scope — navigation indexes (`docs/best-practices/index.md`, `docs/operations/index.md`, `docs/platform/index.md`, `docs/troubleshooting/first-10-minutes/index.md`, `docs/troubleshooting/index.md`, `docs/troubleshooting/playbooks/index.md`), reference-lookup KQL packs and lab guides (`docs/troubleshooting/kql/`, `docs/troubleshooting/lab-guides/`), tutorials, language guides, and start-here landing pages — are not counted here, even when legacy `content_validation` blocks exist on them (the cleanup tool removes those blocks; see `scripts/remove_out_of_scope_validation.py`). See `AGENTS.md` §Text Content Validation for the full policy and `scripts/lib/content_scope.py` for the executable scope definition.
 
 ## Summary
 
@@ -14,15 +14,16 @@ This page tracks the source validation status of all documentation content. All 
 
 | Content Type | Total | Verified | Pending | Unverified | No Metadata |
 |---|---:|---:|---:|---:|---:|
-| Mermaid Diagrams | 475 | 475 | 0 | 0 | 0 |
-| Text Documents | 68 | 68 | 0 | 0 | 0 |
+| Mermaid Diagrams | 498 | 498 | 0 | 0 | 0 |
+| In-Scope Factual-Claim Documents | 57 | 57 | 0 | 0 | 0 |
 
-!!! success "All Content Verified"
-    All text documents have verified Microsoft Learn sources for core claims.
+!!! success "All In-Scope Documents Verified"
+    Every in-scope factual-claim document has verified Microsoft Learn sources for its core claims.
 
+<!-- diagram-id: content-validation-status-pie -->
 ```mermaid
-pie title Document Validation Status
-    "Verified" : 68
+pie title In-Scope Document Validation Status
+    "Verified" : 57
 ```
 
 ## By Section
@@ -35,6 +36,8 @@ pie title Document Validation Status
 | [Fixed Outbound Nat](../platform/networking-scenarios/fixed-outbound-nat.md) | ✅ | ✅ Verified | 3/3 | 2026-04-12 |
 | [Functions Vs App Service](../platform/functions-vs-app-service.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Hosting](../platform/hosting.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
+| [Index](../platform/networking-scenarios/index.md) | ✅ | ✅ Verified | 3/3 | 2026-05-21 |
+| [Index](../platform/architecture/index.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Networking](../platform/networking.md) | ✅ | ✅ Verified | 3/3 | 2026-04-12 |
 | [Private Egress](../platform/networking-scenarios/private-egress.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Private Ingress](../platform/networking-scenarios/private-ingress.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
@@ -80,16 +83,10 @@ pie title Document Validation Status
 | [Architecture](../troubleshooting/architecture.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Architecture Overview](../troubleshooting/architecture-overview.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Blob Trigger Not Firing](../troubleshooting/playbooks/blob-trigger-not-firing.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Code Storage Verification](../troubleshooting/lab-guides/code-storage-verification.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Cold Start](../troubleshooting/lab-guides/cold-start.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Decision Tree](../troubleshooting/decision-tree.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Deployment Failures](../troubleshooting/playbooks/deployment-failures.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Deployment Not Running](../troubleshooting/lab-guides/deployment-not-running.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Detector Map](../troubleshooting/methodology/detector-map.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Dns Vnet Resolution](../troubleshooting/lab-guides/dns-vnet-resolution.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Durable Orchestration Stuck](../troubleshooting/playbooks/scaling/durable-orchestration-stuck.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Durable Replay Storm](../troubleshooting/lab-guides/durable-replay-storm.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Event Hub Checkpoint Lag](../troubleshooting/lab-guides/event-hub-checkpoint-lag.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Event Hub Service Bus Lag](../troubleshooting/playbooks/triggers/event-hub-service-bus-lag.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Evidence Map](../troubleshooting/evidence-map.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Flex Consumption Deployment](../troubleshooting/playbooks/flex-consumption-deployment.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
@@ -97,21 +94,14 @@ pie title Document Validation Status
 | [Functions Not Executing](../troubleshooting/playbooks/functions-not-executing.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [High Latency](../troubleshooting/first-10-minutes/high-latency.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [High Latency](../troubleshooting/playbooks/high-latency.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Hosting Plan Comparison Matrix](../troubleshooting/lab-guides/hosting-plan-comparison-matrix.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Hosting Plan Security Matrix](../troubleshooting/lab-guides/hosting-plan-security-matrix.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Managed Identity Auth](../troubleshooting/lab-guides/managed-identity-auth.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Managed Identity Rbac Failure](../troubleshooting/playbooks/auth-config/managed-identity-rbac-failure.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Mental Model](../troubleshooting/mental-model.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Methodology](../troubleshooting/methodology.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Out Of Memory Crash](../troubleshooting/lab-guides/out-of-memory-crash.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Out Of Memory Worker Crash](../troubleshooting/playbooks/scaling/out-of-memory-worker-crash.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Queue Backlog Scaling](../troubleshooting/lab-guides/queue-backlog-scaling.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Queue Piling Up](../troubleshooting/playbooks/queue-piling-up.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Quick Diagnosis Cards](../troubleshooting/quick-diagnosis-cards.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Scaling Issues](../troubleshooting/first-10-minutes/scaling-issues.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Storage Access Failure](../troubleshooting/lab-guides/storage-access-failure.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Timeout Execution Limit](../troubleshooting/playbooks/triggers/timeout-execution-limit.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Timer Missed Schedules](../troubleshooting/lab-guides/timer-missed-schedules.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Triggers Not Firing](../troubleshooting/first-10-minutes/triggers-not-firing.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Troubleshooting Method](../troubleshooting/methodology/troubleshooting-method.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 
@@ -137,7 +127,9 @@ pie title Document Validation Status
 
 ## How to Add Validation
 
-Add a `content_validation` block to your document's frontmatter:
+Before adding metadata, confirm the page is in scope. The block is required ONLY for factual-claim pages under `docs/platform/`, `docs/best-practices/`, `docs/operations/`, and `docs/troubleshooting/` (excluding `troubleshooting/kql/`, `troubleshooting/lab-guides/`, and navigation landing pages listed in `scripts/lib/content_scope.NAVIGATION_INDEXES`).
+
+For an in-scope page, add a `content_validation` block to its frontmatter:
 
 ```yaml
 ---
@@ -149,11 +141,13 @@ content_validation:
   last_reviewed: 2026-04-12
   reviewer: agent
   core_claims:
-    - claim: "Flex Consumption supports VNet integration"
+    - claim: "Flex Consumption supports VNet integration with regional VNet."
       source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
       verified: true
 ---
 ```
+
+Each `core_claim` MUST be a verifiable factual assertion about Azure Functions behavior (a documented limit, default, or feature). Meta-statements such as "this page uses Microsoft Learn as the primary source basis" are tautological and rejected — the marker text `primary source basis` triggers a fail-fast in this generator.
 
 Then regenerate this page:
 
@@ -165,3 +159,4 @@ python3 scripts/generate_content_validation_status.py
 
 - [Tutorial Validation Status](validation-status.md)
 - [CLI Cheatsheet](cli-cheatsheet.md)
+

--- a/scripts/generate_content_validation_status.py
+++ b/scripts/generate_content_validation_status.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """Generate content validation status dashboard from frontmatter metadata.
 
-Scans all non-tutorial markdown files for content_validation frontmatter and
-generates a dashboard page showing verification status of core claims.
+Scans in-scope factual-claim markdown files (per ``scripts/lib/content_scope``)
+for ``content_validation`` frontmatter and generates a dashboard page showing
+verification status of core claims.
+
+Fails fast when any in-scope page contains a tautological placeholder claim
+(see ``scripts/lib/content_scope.TAUTOLOGICAL_CLAIM_MARKER``).
 
 Usage:
     python3 scripts/generate_content_validation_status.py
@@ -12,22 +16,24 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from datetime import date
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-# Sections to scan (excludes language-guides tutorials and reference)
-SCAN_SECTIONS = [
-    "platform",
-    "best-practices",
-    "operations",
-    "troubleshooting",
-    "networking-scenarios",
-]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-# Status icons
+from lib.content_scope import (  # noqa: E402
+    EXCLUDED_SUBPATHS,
+    NAVIGATION_INDEXES,
+    SCANNED_SECTIONS,
+    TAUTOLOGICAL_CLAIM_MARKER,
+    is_in_scope,
+    is_tautological_text,
+)
+
 ICON_VERIFIED = "✅ Verified"
 ICON_PENDING = "⚠️ Pending Review"
 ICON_UNVERIFIED = "➖ Unverified"
@@ -35,7 +41,6 @@ ICON_NO_META = "❓ No Metadata"
 
 
 def parse_frontmatter(filepath: Path) -> dict[str, Any] | None:
-    """Extract YAML frontmatter from a markdown file."""
     text = filepath.read_text(encoding="utf-8")
     match = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
     if not match:
@@ -47,7 +52,6 @@ def parse_frontmatter(filepath: Path) -> dict[str, Any] | None:
 
 
 def get_section_from_path(filepath: Path, docs_dir: Path) -> str:
-    """Extract section name from file path."""
     rel = filepath.relative_to(docs_dir)
     parts = rel.parts
     if len(parts) > 0:
@@ -56,24 +60,25 @@ def get_section_from_path(filepath: Path, docs_dir: Path) -> str:
 
 
 def scan_documents(docs_dir: Path) -> list[dict[str, Any]]:
-    """Scan all documents and extract validation metadata."""
+    """Return one record per in-scope factual-claim page.
+
+    Scope is defined by ``scripts/lib/content_scope.is_in_scope``. Pages
+    outside scope (navigation indexes, KQL packs, lab guides, tutorials,
+    reference look-ups) are intentionally excluded from the dashboard.
+    """
     documents = []
 
-    for section in SCAN_SECTIONS:
+    for section in sorted(SCANNED_SECTIONS):
         section_dir = docs_dir / section
         if not section_dir.exists():
-            # Check nested path (e.g., platform/networking-scenarios)
-            if "/" in section:
-                section_dir = docs_dir / section.replace("/", "/")
-            if not section_dir.exists():
-                continue
+            continue
 
         for md_file in section_dir.rglob("*.md"):
-            if md_file.name == "index.md":
+            rel_path = md_file.relative_to(docs_dir)
+            if not is_in_scope(rel_path):
                 continue
 
             frontmatter = parse_frontmatter(md_file)
-            rel_path = md_file.relative_to(docs_dir)
 
             doc_info = {
                 "filepath": md_file,
@@ -86,15 +91,14 @@ def scan_documents(docs_dir: Path) -> list[dict[str, Any]]:
                 "validation_status": "no_metadata",
                 "core_claims_count": 0,
                 "verified_claims_count": 0,
+                "tautological_claims_count": 0,
                 "last_reviewed": None,
             }
 
             if frontmatter and isinstance(frontmatter, dict):
-                # Check content_sources
                 if "content_sources" in frontmatter:
                     doc_info["has_content_sources"] = True
 
-                # Check content_validation
                 cv = frontmatter.get("content_validation", {})
                 if cv and isinstance(cv, dict):
                     doc_info["has_content_validation"] = True
@@ -109,6 +113,12 @@ def scan_documents(docs_dir: Path) -> list[dict[str, Any]]:
                             for c in claims
                             if isinstance(c, dict) and c.get("verified", False)
                         )
+                        doc_info["tautological_claims_count"] = sum(
+                            1
+                            for c in claims
+                            if isinstance(c, dict)
+                            and is_tautological_text(c.get("claim"))
+                        )
 
             documents.append(doc_info)
 
@@ -116,7 +126,6 @@ def scan_documents(docs_dir: Path) -> list[dict[str, Any]]:
 
 
 def get_status_icon(status: str) -> str:
-    """Return icon for validation status."""
     mapping = {
         "verified": ICON_VERIFIED,
         "pending_review": ICON_PENDING,
@@ -126,18 +135,49 @@ def get_status_icon(status: str) -> str:
     return mapping.get(status, ICON_NO_META)
 
 
-def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
-    """Generate the markdown dashboard content."""
-    # Compute stats
+def count_mermaid_diagrams(docs_dir: Path) -> int:
+    count = 0
+    for md_file in docs_dir.rglob("*.md"):
+        rel_path = md_file.relative_to(docs_dir)
+        if any(part.startswith("_") or part.startswith(".") for part in rel_path.parts):
+            continue
+
+        text = md_file.read_text(encoding="utf-8")
+        count += len(re.findall(r"^```mermaid\s*$", text, re.MULTILINE))
+    return count
+
+
+def _scope_summary_lines() -> list[str]:
+    sections = ", ".join(f"`docs/{s}/`" for s in sorted(SCANNED_SECTIONS))
+    excluded = ", ".join(f"`docs/{p}`" for p in EXCLUDED_SUBPATHS)
+    nav_examples = ", ".join(
+        f"`docs/{p}`" for p in sorted(NAVIGATION_INDEXES) if "/" in p
+    )
+    return [
+        "This page tracks `content_validation` metadata for **in-scope "
+        "factual-claim documents** under "
+        f"{sections}. Pages outside this scope — navigation indexes "
+        f"({nav_examples}), reference-lookup KQL packs and lab guides "
+        f"({excluded}), tutorials, language guides, and start-here "
+        "landing pages — are not counted here, even when legacy "
+        "`content_validation` blocks exist on them (the cleanup tool "
+        "removes those blocks; see "
+        "`scripts/remove_out_of_scope_validation.py`). See `AGENTS.md` "
+        "§Text Content Validation for the full policy and "
+        "`scripts/lib/content_scope.py` for the executable scope definition.",
+    ]
+
+
+def generate_dashboard(
+    documents: list[dict[str, Any]], docs_dir: Path, today: date
+) -> str:
     total = len(documents)
     verified = sum(1 for d in documents if d["validation_status"] == "verified")
     pending = sum(1 for d in documents if d["validation_status"] == "pending_review")
     unverified = sum(1 for d in documents if d["validation_status"] == "unverified")
     no_meta = sum(1 for d in documents if d["validation_status"] == "no_metadata")
-    has_sources = sum(1 for d in documents if d["has_content_sources"])
 
-    # Count diagrams (from existing system - placeholder)
-    diagram_count = 475  # From existing validation
+    diagram_count = count_mermaid_diagrams(docs_dir)
 
     lines: list[str] = []
     lines.append("---")
@@ -150,13 +190,9 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
     lines.append("")
     lines.append("# Content Validation Status")
     lines.append("")
-    lines.append(
-        "This page tracks the source validation status of all documentation content. "
-        "All content must be traceable to official Microsoft Learn documentation."
-    )
+    lines.extend(_scope_summary_lines())
     lines.append("")
 
-    # Summary section
     lines.append("## Summary")
     lines.append("")
     lines.append(f"*Generated: {today.isoformat()}*")
@@ -169,26 +205,28 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
         f"| Mermaid Diagrams | {diagram_count} | {diagram_count} | 0 | 0 | 0 |"
     )
     lines.append(
-        f"| Text Documents | {total} | {verified} | {pending} | {unverified} | {no_meta} |"
+        "| In-Scope Factual-Claim Documents "
+        f"| {total} | {verified} | {pending} | {unverified} | {no_meta} |"
     )
     lines.append("")
 
-    # Status explanation
     if verified == total and total > 0:
-        lines.append('!!! success "All Content Verified"')
+        lines.append('!!! success "All In-Scope Documents Verified"')
         lines.append(
-            "    All text documents have verified Microsoft Learn sources for core claims."
+            "    Every in-scope factual-claim document has verified "
+            "Microsoft Learn sources for its core claims."
         )
     elif no_meta > 0:
         lines.append('!!! warning "Validation In Progress"')
         lines.append(
-            f"    {no_meta} documents need `content_validation` metadata added."
+            f"    {no_meta} in-scope document(s) need `content_validation` "
+            "metadata added."
         )
     lines.append("")
 
-    # Mermaid pie chart
+    lines.append("<!-- diagram-id: content-validation-status-pie -->")
     lines.append("```mermaid")
-    lines.append("pie title Document Validation Status")
+    lines.append("pie title In-Scope Document Validation Status")
     if verified > 0:
         lines.append(f'    "Verified" : {verified}')
     if pending > 0:
@@ -200,7 +238,6 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
     lines.append("```")
     lines.append("")
 
-    # Group by section
     by_section: dict[str, list[dict[str, Any]]] = {}
     for d in documents:
         section = d["section"]
@@ -243,7 +280,6 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
 
         lines.append("")
 
-    # Validation categories
     lines.append("## Validation Categories")
     lines.append("")
     lines.append("### Source Types")
@@ -274,10 +310,20 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
     lines.append("| `unverified` | New document, no validation performed |")
     lines.append("")
 
-    # How to add validation
     lines.append("## How to Add Validation")
     lines.append("")
-    lines.append("Add a `content_validation` block to your document's frontmatter:")
+    lines.append(
+        "Before adding metadata, confirm the page is in scope. The block is "
+        "required ONLY for factual-claim pages under `docs/platform/`, "
+        "`docs/best-practices/`, `docs/operations/`, and `docs/troubleshooting/` "
+        "(excluding `troubleshooting/kql/`, `troubleshooting/lab-guides/`, and "
+        "navigation landing pages listed in "
+        "`scripts/lib/content_scope.NAVIGATION_INDEXES`)."
+    )
+    lines.append("")
+    lines.append(
+        "For an in-scope page, add a `content_validation` block to its frontmatter:"
+    )
     lines.append("")
     lines.append("```yaml")
     lines.append("---")
@@ -289,13 +335,24 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
     lines.append("  last_reviewed: 2026-04-12")
     lines.append("  reviewer: agent")
     lines.append("  core_claims:")
-    lines.append('    - claim: "Flex Consumption supports VNet integration"')
+    lines.append(
+        '    - claim: "Flex Consumption supports VNet integration with regional VNet."'
+    )
     lines.append(
         "      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan"
     )
     lines.append("      verified: true")
     lines.append("---")
     lines.append("```")
+    lines.append("")
+    lines.append(
+        "Each `core_claim` MUST be a verifiable factual assertion about Azure "
+        "Functions behavior (a documented limit, default, or feature). "
+        'Meta-statements such as "this page uses Microsoft Learn as the '
+        f'primary source basis" are tautological and rejected — the marker '
+        f"text `{TAUTOLOGICAL_CLAIM_MARKER}` triggers a fail-fast in this "
+        "generator."
+    )
     lines.append("")
     lines.append("Then regenerate this page:")
     lines.append("")
@@ -304,14 +361,13 @@ def generate_dashboard(documents: list[dict[str, Any]], today: date) -> str:
     lines.append("```")
     lines.append("")
 
-    # See Also
     lines.append("## See Also")
     lines.append("")
     lines.append("- [Tutorial Validation Status](validation-status.md)")
     lines.append("- [CLI Cheatsheet](cli-cheatsheet.md)")
     lines.append("")
 
-    return "\n".join(lines).rstrip() + "\n"
+    return "\n".join(lines) + "\n"
 
 
 def main() -> None:
@@ -341,16 +397,41 @@ def main() -> None:
         raise SystemExit(1)
 
     documents = scan_documents(docs_dir)
+
+    tautological_docs = [d for d in documents if d["tautological_claims_count"] > 0]
+    if tautological_docs:
+        print(
+            f"ERROR: {len(tautological_docs)} in-scope document(s) contain "
+            f"tautological placeholder claims (text containing "
+            f"'{TAUTOLOGICAL_CLAIM_MARKER}').",
+            file=sys.stderr,
+        )
+        print(
+            "Tautological claims are forbidden by AGENTS.md \u00a7Text Content "
+            "Validation (Agent Rule 3). Edit each offending file to replace the "
+            "placeholder claim with a verifiable factual assertion about Azure "
+            "Functions behavior, or — if the page does not actually contain "
+            "factual claims — remove the `content_validation` block entirely.",
+            file=sys.stderr,
+        )
+        print("Offending files:", file=sys.stderr)
+        for d in tautological_docs:
+            print(
+                f"  - {d['rel_path']} "
+                f"({d['tautological_claims_count']}/{d['core_claims_count']} claims)",
+                file=sys.stderr,
+            )
+        raise SystemExit(1)
+
     today = date.today()
-    dashboard = generate_dashboard(documents, today)
+    dashboard = generate_dashboard(documents, docs_dir, today)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(dashboard, encoding="utf-8")
 
-    # Stats
     verified = sum(1 for d in documents if d["validation_status"] == "verified")
     print(
-        f"Scanned {len(documents)} documents, "
+        f"Scanned {len(documents)} in-scope documents, "
         f"{verified} verified, "
         f"generated {output_path}"
     )

--- a/scripts/lib/content_scope.py
+++ b/scripts/lib/content_scope.py
@@ -2,25 +2,22 @@
 
 Defines which markdown files in ``docs/`` are required to carry the
 ``content_validation:`` frontmatter block (factual-claim pages) versus those
-that are out of scope (navigation indexes, KQL packs, lab guides, tutorials,
-reference look-ups, and other non-claim content).
+that are out of scope for the dashboard and cleanup tool (navigation indexes,
+KQL packs, lab guides, tutorials, reference look-ups, and other non-claim
+content).
 
-Out-of-scope pages are not required to carry a ``content_validation`` block.
-Legacy blocks may still exist on some out-of-scope pages from before this
-scope policy was formalized; they are accepted, and a follow-up editorial
-pass will remove them. New out-of-scope pages should not add the block.
+Out-of-scope pages are not counted by
+``scripts/generate_content_validation_status.py`` and are not required to
+carry a ``content_validation`` block. Legacy blocks may still exist on some
+out-of-scope pages from before this scope policy was formalized; they are
+accepted but not tracked, and can be removed with
+``scripts/remove_out_of_scope_validation.py --apply``. New out-of-scope pages
+should not add the block.
 
 Imported by:
 
+- ``scripts/generate_content_validation_status.py``
 - ``scripts/remove_out_of_scope_validation.py``
-
-The dashboard generator (``scripts/generate_content_validation_status.py``)
-still uses its legacy local ``SCAN_SECTIONS`` list and ``index.md`` skip
-heuristic, so the current dashboard may still surface a few out-of-scope
-pages (notably lab guides under ``troubleshooting/lab-guides/``). Migrating
-the generator to ``is_in_scope`` is the strict-validator sync planned for a
-follow-up PR; until then this module is the *authoritative* scope policy and
-the dashboard's behavior is *aspirational*.
 
 The policy MUST stay in sync with ``AGENTS.md`` §Text Content Validation.
 If you change the rules here, update ``AGENTS.md`` in the same commit.


### PR DESCRIPTION
## Summary

Rewrite `scripts/generate_content_validation_status.py` to use `scripts/lib/content_scope.is_in_scope()` instead of the legacy local `SCAN_SECTIONS` list and `md_file.name == 'index.md'` skip heuristic.

This is the strict-validator sync follow-up that PR #46 promised: the dashboard generator and the out-of-scope cleanup tool now share a **single executable scope definition** (`scripts/lib/content_scope.py`).

This is **sub-task A** of the PR 2d.2 sequence per Oracle strategy (Option 3 modified, A → C → B-series). It is intentionally narrow and does **NOT** add list-form rejection; validator continues to accept both list-form and dict-form `content_sources` during the schema migration window.

## Dashboard behavior changes (net 68 → 57 in-scope documents)

| Change | Count | Reason |
|---|---|---|
| DROP `troubleshooting/lab-guides/` rows | -13 | Excluded by `content_scope.EXCLUDED_SUBPATHS` (labs use evidence-integrity model with their own Falsification step) |
| ADD factual subsection indexes | +2 | `platform/architecture/index.md` and `platform/networking-scenarios/index.md` were hidden by the overly broad legacy `index.md` skip |
| Mermaid count | 475 → 498 | Hardcoded number replaced with live `count_mermaid_diagrams()` |
| **Net dashboard total** | **68 → 57** | |

## Tautological-claim fail-fast added

Mirrors the ACA pattern. No in-scope Functions docs currently trigger it:

- 229 tautological claims exist in the repo total
- All 229 are on out-of-scope pages
- All 229 will be removed by the upcoming editorial cleanup PR (PR 2d.2c) via \`remove_out_of_scope_validation.py --apply\`

If a future in-scope page introduces a tautological claim, the generator exits with an actionable message naming the offending file(s).

## Documentation updates (remove now-false disclaimers)

- **\`scripts/lib/content_scope.py\` module docstring**: add the generator to the 'Imported by' list; drop the paragraph that called the dashboard behavior 'aspirational'
- **\`AGENTS.md\` Text Content Validation section** (3 spots):
  - Line 150: 'Both scripts now import this helper' (was 'will eventually use')
  - Line 163: 'These blocks are accepted but are not counted by the dashboard' (was 'will be counted... while the generator uses its legacy scan')
  - Line 179: Removed 'will surface a few out-of-scope pages' caveat

## Verification

| Check | Result |
|---|---|
| \`python3 -m doctest scripts/lib/content_scope.py\` | 14/14 pass |
| \`python3 scripts/normalize_yaml_frontmatter.py --check\` | 0 drift (303 files) |
| \`python3 scripts/normalize_mslearn_locale.py --check\` | 0 drift (380 files) |
| \`python3 scripts/generate_content_validation_status.py\` | 57 in-scope, 57 verified |
| \`mkdocs build --strict\` | pass in 26.58s |

## Cross-repo alignment

This PR brings Functions' \`generate_content_validation_status.py\` to **structural parity** with ACA's canonical version (\`yeongseon/azure-container-apps-practical-guide@8fb31d2\`). Functions-specific phrasing preserved where appropriate:

- Examples reference 'Azure Functions' / Flex Consumption (not Container Apps)
- Tautological error message points to manual remediation (no \`remove_tautological_validation.py\` script in Functions repo)
- See Also section keeps \`validation-status.md\` + \`cli-cheatsheet.md\` (existing Functions pattern)

## Strategy context

Per Oracle's PR 2d.2 strategy consultation (session \`ses_15449c667ffe6jHaDJz8Xd8aLT\`): full sequence is **A → C → B-series**:

- **2d.2a** (this PR) — validator/dashboard sync
- 2d.2c — editorial cleanup: \`remove_out_of_scope_validation.py --apply\` (243 blocks)
- 2d.2b-prep — investigate 6 'other' malformed frontmatter files manually
- 2d.2b1 — migrate platform/ + best-practices/ + operations/ to dict-form
- 2d.2b2 — migrate troubleshooting/ to dict-form
- 2d.2b3+ — language-guides batched by template family
- Final — strict schema enforcement (reject list-form)

## Files changed (4 files, +166 / -93)

- \`scripts/generate_content_validation_status.py\` — REWRITTEN (uses \`lib.content_scope.is_in_scope()\`)
- \`scripts/lib/content_scope.py\` — module docstring updated
- \`AGENTS.md\` — 3 spots updated
- \`docs/reference/content-validation-status.md\` — regenerated