### PR TITLE
chore(docs): remove legacy content_validation blocks from out-of-scope pages

### DIFF
--- a/docs/best-practices/index.md
+++ b/docs/best-practices/index.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/
-      verified: true
 ---
 # Best Practices
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/
-      verified: true
 ---
 # Azure Functions Practical Guide
 

--- a/docs/language-guides/dotnet/cli-cheatsheet.md
+++ b/docs/language-guides/dotnet/cli-cheatsheet.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # CLI Cheatsheet
 

--- a/docs/language-guides/dotnet/dotnet-runtime.md
+++ b/docs/language-guides/dotnet/dotnet-runtime.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
-      verified: true
 ---
 # .NET Runtime
 

--- a/docs/language-guides/dotnet/environment-variables.md
+++ b/docs/language-guides/dotnet/environment-variables.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Environment Variables
 

--- a/docs/language-guides/dotnet/host-json.md
+++ b/docs/language-guides/dotnet/host-json.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # host.json Reference
 

--- a/docs/language-guides/dotnet/index.md
+++ b/docs/language-guides/dotnet/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
-      verified: true
 ---
 # .NET Language Guide
 

--- a/docs/language-guides/dotnet/isolated-worker-model.md
+++ b/docs/language-guides/dotnet/isolated-worker-model.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # .NET Isolated Worker Model
 

--- a/docs/language-guides/dotnet/platform-limits.md
+++ b/docs/language-guides/dotnet/platform-limits.md
@@ -9,14 +9,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Platform Limits
 

--- a/docs/language-guides/dotnet/recipes/blob-storage.md
+++ b/docs/language-guides/dotnet/recipes/blob-storage.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Blob Storage
 

--- a/docs/language-guides/dotnet/recipes/cosmosdb.md
+++ b/docs/language-guides/dotnet/recipes/cosmosdb.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Cosmos DB
 

--- a/docs/language-guides/dotnet/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/dotnet/recipes/custom-domain-certificates.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Custom Domain and Certificates
 

--- a/docs/language-guides/dotnet/recipes/durable-orchestration.md
+++ b/docs/language-guides/dotnet/recipes/durable-orchestration.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Durable Orchestration
 

--- a/docs/language-guides/dotnet/recipes/event-grid.md
+++ b/docs/language-guides/dotnet/recipes/event-grid.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Event Grid
 

--- a/docs/language-guides/dotnet/recipes/http-api.md
+++ b/docs/language-guides/dotnet/recipes/http-api.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # HTTP API Patterns
 

--- a/docs/language-guides/dotnet/recipes/http-auth.md
+++ b/docs/language-guides/dotnet/recipes/http-auth.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # HTTP Authentication
 

--- a/docs/language-guides/dotnet/recipes/index.md
+++ b/docs/language-guides/dotnet/recipes/index.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
-      verified: true
 ---
 # .NET Recipes
 

--- a/docs/language-guides/dotnet/recipes/key-vault.md
+++ b/docs/language-guides/dotnet/recipes/key-vault.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Key Vault
 

--- a/docs/language-guides/dotnet/recipes/managed-identity.md
+++ b/docs/language-guides/dotnet/recipes/managed-identity.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Managed Identity
 

--- a/docs/language-guides/dotnet/recipes/queue.md
+++ b/docs/language-guides/dotnet/recipes/queue.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Queue
 

--- a/docs/language-guides/dotnet/recipes/timer.md
+++ b/docs/language-guides/dotnet/recipes/timer.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Timer Trigger
 

--- a/docs/language-guides/dotnet/troubleshooting.md
+++ b/docs/language-guides/dotnet/troubleshooting.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # Troubleshooting
 

--- a/docs/language-guides/dotnet/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 01 - Run Locally (Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 02 - First Deploy (Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 03 - Configuration (Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 04 - Logging and Monitoring (Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 05 - Infrastructure as Code (Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 06 - CI/CD (Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/consumption/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 07 - Extending with Triggers (Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 01 - Run Locally (Dedicated)
 

--- a/docs/language-guides/dotnet/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/02-first-deploy.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 02 - First Deploy (Dedicated)
 

--- a/docs/language-guides/dotnet/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/03-configuration.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 03 - Configuration (Dedicated)
 

--- a/docs/language-guides/dotnet/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/04-logging-monitoring.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 04 - Logging and Monitoring (Dedicated)
 

--- a/docs/language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 05 - Infrastructure as Code (Dedicated)
 

--- a/docs/language-guides/dotnet/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/06-ci-cd.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 06 - CI/CD (Dedicated)
 

--- a/docs/language-guides/dotnet/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/dedicated/07-extending-triggers.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 07 - Extending with Triggers (Dedicated)
 

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 01 - Run Locally (Flex Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 02 - First Deploy (Flex Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 03 - Configuration (Flex Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 04 - Logging and Monitoring (Flex Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 05 - Infrastructure as Code (Flex Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 06 - CI/CD (Flex Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 07 - Extending with Triggers (Flex Consumption)
 

--- a/docs/language-guides/dotnet/tutorial/index.md
+++ b/docs/language-guides/dotnet/tutorial/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-      verified: true
 ---
 # Tutorial — Choose Your Hosting Plan
 

--- a/docs/language-guides/dotnet/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/dotnet/tutorial/premium/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 01 - Run Locally (Premium)
 

--- a/docs/language-guides/dotnet/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/dotnet/tutorial/premium/02-first-deploy.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 02 - First Deploy (Premium)
 

--- a/docs/language-guides/dotnet/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/dotnet/tutorial/premium/02a-first-deploy-private-egress.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 

--- a/docs/language-guides/dotnet/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/dotnet/tutorial/premium/03-configuration.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 03 - Configuration (Premium)
 

--- a/docs/language-guides/dotnet/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/dotnet/tutorial/premium/04-logging-monitoring.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 04 - Logging and Monitoring (Premium)
 

--- a/docs/language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 05 - Infrastructure as Code (Premium)
 

--- a/docs/language-guides/dotnet/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/dotnet/tutorial/premium/06-ci-cd.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 06 - CI/CD (Premium)
 

--- a/docs/language-guides/dotnet/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/dotnet/tutorial/premium/07-extending-triggers.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-      verified: true
 ---
 # 07 - Extending with Triggers (Premium)
 

--- a/docs/language-guides/index.md
+++ b/docs/language-guides/index.md
@@ -9,14 +9,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # Language Guides
 

--- a/docs/language-guides/java/annotation-programming-model.md
+++ b/docs/language-guides/java/annotation-programming-model.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # Java Annotation Programming Model
 

--- a/docs/language-guides/java/cli-cheatsheet.md
+++ b/docs/language-guides/java/cli-cheatsheet.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/functionapp
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # CLI Cheatsheet
 

--- a/docs/language-guides/java/environment-variables.md
+++ b/docs/language-guides/java/environment-variables.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/functionapp
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # Environment Variables
 

--- a/docs/language-guides/java/host-json.md
+++ b/docs/language-guides/java/host-json.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/functionapp
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # host.json Reference
 

--- a/docs/language-guides/java/index.md
+++ b/docs/language-guides/java/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # Java Language Guide
 

--- a/docs/language-guides/java/java-runtime.md
+++ b/docs/language-guides/java/java-runtime.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
-      verified: true
 ---
 # Java Runtime
 

--- a/docs/language-guides/java/platform-limits.md
+++ b/docs/language-guides/java/platform-limits.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/functionapp
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # Platform Limits
 

--- a/docs/language-guides/java/recipes/blob-storage.md
+++ b/docs/language-guides/java/recipes/blob-storage.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
-      verified: true
 ---
 # Blob Storage Integration
 

--- a/docs/language-guides/java/recipes/cosmosdb.md
+++ b/docs/language-guides/java/recipes/cosmosdb.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
-      verified: true
 ---
 # Cosmos DB Integration
 

--- a/docs/language-guides/java/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/java/recipes/custom-domain-certificates.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
-      verified: true
 ---
 # Custom Domain and Certificates
 

--- a/docs/language-guides/java/recipes/durable-orchestration.md
+++ b/docs/language-guides/java/recipes/durable-orchestration.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
-      verified: true
 ---
 # Durable Orchestration
 

--- a/docs/language-guides/java/recipes/event-grid.md
+++ b/docs/language-guides/java/recipes/event-grid.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
-      verified: true
 ---
 # Event Grid Trigger
 

--- a/docs/language-guides/java/recipes/http-api.md
+++ b/docs/language-guides/java/recipes/http-api.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
-      verified: true
 ---
 # HTTP API Patterns
 

--- a/docs/language-guides/java/recipes/http-auth.md
+++ b/docs/language-guides/java/recipes/http-auth.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger#working-with-client-identities
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
-      verified: true
 ---
 # HTTP Authentication
 

--- a/docs/language-guides/java/recipes/index.md
+++ b/docs/language-guides/java/recipes/index.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-      verified: true
 ---
 # Recipes
 

--- a/docs/language-guides/java/recipes/key-vault.md
+++ b/docs/language-guides/java/recipes/key-vault.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
-      verified: true
 ---
 # Key Vault Integration
 

--- a/docs/language-guides/java/recipes/managed-identity.md
+++ b/docs/language-guides/java/recipes/managed-identity.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-      verified: true
 ---
 # Managed Identity
 

--- a/docs/language-guides/java/recipes/queue.md
+++ b/docs/language-guides/java/recipes/queue.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
-      verified: true
 ---
 # Queue Storage Integration
 

--- a/docs/language-guides/java/recipes/timer.md
+++ b/docs/language-guides/java/recipes/timer.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
-      verified: true
 ---
 # Timer Trigger
 

--- a/docs/language-guides/java/troubleshooting.md
+++ b/docs/language-guides/java/troubleshooting.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/functionapp
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # Troubleshooting
 

--- a/docs/language-guides/java/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/java/tutorial/consumption/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 01 - Run Locally (Consumption)
 

--- a/docs/language-guides/java/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/consumption/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 02 - First Deploy (Consumption)
 

--- a/docs/language-guides/java/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/java/tutorial/consumption/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 03 - Configuration (Consumption)
 

--- a/docs/language-guides/java/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/consumption/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 04 - Logging and Monitoring (Consumption)
 

--- a/docs/language-guides/java/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/consumption/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 05 - Infrastructure as Code (Consumption)
 

--- a/docs/language-guides/java/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/consumption/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 06 - CI/CD (Consumption)
 

--- a/docs/language-guides/java/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/consumption/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 07 - Extending with Triggers (Consumption)
 

--- a/docs/language-guides/java/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/java/tutorial/dedicated/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 01 - Run Locally (Dedicated)
 

--- a/docs/language-guides/java/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/dedicated/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 02 - First Deploy (Dedicated)
 

--- a/docs/language-guides/java/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/java/tutorial/dedicated/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 03 - Configuration (Dedicated)
 

--- a/docs/language-guides/java/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/dedicated/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 04 - Logging and Monitoring (Dedicated)
 

--- a/docs/language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 05 - Infrastructure as Code (Dedicated)
 

--- a/docs/language-guides/java/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/dedicated/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 06 - CI/CD (Dedicated)
 

--- a/docs/language-guides/java/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/dedicated/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 07 - Extending with Triggers (Dedicated)
 

--- a/docs/language-guides/java/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 01 - Run Locally (Flex Consumption)
 

--- a/docs/language-guides/java/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 02 - First Deploy (Flex Consumption)
 

--- a/docs/language-guides/java/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 

--- a/docs/language-guides/java/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 03 - Configuration (Flex Consumption)
 

--- a/docs/language-guides/java/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 04 - Logging and Monitoring (Flex Consumption)
 

--- a/docs/language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 05 - Infrastructure as Code (Flex Consumption)
 

--- a/docs/language-guides/java/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 06 - CI/CD (Flex Consumption)
 

--- a/docs/language-guides/java/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 07 - Extending with Triggers (Flex Consumption)
 

--- a/docs/language-guides/java/tutorial/index.md
+++ b/docs/language-guides/java/tutorial/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-      verified: true
 ---
 # Tutorial — Choose Your Hosting Plan
 

--- a/docs/language-guides/java/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/java/tutorial/premium/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 01 - Run Locally (Premium)
 

--- a/docs/language-guides/java/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/java/tutorial/premium/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 02 - First Deploy (Premium)
 

--- a/docs/language-guides/java/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/java/tutorial/premium/02a-first-deploy-private-egress.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 

--- a/docs/language-guides/java/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/java/tutorial/premium/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 03 - Configuration (Premium)
 

--- a/docs/language-guides/java/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/java/tutorial/premium/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 04 - Logging and Monitoring (Premium)
 

--- a/docs/language-guides/java/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/java/tutorial/premium/05-infrastructure-as-code.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/templates/microsoft.web/sites
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 05 - Infrastructure as Code (Premium)
 

--- a/docs/language-guides/java/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/java/tutorial/premium/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 06 - CI/CD (Premium)
 

--- a/docs/language-guides/java/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/java/tutorial/premium/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-      verified: true
 ---
 # 07 - Extending with Triggers (Premium)
 

--- a/docs/language-guides/nodejs/cli-cheatsheet.md
+++ b/docs/language-guides/nodejs/cli-cheatsheet.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/functionapp
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-      verified: true
 ---
 # CLI Cheatsheet
 

--- a/docs/language-guides/nodejs/environment-variables.md
+++ b/docs/language-guides/nodejs/environment-variables.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-      verified: true
 ---
 # Environment Variables
 

--- a/docs/language-guides/nodejs/host-json.md
+++ b/docs/language-guides/nodejs/host-json.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-      verified: true
 ---
 # host.json Reference
 

--- a/docs/language-guides/nodejs/index.md
+++ b/docs/language-guides/nodejs/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # Node.js Language Guide
 

--- a/docs/language-guides/nodejs/nodejs-runtime.md
+++ b/docs/language-guides/nodejs/nodejs-runtime.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # Node.js Runtime
 

--- a/docs/language-guides/nodejs/platform-limits.md
+++ b/docs/language-guides/nodejs/platform-limits.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-      verified: true
 ---
 # Platform Limits
 

--- a/docs/language-guides/nodejs/recipes/blob-storage.md
+++ b/docs/language-guides/nodejs/recipes/blob-storage.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
-      verified: true
 ---
 # Blob Storage Patterns
 

--- a/docs/language-guides/nodejs/recipes/cosmosdb.md
+++ b/docs/language-guides/nodejs/recipes/cosmosdb.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
-      verified: true
 ---
 # Cosmos DB Integration
 

--- a/docs/language-guides/nodejs/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/nodejs/recipes/custom-domain-certificates.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
-      verified: true
 ---
 # Custom Domains and Certificates
 

--- a/docs/language-guides/nodejs/recipes/durable-orchestration.md
+++ b/docs/language-guides/nodejs/recipes/durable-orchestration.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade
-      verified: true
 ---
 # Durable Orchestration
 

--- a/docs/language-guides/nodejs/recipes/event-grid.md
+++ b/docs/language-guides/nodejs/recipes/event-grid.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
-      verified: true
 ---
 # Event Grid Events
 

--- a/docs/language-guides/nodejs/recipes/http-api.md
+++ b/docs/language-guides/nodejs/recipes/http-api.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # HTTP API Patterns
 

--- a/docs/language-guides/nodejs/recipes/http-auth.md
+++ b/docs/language-guides/nodejs/recipes/http-auth.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
-      verified: true
 ---
 # HTTP Authentication
 

--- a/docs/language-guides/nodejs/recipes/index.md
+++ b/docs/language-guides/nodejs/recipes/index.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-      verified: true
 ---
 # Node.js Recipes
 

--- a/docs/language-guides/nodejs/recipes/key-vault.md
+++ b/docs/language-guides/nodejs/recipes/key-vault.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/keyvault-secrets-readme
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
-      verified: true
 ---
 # Key Vault Access
 

--- a/docs/language-guides/nodejs/recipes/managed-identity.md
+++ b/docs/language-guides/nodejs/recipes/managed-identity.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview
-      verified: true
 ---
 # Managed Identity
 

--- a/docs/language-guides/nodejs/recipes/queue.md
+++ b/docs/language-guides/nodejs/recipes/queue.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
-      verified: true
 ---
 # Queue Processing
 

--- a/docs/language-guides/nodejs/recipes/timer.md
+++ b/docs/language-guides/nodejs/recipes/timer.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
-      verified: true
 ---
 # Timer Jobs
 

--- a/docs/language-guides/nodejs/troubleshooting.md
+++ b/docs/language-guides/nodejs/troubleshooting.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # Troubleshooting
 

--- a/docs/language-guides/nodejs/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 01 - Run Locally (Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 02 - First Deploy (Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 03 - Configuration (Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 04 - Logging and Monitoring (Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 05 - Infrastructure as Code (Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 06 - CI/CD (Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/consumption/07-extending-triggers.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 07 - Extending Triggers (Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 01 - Run Locally (Dedicated)
 

--- a/docs/language-guides/nodejs/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 02 - First Deploy (Dedicated)
 

--- a/docs/language-guides/nodejs/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 03 - Configuration (Dedicated)
 

--- a/docs/language-guides/nodejs/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 04 - Logging and Monitoring (Dedicated)
 

--- a/docs/language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 05 - Infrastructure as Code (Dedicated)
 

--- a/docs/language-guides/nodejs/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 06 - CI/CD (Dedicated)
 

--- a/docs/language-guides/nodejs/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/dedicated/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 07 - Extending Triggers (Dedicated)
 

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 01 - Run Locally (Flex Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 02 - First Deploy (Flex Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 03 - Configuration (Flex Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 04 - Logging and Monitoring (Flex Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 05 - Infrastructure as Code (Flex Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 06 - CI/CD (Flex Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 07 - Extending Triggers (Flex Consumption)
 

--- a/docs/language-guides/nodejs/tutorial/index.md
+++ b/docs/language-guides/nodejs/tutorial/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-      verified: true
 ---
 # Tutorial - Choose Your Hosting Plan
 

--- a/docs/language-guides/nodejs/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/nodejs/tutorial/premium/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 01 - Run Locally (Premium)
 

--- a/docs/language-guides/nodejs/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/nodejs/tutorial/premium/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 02 - First Deploy (Premium)
 

--- a/docs/language-guides/nodejs/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/nodejs/tutorial/premium/02a-first-deploy-private-egress.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 

--- a/docs/language-guides/nodejs/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/nodejs/tutorial/premium/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-node
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 03 - Configuration (Premium)
 

--- a/docs/language-guides/nodejs/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/nodejs/tutorial/premium/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 04 - Logging and Monitoring (Premium)
 

--- a/docs/language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 05 - Infrastructure as Code (Premium)
 

--- a/docs/language-guides/nodejs/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/nodejs/tutorial/premium/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 06 - CI/CD (Premium)
 

--- a/docs/language-guides/nodejs/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/nodejs/tutorial/premium/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # 07 - Extending Triggers (Premium)
 

--- a/docs/language-guides/nodejs/v4-programming-model.md
+++ b/docs/language-guides/nodejs/v4-programming-model.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-      verified: true
 ---
 # Node.js v4 Programming Model
 

--- a/docs/language-guides/python/cli-cheatsheet.md
+++ b/docs/language-guides/python/cli-cheatsheet.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/cli/azure/functionapp
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-      verified: true
 ---
 # CLI Cheatsheet
 

--- a/docs/language-guides/python/environment-variables.md
+++ b/docs/language-guides/python/environment-variables.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # Environment Variables
 

--- a/docs/language-guides/python/host-json.md
+++ b/docs/language-guides/python/host-json.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-      verified: true
 ---
 # host.json Reference
 

--- a/docs/language-guides/python/index.md
+++ b/docs/language-guides/python/index.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # Python Language Guide
 

--- a/docs/language-guides/python/platform-limits.md
+++ b/docs/language-guides/python/platform-limits.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
-      verified: true
 ---
 # Platform Limits
 

--- a/docs/language-guides/python/python-runtime.md
+++ b/docs/language-guides/python/python-runtime.md
@@ -9,14 +9,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
-      verified: true
 ---
 # Python Runtime
 

--- a/docs/language-guides/python/recipes/blob-storage.md
+++ b/docs/language-guides/python/recipes/blob-storage.md
@@ -9,14 +9,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
-      verified: true
 ---
 # Blob Storage
 

--- a/docs/language-guides/python/recipes/cosmosdb.md
+++ b/docs/language-guides/python/recipes/cosmosdb.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
-      verified: true
 ---
 # Cosmos DB Integration
 

--- a/docs/language-guides/python/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/python/recipes/custom-domain-certificates.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
-      verified: true
 ---
 # Custom Domains and Certificates
 

--- a/docs/language-guides/python/recipes/durable-orchestration.md
+++ b/docs/language-guides/python/recipes/durable-orchestration.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
-      verified: true
 ---
 # Durable Functions
 

--- a/docs/language-guides/python/recipes/event-grid.md
+++ b/docs/language-guides/python/recipes/event-grid.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid
-      verified: true
 ---
 # Event Grid Trigger
 

--- a/docs/language-guides/python/recipes/http-api.md
+++ b/docs/language-guides/python/recipes/http-api.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
-      verified: true
 ---
 # HTTP API Patterns
 

--- a/docs/language-guides/python/recipes/http-auth.md
+++ b/docs/language-guides/python/recipes/http-auth.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
-      verified: true
 ---
 # HTTP Authentication
 

--- a/docs/language-guides/python/recipes/index.md
+++ b/docs/language-guides/python/recipes/index.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # Python Recipes
 

--- a/docs/language-guides/python/recipes/key-vault.md
+++ b/docs/language-guides/python/recipes/key-vault.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
-      verified: true
 ---
 # Key Vault Integration
 

--- a/docs/language-guides/python/recipes/managed-identity.md
+++ b/docs/language-guides/python/recipes/managed-identity.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-      verified: true
 ---
 # Managed Identity
 

--- a/docs/language-guides/python/recipes/queue.md
+++ b/docs/language-guides/python/recipes/queue.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
-      verified: true
 ---
 # Queue Storage
 

--- a/docs/language-guides/python/recipes/timer.md
+++ b/docs/language-guides/python/recipes/timer.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
-      verified: true
 ---
 # Timer Trigger
 

--- a/docs/language-guides/python/troubleshooting.md
+++ b/docs/language-guides/python/troubleshooting.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # Troubleshooting
 

--- a/docs/language-guides/python/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/python/tutorial/consumption/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-      verified: true
 ---
 # 01 - Run Locally (Consumption)
 

--- a/docs/language-guides/python/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/consumption/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
-      verified: true
 ---
 # 02 - First Deploy (Consumption)
 

--- a/docs/language-guides/python/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/python/tutorial/consumption/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-      verified: true
 ---
 # 03 - Configuration (Consumption)
 

--- a/docs/language-guides/python/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/consumption/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/cli/azure/monitor/app-insights?view=azure-cli-latest
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/webapp/log
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
-      verified: true
 ---
 # 04 - Logging and Monitoring (Consumption)
 

--- a/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code
-      verified: true
 ---
 # 05 - Infrastructure as Code (Consumption)
 

--- a/docs/language-guides/python/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/consumption/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions#download-your-publish-profile
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
-      verified: true
 ---
 # 06 - CI/CD (Consumption)
 

--- a/docs/language-guides/python/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/consumption/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-      verified: true
 ---
 # 07 - Extending Triggers (Consumption)
 

--- a/docs/language-guides/python/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/python/tutorial/dedicated/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-      verified: true
 ---
 # 01 - Run Locally (Dedicated)
 

--- a/docs/language-guides/python/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/dedicated/02-first-deploy.md
@@ -18,14 +18,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings
-      verified: true
 ---
 # 02 - First Deploy (Dedicated)
 

--- a/docs/language-guides/python/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/python/tutorial/dedicated/03-configuration.md
@@ -20,14 +20,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-      verified: true
 ---
 # 03 - Configuration (Dedicated)
 

--- a/docs/language-guides/python/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/dedicated/04-logging-monitoring.md
@@ -20,14 +20,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-metric-overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-      verified: true
 ---
 # 04 - Logging & Monitoring (Dedicated)
 

--- a/docs/language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md
@@ -20,14 +20,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/
-      verified: true
 ---
 # 05 - Infrastructure as Code (Dedicated)
 

--- a/docs/language-guides/python/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/dedicated/06-ci-cd.md
@@ -20,14 +20,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/deployment-zip-push
-      verified: true
 ---
 # 06 - CI/CD (Dedicated)
 

--- a/docs/language-guides/python/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/dedicated/07-extending-triggers.md
@@ -22,14 +22,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-      verified: true
 ---
 # 07 - Extending with Triggers (Dedicated)
 

--- a/docs/language-guides/python/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-      verified: true
 ---
 # 01 - Run Locally (Flex Consumption)
 

--- a/docs/language-guides/python/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # 02 - First Deploy (Flex Consumption)
 

--- a/docs/language-guides/python/tutorial/flex-consumption/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/02a-first-deploy-private-egress.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 

--- a/docs/language-guides/python/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#connecting-to-host-storage-with-an-identity
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-      verified: true
 ---
 # 03 - Configuration (Flex Consumption)
 

--- a/docs/language-guides/python/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/04-logging-monitoring.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
-      verified: true
 ---
 # 04 - Logging and Monitoring (Flex Consumption)
 

--- a/docs/language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview
-      verified: true
 ---
 # 05 - Infrastructure as Code (Flex Consumption)
 

--- a/docs/language-guides/python/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure-openid-connect
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
-      verified: true
 ---
 # 06 - CI/CD (Flex Consumption)
 

--- a/docs/language-guides/python/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-      verified: true
 ---
 # 07 - Extending Triggers (Flex Consumption)
 

--- a/docs/language-guides/python/tutorial/index.md
+++ b/docs/language-guides/python/tutorial/index.md
@@ -11,14 +11,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/pricing
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/migration/migrate-plan-consumption-to-flex
-      verified: true
 ---
 # Tutorial — Choose Your Hosting Plan
 

--- a/docs/language-guides/python/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/python/tutorial/premium/01-local-run.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-      verified: true
 ---
 # 01 - Run Locally (Premium)
 

--- a/docs/language-guides/python/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/python/tutorial/premium/02-first-deploy.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # 02 - First Deploy (Premium)
 

--- a/docs/language-guides/python/tutorial/premium/02a-first-deploy-private-egress.md
+++ b/docs/language-guides/python/tutorial/premium/02a-first-deploy-private-egress.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-      verified: true
 ---
 # 02A - First Deploy (Private Egress)
 

--- a/docs/language-guides/python/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/python/tutorial/premium/03-configuration.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-      verified: true
 ---
 # 03 - Configuration (Premium)
 

--- a/docs/language-guides/python/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/python/tutorial/premium/04-logging-monitoring.md
@@ -14,14 +14,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/monitor/app-insights?view=azure-cli-latest
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
-      verified: true
 ---
 # 04 - Logging and Monitoring (Premium)
 

--- a/docs/language-guides/python/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/premium/05-infrastructure-as-code.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code
-      verified: true
 ---
 # 05 - Infrastructure as Code (Premium)
 

--- a/docs/language-guides/python/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/python/tutorial/premium/06-ci-cd.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots#swap-slots
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
-      verified: true
 ---
 # 06 - CI/CD (Premium)
 

--- a/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
@@ -16,14 +16,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-      verified: true
 ---
 # 07 - Extending Triggers (Premium)
 

--- a/docs/language-guides/python/v2-programming-model.md
+++ b/docs/language-guides/python/v2-programming-model.md
@@ -9,14 +9,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # Python v2 Programming Model
 

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
-      verified: true
 ---
 # Operations
 

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -11,14 +11,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/reliability/reliability-functions
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-      verified: true
 ---
 # Platform
 

--- a/docs/reference/cli-cheatsheet.md
+++ b/docs/reference/cli-cheatsheet.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/cli/azure/functionapp
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-      verified: true
 ---
 # CLI Cheatsheet
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # Environment Variables
 

--- a/docs/reference/host-json.md
+++ b/docs/reference/host-json.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-      verified: true
 ---
 # host.json Reference
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,14 +9,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-core-tools-reference
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/
-      verified: true
 ---
 # Reference
 

--- a/docs/reference/platform-limits.md
+++ b/docs/reference/platform-limits.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
-      verified: true
 ---
 # Platform Limits
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-      verified: true
 ---
 # Troubleshooting
 

--- a/docs/reference/validation-status.md
+++ b/docs/reference/validation-status.md
@@ -10,14 +10,6 @@ content_sources:
       justification: Auto-generated dashboard chart from repository validation metadata.
       based_on:
         - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This generated dashboard summarizes repository validation metadata and links back to Microsoft Learn as the source basis for Azure content checks.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-      verified: true
 ---
 # Tutorial Validation Status
 

--- a/docs/start-here/hosting-options.md
+++ b/docs/start-here/hosting-options.md
@@ -11,14 +11,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-      verified: true
 ---
 # Hosting Options
 

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-      verified: true
 ---
 # Start Here
 

--- a/docs/start-here/learning-paths.md
+++ b/docs/start-here/learning-paths.md
@@ -13,14 +13,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-      verified: true
 ---
 # Learning Paths
 

--- a/docs/start-here/overview.md
+++ b/docs/start-here/overview.md
@@ -23,14 +23,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-      verified: true
 ---
 # Overview: What is Azure Functions
 

--- a/docs/start-here/repository-map.md
+++ b/docs/start-here/repository-map.md
@@ -3,14 +3,6 @@ content_sources:
 
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/
-      verified: true
 ---
 # Repository Map
 

--- a/docs/troubleshooting/first-10-minutes/index.md
+++ b/docs/troubleshooting/first-10-minutes/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/service-health/overview
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-      verified: true
 ---
 # Checklists
 

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -13,14 +13,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/
-      verified: true
 ---
 # Troubleshooting
 

--- a/docs/troubleshooting/kql/correlation/index.md
+++ b/docs/troubleshooting/kql/correlation/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/correlation
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-monitor/app/correlation
-      verified: true
 ---
 # Correlation Queries
 

--- a/docs/troubleshooting/kql/dependencies/index.md
+++ b/docs/troubleshooting/kql/dependencies/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
-      verified: true
 ---
 # Dependency Queries
 

--- a/docs/troubleshooting/kql/execution/index.md
+++ b/docs/troubleshooting/kql/execution/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
-      verified: true
 ---
 # Execution Queries
 

--- a/docs/troubleshooting/kql/index.md
+++ b/docs/troubleshooting/kql/index.md
@@ -11,14 +11,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-      verified: true
 ---
 # KQL Query Library for Azure Functions
 

--- a/docs/troubleshooting/kql/scaling/index.md
+++ b/docs/troubleshooting/kql/scaling/index.md
@@ -5,14 +5,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-      verified: true
 ---
 # Scaling Queries
 

--- a/docs/troubleshooting/lab-guides/code-storage-verification.md
+++ b/docs/troubleshooting/lab-guides/code-storage-verification.md
@@ -16,16 +16,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Code Storage Verification (All Hosting Plans) 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
-      verified: true
 ---
-
 # Lab Guide: Code Storage Verification (All Hosting Plans)
 
 This Level 3 lab guide validates how Azure Functions stores and loads code across all four hosting plans used in this repository: Consumption (Y1), Flex Consumption (FC1), Premium (EP), and Dedicated (ASP). The lab proves the deployment-storage model, required app settings, identity and RBAC dependencies, and the failure signatures you should expect when one plan is misconfigured. It also gives deterministic recovery procedures and evidence standards for production-grade triage.

--- a/docs/troubleshooting/lab-guides/cold-start.md
+++ b/docs/troubleshooting/lab-guides/cold-start.md
@@ -12,16 +12,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/data-explorer/kusto/query/
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Cold Start on Azure Functions 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-      verified: true
 ---
-
 # Lab Guide: Cold Start on Azure Functions
 This Level 3 lab reproduces and analyzes Azure Functions cold-start behavior across hosting plans, with emphasis on FC1 Flex Consumption evidence. You will build a falsifiable timeline that separates worker provisioning delay from host startup time and request execution time.
 ---

--- a/docs/troubleshooting/lab-guides/deployment-not-running.md
+++ b/docs/troubleshooting/lab-guides/deployment-not-running.md
@@ -10,16 +10,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Deployment Succeeded but Function Not Running 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
-      verified: true
 ---
-
 # Lab Guide: Deployment Succeeded but Function Not Running
 
 This lab reproduces a deceptive production scenario: deployment transport succeeds, but Azure Functions cannot discover triggers, so no functions execute. You will validate failure evidence using Application Insights tables only (`traces`, `requests`, `dependencies`, `exceptions`), then recover by correcting runtime and package structure.

--- a/docs/troubleshooting/lab-guides/dns-vnet-resolution.md
+++ b/docs/troubleshooting/lab-guides/dns-vnet-resolution.md
@@ -12,16 +12,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/cli/azure/network/private-dns
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: DNS and VNet Resolution Failure 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-      verified: true
 ---
-
 # Lab Guide: DNS and VNet Resolution Failure
 
 This lab reproduces a private DNS resolution failure on an Azure Functions Flex Consumption (FC1) app with private endpoints. By removing the blob storage Private DNS zone VNet link, the function app loses private DNS resolution for blob storage, causing storage operations to route to the public endpoint and fail with `AuthorizationFailure`. Restoring the link restores private resolution and storage access.

--- a/docs/troubleshooting/lab-guides/durable-replay-storm.md
+++ b/docs/troubleshooting/lab-guides/durable-replay-storm.md
@@ -12,16 +12,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Durable Functions Replay Storm on Azure Functions Premium EP1 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-orchestrations
-      verified: true
 ---
-
 # Lab Guide: Durable Functions Replay Storm on Azure Functions Premium EP1
 
 This lab guide documents a completed Azure Functions Premium EP1 experiment that captured a real Durable Functions replay storm. The objective is to prove, with reproducible evidence, that orchestration replay overhead can dominate end-to-end completion time even when activity execution remains stable.

--- a/docs/troubleshooting/lab-guides/event-hub-checkpoint-lag.md
+++ b/docs/troubleshooting/lab-guides/event-hub-checkpoint-lag.md
@@ -10,16 +10,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Event Hub Checkpoint Lag on Azure Functions Premium EP1 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
-      verified: true
 ---
-
 # Lab Guide: Event Hub Checkpoint Lag on Azure Functions Premium EP1
 
 This lab guide documents a completed Event Hub checkpoint lag experiment on Azure Functions Premium EP1. Every metric in this document comes from a real telemetry window (`2026-04-07 13:12:00` to `13:36:00` UTC) captured from the production-like lab deployment.

--- a/docs/troubleshooting/lab-guides/hosting-plan-comparison-matrix.md
+++ b/docs/troubleshooting/lab-guides/hosting-plan-comparison-matrix.md
@@ -8,16 +8,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Hosting Plan Security Comparison Matrix 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-      verified: true
 ---
-
 # Hosting Plan Security Comparison Matrix
 
 Quick-reference comparison of Azure Functions hosting plan behavior under identity and networking fault conditions. Data collected from real Azure deployments across all four hosting plans.

--- a/docs/troubleshooting/lab-guides/hosting-plan-security-matrix.md
+++ b/docs/troubleshooting/lab-guides/hosting-plan-security-matrix.md
@@ -10,16 +10,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-networking-how-to
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Hosting Plan Security Matrix — Private Endpoint + Managed Identity Fault Injection 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-      verified: true
 ---
-
 # Lab Guide: Hosting Plan Security Matrix — Private Endpoint + Managed Identity Fault Injection
 
 This Level 4 lab guide reproduces the same four security and access faults across four Azure Functions hosting plans and documents how each plan fails differently. The goal is to build evidence-driven, plan-specific troubleshooting muscle so operators can stop using one-size-fits-all runbooks for fundamentally different runtime architectures.

--- a/docs/troubleshooting/lab-guides/index.md
+++ b/docs/troubleshooting/lab-guides/index.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/configure-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-      verified: true
 ---
 # Hands-on Labs
 

--- a/docs/troubleshooting/lab-guides/managed-identity-auth.md
+++ b/docs/troubleshooting/lab-guides/managed-identity-auth.md
@@ -12,16 +12,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Managed Identity Authentication Failure 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-      verified: true
 ---
-
 # Lab Guide: Managed Identity Authentication Failure
 
 This Level 3 lab guide reproduces a managed identity authorization failure in Azure Functions and demonstrates a complete, evidence-driven chain from RBAC drift to host storage unhealthy state, listener startup failure, and trigger interruption. The scenario uses Python v2 on Flex Consumption (`FC1`) with a system-assigned identity that reads and writes blob containers.

--- a/docs/troubleshooting/lab-guides/out-of-memory-crash.md
+++ b/docs/troubleshooting/lab-guides/out-of-memory-crash.md
@@ -10,16 +10,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model-complete
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Out of Memory Crash Under Blob Processing Load 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-      verified: true
 ---
-
 # Lab Guide: Out of Memory Crash Under Blob Processing Load
 
 This lab reproduces a Python Azure Functions out-of-memory incident under sustained blob-trigger load. You will intentionally use a memory-inefficient buffering path, drive concurrency in phases, collect telemetry, and verify that a streaming fix plus concurrency controls removes crash-loop behavior.

--- a/docs/troubleshooting/lab-guides/queue-backlog-scaling.md
+++ b/docs/troubleshooting/lab-guides/queue-backlog-scaling.md
@@ -10,16 +10,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Queue Backlog Scaling on Y1 Consumption (Real Evidence) 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
-      verified: true
 ---
-
 # Lab Guide: Queue Backlog Scaling on Y1 Consumption (Real Evidence)
 
 This lab reproduces and analyzes a real queue backlog burst on Azure Functions Consumption (Y1) using telemetry collected on 2026-04-07. The objective is to prove what happened, what did not happen, and why a 2000-message burst drained in about 7.3 minutes without scale-out.

--- a/docs/troubleshooting/lab-guides/storage-access-failure.md
+++ b/docs/troubleshooting/lab-guides/storage-access-failure.md
@@ -12,16 +12,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/data-model
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-cli
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Storage Access Failure (AzureWebJobsStorage) 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
-      verified: true
 ---
-
 # Lab Guide: Storage Access Failure (AzureWebJobsStorage)
 
 This Level 3 lab guide reproduces a storage authorization failure in Azure Functions and shows how to prove a full failure cascade from `AzureWebJobsStorage` access loss to listener startup failure, host unhealthy state, and zero trigger execution. The experiment uses the lab assets in `labs/storage-access-failure/` and captures evidence with KQL, CLI, and runtime logs.

--- a/docs/troubleshooting/lab-guides/timer-missed-schedules.md
+++ b/docs/troubleshooting/lab-guides/timer-missed-schedules.md
@@ -10,16 +10,7 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-overviewlog-query-overview
-content_validation:
-  status: verified
-  last_reviewed: 2026-04-12
-  reviewer: agent
-  core_claims:
-    - claim: "Lab Guide: Timer Trigger Missed Schedules 관련 핵심 진단 절차와 운영 판단 기준"
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
-      verified: true
 ---
-
 # Lab Guide: Timer Trigger Missed Schedules
 
 This lab reproduces missed Timer Trigger executions in a real Y1 Consumption deployment by intentionally stopping the app during active schedule windows. You will validate timer behavior with real evidence from 2026-04-07, including baseline fires, missed windows, and post-restart `isPastDue` recovery.

--- a/docs/troubleshooting/playbooks/index.md
+++ b/docs/troubleshooting/playbooks/index.md
@@ -7,14 +7,6 @@ content_sources:
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
   - type: mslearn-adapted
     url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
-content_validation:
-  status: verified
-  last_reviewed: '2026-05-23'
-  reviewer: agent
-  core_claims:
-    - claim: This page uses Microsoft Learn as the primary source basis for its Azure-specific guidance.
-      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
-      verified: true
 ---
 # Incident Playbooks
 


### PR DESCRIPTION
## Summary

Run \`scripts/remove_out_of_scope_validation.py --apply\` to surgically strip \`content_validation\` blocks from **243 out-of-scope** documentation pages. These blocks were authored before the scope policy was formalized in \`scripts/lib/content_scope.py\` and AGENTS.md §Text Content Validation.

This is **sub-task C** of the PR 2d.2 sequence (Option 3 modified, A → C → B-series) per Oracle strategy. It runs **after** PR #47 (sub-task A) so the dashboard generator is already correctly using \`is_in_scope()\` before this editorial cleanup lands.

## Scope of removal (243 files, 1957 lines deleted)

| Section | Files | Why out of scope |
|---|---|---|
| \`docs/start-here/\` | 5 | Navigation indexes / overview pages |
| \`docs/reference/\` | 9 | Quick-lookup references (CLI, env vars, etc.) |
| \`docs/language-guides/\` | ~200 | Tutorials and recipes (use validation tracking instead) |
| \`docs/troubleshooting/kql/\` | 5 | KQL packs make no factual assertions of their own |
| \`docs/troubleshooting/lab-guides/\` | 14 | Use evidence-integrity model with Falsification step |
| Navigation indexes (root + section indexes) | 7 | \`NAVIGATION_INDEXES\` in \`content_scope.py\` |

In-scope pages were **not** touched. Dashboard still shows 57 in-scope, 57 verified (identical to PR #47 output).

## Mechanism

- **Tool**: \`scripts/remove_out_of_scope_validation.py --apply --quiet\`
- **Scope source**: \`lib.content_scope.is_in_scope\` — same policy as dashboard generator and AGENTS.md table
- **Surgical removal**: only \`content_validation:\` key and indented body removed; all other frontmatter keys, ordering, quoting preserved

## Verification

| Check | Result |
|---|---|
| \`python3 scripts/normalize_yaml_frontmatter.py --check\` | 0 drift (303 files) |
| \`python3 scripts/normalize_mslearn_locale.py --check\` | 0 drift (380 files) |
| \`python3 scripts/generate_content_validation_status.py\` | 57 in-scope, 57 verified (unchanged from PR #47) |
| \`mkdocs build --strict\` | pass in 26.76s |

## Strategy context

Per Oracle's PR 2d.2 strategy consultation (session \`ses_15449c667ffe6jHaDJz8Xd8aLT\`): full sequence is **A → C → B-series**.

- 2d.2a (#47, MERGED) — validator/dashboard sync
- **2d.2c (this PR)** — editorial cleanup
- 2d.2b-prep — investigate 6 'other' malformed frontmatter files
- 2d.2b1 — migrate platform/ + best-practices/ + operations/ to dict-form
- 2d.2b2 — migrate troubleshooting/ to dict-form
- 2d.2b3+ — language-guides batched by template family
- Final — strict schema enforcement (reject list-form)