### PR TITLE
fix(scripts): make validate_mslearn_urls defensive across all reference sub-keys

### DIFF
--- a/scripts/validate_mslearn_urls.py
+++ b/scripts/validate_mslearn_urls.py
@@ -70,38 +70,117 @@ def add_mslearn_urls(urls: set, values: Any) -> None:
             add_mslearn_url(urls, value)
 
 
-def extract_mslearn_urls(frontmatter: dict) -> List[str]:
-    """Extract all MSLearn URLs from content_sources in frontmatter."""
-    urls = set()
+# Reference-list sub-keys in dict-form content_sources. All semantically equivalent;
+# 'references' is the canonical key (see Phase 2d schema normalization plan).
+# Legacy aliases (sources, text, documents) are accepted during the migration window.
+REFERENCE_SUBKEYS = ("references", "sources", "text", "documents")
 
-    content_sources = frontmatter.get("content_sources", {})
 
-    source_items = []
+def iter_reference_items(content_sources: Any) -> Iterable[dict]:
+    """
+    Yield reference-list dict items from content_sources frontmatter.
+
+    Supports both list-form content_sources (legacy) and dict-form with any of
+    the known reference sub-key aliases. Items under unknown sub-keys are
+    skipped.
+
+    >>> list(iter_reference_items({'references': [{'url': 'a'}]}))
+    [{'url': 'a'}]
+    >>> list(iter_reference_items({'sources': [{'url': 'b'}]}))
+    [{'url': 'b'}]
+    >>> list(iter_reference_items({'text': [{'url': 'c'}]}))
+    [{'url': 'c'}]
+    >>> list(iter_reference_items({'documents': [{'url': 'd'}]}))
+    [{'url': 'd'}]
+    >>> list(iter_reference_items([{'url': 'e'}, {'url': 'f'}]))
+    [{'url': 'e'}, {'url': 'f'}]
+    >>> list(iter_reference_items({'unknown_key': [{'url': 'z'}]}))
+    []
+    >>> list(iter_reference_items({}))
+    []
+    >>> list(iter_reference_items(None))
+    []
+    >>> sorted(item['url'] for item in iter_reference_items({'references': [{'url': 'a'}], 'sources': [{'url': 'b'}]}))
+    ['a', 'b']
+    """
+    if isinstance(content_sources, list):
+        for item in content_sources:
+            if isinstance(item, dict):
+                yield item
+    elif isinstance(content_sources, dict):
+        for key in REFERENCE_SUBKEYS:
+            items = content_sources.get(key)
+            if isinstance(items, list):
+                for item in items:
+                    if isinstance(item, dict):
+                        yield item
+
+
+def iter_diagram_items(content_sources: Any) -> Iterable[dict]:
+    """
+    Yield diagram dict items from content_sources frontmatter.
+
+    Diagrams only appear under dict-form content_sources.diagrams.
+
+    >>> list(iter_diagram_items({'diagrams': [{'id': 'foo'}]}))
+    [{'id': 'foo'}]
+    >>> list(iter_diagram_items({'references': [{'url': 'a'}]}))
+    []
+    >>> list(iter_diagram_items([{'url': 'a'}]))
+    []
+    >>> list(iter_diagram_items(None))
+    []
+    >>> list(iter_diagram_items({}))
+    []
+    """
     if isinstance(content_sources, dict):
-        nested_sources = content_sources.get("sources", [])
-        if isinstance(nested_sources, list):
-            source_items.extend(nested_sources)
-        source_items.extend(content_sources.get("diagrams", []))
-        source_items.append(content_sources)
-    elif isinstance(content_sources, list):
-        source_items.extend(content_sources)
-    else:
-        source_items = []
+        diagrams = content_sources.get("diagrams")
+        if isinstance(diagrams, list):
+            for item in diagrams:
+                if isinstance(item, dict):
+                    yield item
 
-    for source in source_items:
-        if isinstance(source, dict):
-            add_mslearn_url(urls, source.get("url"))
-            add_mslearn_url(urls, source.get("mslearn_url"))
-            add_mslearn_urls(urls, source.get("based_on", []))
 
-            nested_diagrams = source.get("diagrams", [])
-            if isinstance(nested_diagrams, list):
-                for diagram in nested_diagrams:
-                    if isinstance(diagram, dict):
-                        add_mslearn_url(urls, diagram.get("mslearn_url"))
-                        add_mslearn_urls(urls, diagram.get("based_on", []))
+def extract_mslearn_urls(frontmatter: dict) -> List[str]:
+    """Extract all MSLearn URLs from content_sources in frontmatter.
 
-    return list(urls)
+    Deduplicates URLs and returns deterministic sorted order.
+    Supports list-form and dict-form content_sources. All four reference
+    sub-key aliases (references, sources, text, documents) are accepted
+    during the Phase 2d schema migration window.
+
+    >>> extract_mslearn_urls({'content_sources': {'references': [{'url': 'https://learn.microsoft.com/a'}]}})
+    ['https://learn.microsoft.com/a']
+    >>> extract_mslearn_urls({'content_sources': {'sources': [{'url': 'https://learn.microsoft.com/b'}]}})
+    ['https://learn.microsoft.com/b']
+    >>> extract_mslearn_urls({'content_sources': {'text': [{'url': 'https://learn.microsoft.com/c'}]}})
+    ['https://learn.microsoft.com/c']
+    >>> extract_mslearn_urls({'content_sources': {'documents': [{'url': 'https://learn.microsoft.com/d'}]}})
+    ['https://learn.microsoft.com/d']
+    >>> extract_mslearn_urls({'content_sources': [{'url': 'https://learn.microsoft.com/e'}]})
+    ['https://learn.microsoft.com/e']
+    >>> extract_mslearn_urls({'content_sources': {'diagrams': [{'based_on': ['https://learn.microsoft.com/f']}]}})
+    ['https://learn.microsoft.com/f']
+    >>> extract_mslearn_urls({'content_sources': {'references': [{'url': 'https://example.com/skip-non-mslearn'}]}})
+    []
+    >>> extract_mslearn_urls({})
+    []
+    >>> extract_mslearn_urls({'content_sources': {'references': [{'url': 'https://learn.microsoft.com/g'}], 'diagrams': [{'based_on': ['https://learn.microsoft.com/g']}]}})
+    ['https://learn.microsoft.com/g']
+    """
+    urls = set()
+    content_sources = frontmatter.get("content_sources")
+
+    for item in iter_reference_items(content_sources):
+        add_mslearn_url(urls, item.get("url"))
+        add_mslearn_url(urls, item.get("mslearn_url"))
+        add_mslearn_urls(urls, item.get("based_on", []))
+
+    for diagram in iter_diagram_items(content_sources):
+        add_mslearn_url(urls, diagram.get("mslearn_url"))
+        add_mslearn_urls(urls, diagram.get("based_on", []))
+
+    return sorted(urls)
 
 
 def extract_source_section_urls(content: str) -> List[str]:
@@ -150,7 +229,11 @@ def check_url(
             if response.status_code == 429:
                 retry_after = response.headers.get("Retry-After")
                 if attempt < MAX_RETRIES:
-                    delay = float(retry_after) if retry_after and retry_after.isdigit() else 2**attempt
+                    delay = (
+                        float(retry_after)
+                        if retry_after and retry_after.isdigit()
+                        else 2**attempt
+                    )
                     time.sleep(delay)
                     continue
                 return (url, response.status_code, "rate_limited", None)
@@ -372,7 +455,9 @@ def main():
         print("\nBroken URLs require manual fixing!")
         sys.exit(1)
     elif total_rate_limited > 0:
-        print("\nSome URLs were rate limited after retries; rerun later for full coverage.")
+        print(
+            "\nSome URLs were rate limited after retries; rerun later for full coverage."
+        )
         sys.exit(0)
     elif total_redirects > 0:
         print("\nRedirected URLs should be updated to canonical versions.")


### PR DESCRIPTION
## Summary

`validate_mslearn_urls.py` only read `content_sources.sources` and silently skipped URLs under other valid sub-keys. This PR adds defensive readers that handle all 4 alias keys uniformly.

## Why

Cross-repo schema audit found 4 sub-key naming conventions in active use across sibling repos. In this repo specifically:

- `docs/platform/architecture/index.md` uses the newer `references:` form — its URLs were not being validated
- 6 files use `sources:` (5 networking-scenarios + 1 validation-status)
- Most other files use the legacy list-form `content_sources: [...]` (already supported)

All sub-key variants are semantically identical (arrays of `{type, url, mslearn_url?}`).

## What changed

- Removed the awkward `source_items.append(content_sources)` trick (was a way to read top-level `content_sources` dict as if it were a source item, which silently absorbed valid alias keys)
- New `REFERENCE_SUBKEYS` constant lists all 4 accepted alias keys
- New `iter_reference_items()` helper yields ref items from both list-form (legacy) and dict-form with any of the 4 aliases
- New `iter_diagram_items()` helper isolates diagram traversal
- `extract_mslearn_urls()` rewritten on top of the new helpers; deduplicates URLs and returns sorted order for deterministic output
- **23 doctests** added (9 + 5 + 9) covering: each alias key, list-form, unknown keys, None/empty inputs, mixed inputs, non-MSLearn URL skipping, dedup

## Validation

- `python3 -m doctest scripts/validate_mslearn_urls.py -v` → 23 passed
- `python3 scripts/validate_content_sources.py` → no regression
- Script imports cleanly, sample extraction works

## Scope

**Code-only.** No data changes in this PR. The 4 alias keys are accepted as semantically equivalent during the Phase 2d migration window. Schema normalization to canonical `references:` is a separate follow-up PR.

## Phase 2d roadmap

- This PR (2d.2b-prep) — defensive reader fix (3 sibling repos in parallel)
- PR 2d.2b1 — migrate `platform/`, `best-practices/`, `operations/` to dict-form
- PR 2d.2b2 — migrate `troubleshooting/`
- PR 2d.2b3+ — language-guides batched by template family
- Final PR — reject legacy list-form
- Later — normalize alias keys (`sources:`/`text:`/`documents:`) → `references:`

Refs: PR 2d.2b-prep (cross-repo coordinated with sibling repos `azure-container-apps-practical-guide` and `azure-app-service-practical-guide`)