### PR TITLE
feat(validation): expand legacy escape to dict-form references and migrate safe sections (2d.2b1-functions)

### DIFF
--- a/docs/best-practices/common-anti-patterns.md
+++ b/docs/best-practices/common-anti-patterns.md
@@ -1,9 +1,10 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/best-practices/cost-optimization.md
+++ b/docs/best-practices/cost-optimization.md
@@ -1,9 +1,10 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/pricing
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/pricing
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/best-practices/deployment.md
+++ b/docs/best-practices/deployment.md
@@ -1,9 +1,10 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/best-practices/hosting-plan-selection.md
+++ b/docs/best-practices/hosting-plan-selection.md
@@ -1,11 +1,12 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/best-practices/index.md
+++ b/docs/best-practices/index.md
@@ -1,12 +1,13 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
 ---
 # Best Practices
 

--- a/docs/best-practices/networking.md
+++ b/docs/best-practices/networking.md
@@ -1,15 +1,16 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options#private-endpoints
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options#private-endpoints
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/best-practices/reliability.md
+++ b/docs/best-practices/reliability.md
@@ -1,21 +1,22 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-idempotent
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reliable-event-processing
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#timeout
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-idempotent
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reliable-event-processing
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#timeout
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/best-practices/scaling.md
+++ b/docs/best-practices/scaling.md
@@ -1,13 +1,14 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/best-practices/security.md
+++ b/docs/best-practices/security.md
@@ -1,17 +1,18 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/best-practices/trigger-and-binding.md
+++ b/docs/best-practices/trigger-and-binding.md
@@ -1,11 +1,12 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/alerts.md
+++ b/docs/operations/alerts.md
@@ -1,15 +1,16 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-metric
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-log
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-create-log-alert-rule
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/proactive-diagnostics
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-metric
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-log
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-create-log-alert-rule
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/proactive-diagnostics
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/cold-start.md
+++ b/docs/operations/cold-start.md
@@ -1,15 +1,16 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/analyze-telemetry-data
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -1,15 +1,16 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/cost-optimization.md
+++ b/docs/operations/cost-optimization.md
@@ -1,15 +1,16 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -1,13 +1,14 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/run-functions-from-deployment-package
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-github-actions
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,12 +1,13 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 ---
 # Operations
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -1,13 +1,14 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/monitor-functions
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/recovery.md
+++ b/docs/operations/recovery.md
@@ -1,17 +1,18 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/architecture/framework/resiliency/disaster-recovery
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/frontdoor/health-probes
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/architecture/framework/resiliency/disaster-recovery
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-slots
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/frontdoor/health-probes
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/retries-and-poison-handling.md
+++ b/docs/operations/retries-and-poison-handling.md
@@ -1,13 +1,14 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/operations/security.md
+++ b/docs/operations/security.md
@@ -1,21 +1,22 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/role-based-access-control/overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-rest-api#app-service-cors-versus-your-cors
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/platform-logs-overview
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/role-based-access-control/overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-rest-api#app-service-cors-versus-your-cors
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-ip-restrictions
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/platform-logs-overview
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/platform/deployment-scenarios.md
+++ b/docs/platform/deployment-scenarios.md
@@ -1,17 +1,18 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob#configure-an-identity-based-connection
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-vnet
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference?tabs=blob#configure-an-identity-based-connection
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/platform/functions-vs-app-service.md
+++ b/docs/platform/functions-vs-app-service.md
@@ -1,15 +1,16 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-decision-tree
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/platform/hosting.md
+++ b/docs/platform/hosting.md
@@ -1,15 +1,16 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-hosting-plans
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -1,16 +1,17 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/reliability/reliability-functions
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/reliability/reliability-functions
 ---
 # Platform
 

--- a/docs/platform/networking-scenarios/fixed-outbound-nat.md
+++ b/docs/platform/networking-scenarios/fixed-outbound-nat.md
@@ -1,6 +1,6 @@
 ---
 content_sources:
-  sources:
+  references:
     - type: mslearn-adapted
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted

--- a/docs/platform/networking-scenarios/index.md
+++ b/docs/platform/networking-scenarios/index.md
@@ -1,6 +1,6 @@
 ---
 content_sources:
-  sources:
+  references:
     - type: mslearn-adapted
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted

--- a/docs/platform/networking-scenarios/private-egress.md
+++ b/docs/platform/networking-scenarios/private-egress.md
@@ -1,6 +1,6 @@
 ---
 content_sources:
-  sources:
+  references:
     - type: mslearn-adapted
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted

--- a/docs/platform/networking-scenarios/private-ingress.md
+++ b/docs/platform/networking-scenarios/private-ingress.md
@@ -1,6 +1,6 @@
 ---
 content_sources:
-  sources:
+  references:
     - type: mslearn-adapted
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted

--- a/docs/platform/networking-scenarios/public-only.md
+++ b/docs/platform/networking-scenarios/public-only.md
@@ -1,6 +1,6 @@
 ---
 content_sources:
-  sources:
+  references:
     - type: mslearn-adapted
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted

--- a/docs/platform/networking.md
+++ b/docs/platform/networking.md
@@ -1,13 +1,14 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-enable
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/networking/private-endpoint
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-nat-gateway-integration
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/platform/reliability.md
+++ b/docs/platform/reliability.md
@@ -1,15 +1,16 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/reliability/reliability-functions
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/reliability/reliability-functions
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/platform/scaling.md
+++ b/docs/platform/scaling.md
@@ -1,17 +1,18 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-perf-and-scale
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-concurrency
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-perf-and-scale
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/platform/security.md
+++ b/docs/platform/security.md
@@ -1,13 +1,14 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-protect-backend-with-aad
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/api-management/api-management-howto-protect-backend-with-aad
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/platform/triggers-and-bindings.md
+++ b/docs/platform/triggers-and-bindings.md
@@ -1,17 +1,18 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/event-driven-scaling
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/scripts/validate_content_sources.py
+++ b/scripts/validate_content_sources.py
@@ -125,16 +125,79 @@ def find_diagram_id_comments(content: str) -> Dict[int, str]:
 
 def get_diagram_sources(content_sources: Any) -> Tuple[List[dict], bool]:
     """
-    Return diagram-level source metadata from content_sources.
+    Return ``(diagrams, legacy_escape)`` from ``content_sources``.
 
-    Older pages in this repository use list-form content_sources for document-level
-    Microsoft Learn attribution. Keep those pages actionable by validating their
-    diagram-id comments without treating the legacy shape as a Python error.
+    The validator gates strict diagram-level validation on the Mermaid blocks
+    present in a file. ``legacy_escape=True`` activates the legacy-permissive
+    code path: a page is allowed to have Mermaid blocks without per-diagram
+    provenance, as a transition aid while data is migrated to the canonical
+    ``{diagrams: [...]}`` shape.
+
+    Two legacy shapes activate the escape:
+
+    1. List-form ``content_sources``: ``[{type, url}, ...]`` — the oldest
+       shape, document-level provenance only.
+    2. Dict-form with ``references:`` present and no ``diagrams:`` key:
+       ``{references: [...]}`` — semantically identical to (1) after the Phase
+       2d.2b-prep migration to dict-form. The document still has Microsoft
+       Learn attribution but has not yet declared per-diagram provenance.
+
+    Cases that intentionally do NOT activate the escape:
+
+    - ``{diagrams: []}`` — someone added the key but failed to populate it.
+      Surface as ``content_sources.diagrams is empty`` so the gap is visible.
+    - ``{diagrams: <non-list>}`` — malformed; surface explicitly.
+    - ``{}`` or dicts with neither ``references`` nor ``diagrams`` — no
+      document-level provenance to fall back on; not legacy data, just broken.
+
+    Doctests (regression for Phase 2d.2b1-functions):
+
+    >>> # Legacy list-form -> escape
+    >>> get_diagram_sources([{'type': 'mslearn', 'url': 'https://example'}])
+    ([], True)
+
+    >>> # Dict-form {references} without diagrams -> escape
+    >>> get_diagram_sources({'references': [{'type': 'mslearn', 'url': 'https://example'}]})
+    ([], True)
+
+    >>> # Explicit empty diagrams -> NO escape (surface as error)
+    >>> get_diagram_sources({'diagrams': []})
+    ([], False)
+
+    >>> # Explicit empty diagrams alongside references -> NO escape
+    >>> get_diagram_sources({'references': [{'url': 'https://example'}], 'diagrams': []})
+    ([], False)
+
+    >>> # Populated diagrams -> canonical path, no escape
+    >>> result, legacy = get_diagram_sources({'diagrams': [{'id': 'foo', 'source': 'mslearn'}]})
+    >>> legacy
+    False
+    >>> [d['id'] for d in result]
+    ['foo']
+
+    >>> # Empty dict -> NO escape (broken, not legacy)
+    >>> get_diagram_sources({})
+    ([], False)
+
+    >>> # Malformed diagrams (non-list) -> NO escape
+    >>> get_diagram_sources({'diagrams': 'not-a-list'})
+    ([], False)
+
+    >>> # None -> NO escape
+    >>> get_diagram_sources(None)
+    ([], False)
     """
     if isinstance(content_sources, dict):
-        diagrams = content_sources.get("diagrams", [])
-        if isinstance(diagrams, list):
-            return diagrams, False
+        if "diagrams" in content_sources:
+            diagrams = content_sources["diagrams"]
+            if isinstance(diagrams, list):
+                return diagrams, False
+            return [], False
+        # ``diagrams`` key absent; permit the legacy escape only when
+        # ``references`` is present (i.e., the document still has document-level
+        # provenance, just not per-diagram).
+        if "references" in content_sources:
+            return [], True
         return [], False
 
     if isinstance(content_sources, list):


### PR DESCRIPTION
## Summary

Closes the sibling-coordination gap for Functions's Phase 2d.2b1 safe-section migration. ACA #196 (`dc65f4c`) and AS #100 (`c411d2a`) already shipped the safe-section data migration in their repos using the canonical `{references: [...]}` shape; Functions held back because its `validate_content_sources.py` was strict in a way that ACA's and AS's were not. This PR closes that gap with a single, focused validator change and then applies the same safe-section migration to Functions.

## The validator gap and Oracle's binding design

Functions's validator already had a legacy-permissive escape in `get_diagram_sources()`, but it only covered **list-form** `content_sources` (the oldest shape: `[{type, url}, ...]`). The Phase 2d.2b-prep migration moves data into dict-form `{references: [...]}`, which is **semantically identical** to the old list-form (document-level provenance only, no per-diagram provenance), but the legacy escape didn't recognize this shape. Without this fix, the Functions safe-section migration would produce 29 `content_sources.diagrams is empty` errors on pages that legitimately don't yet have per-diagram provenance.

Per Oracle's binding 2d.2b1 review:

- `{references: [...]}` (no `diagrams` key) → activate legacy escape (semantically equivalent to list-form).
- Explicit `{diagrams: []}` → **still error** (someone tried but failed to populate; gap must remain visible).
- Malformed dicts with neither `references` nor `diagrams` → **still error** (no document-level provenance, not legacy data, just broken).
- Do NOT broaden the escape to "any dict missing diagrams" — keep it keyed to the `references` presence so partial migrations can't be masked.

## Validator changes

`scripts/validate_content_sources.py` — only `get_diagram_sources()` is rewritten:

| Input | Before | After |
|---|---|---|
| `[{type, url}, ...]` (legacy list-form) | `([], True)` legacy escape | `([], True)` legacy escape (unchanged) |
| `{diagrams: [{...}]}` populated | `(diagrams, False)` canonical | `(diagrams, False)` canonical (unchanged) |
| `{diagrams: []}` explicit empty | `([], False)` → error | `([], False)` → error (unchanged — Oracle's intent) |
| `{diagrams: <non-list>}` malformed | `([], False)` → error | `([], False)` → error (unchanged) |
| `{references: [...]}` (no `diagrams` key) | `([], False)` → error | `([], True)` legacy escape (**NEW**) |
| `{}` empty dict | `([], False)` → error | `([], False)` → error (unchanged) |
| `None` / other type | `([], False)` → error | `([], False)` → error (unchanged) |

The docstring documents the contract and contains **10 doctests** (Oracle's requested regression test format) covering all eight boundary cases above plus the two-expression populated-diagrams case. Run them with:

```bash
python -m doctest scripts/validate_content_sources.py -v
```

## Data migration

Applied the same script that produced ACA #196 and AS #100:

```bash
python3 scripts/normalize_content_sources_schema.py --apply --paths-glob 'platform/**/*.md'
python3 scripts/normalize_content_sources_schema.py --apply --paths-glob 'best-practices/**/*.md'
python3 scripts/normalize_content_sources_schema.py --apply --paths-glob 'operations/**/*.md'
```

Per-section counts:

| Section | Files migrated |
|---|---|
| `platform/` | 14 |
| `best-practices/` | 10 |
| `operations/` | 10 |

Two transformations applied:

- **A**: `content_sources: [{type, url}, ...]` → `{references: [...]}`
- **B**: alias keys (`sources`, `text`, `documents`) → renamed to `references`

## Verification

All strict CI checks pass locally:

| Check | Result |
|---|---|
| `python -m doctest scripts/validate_content_sources.py -v` | 10/10 pass |
| `python scripts/validate_content_sources.py` | 0 errors / 303 files |
| `python scripts/normalize_yaml_frontmatter.py --check` | 0 drift / 303 files |
| `python scripts/normalize_mslearn_locale.py --check` | 0 drift |
| `python scripts/validate_mermaid_format.py` | 0 errors |
| `python scripts/validate_mermaid_syntax.py` | 0 errors |
| `python scripts/normalize_content_sources_schema.py --check --paths-glob '<safe sections>'` | 0 drift (idempotent) |
| `mkdocs build --strict` | builds in 31s |

The validator's strict-against-`{diagrams: []}` invariant is exercised by doctest case 3 (and case 4 with `references` alongside) so the policy boundary is locked in.

## Out of scope (intentional)

- `troubleshooting/**` → PR 2d.2b2 (sibling-coordinated across all three repos)
- `language-guides/**` → PR 2d.2b3+ (Functions has 205 files; will be batched)
- `reference/**`, `start-here/**` → small remainder folded into 2d.2b2 / 2d.2b3

## Sibling-repo coordination

This PR is the Functions-side equivalent of:

- ACA #196 (`dc65f4c`) — 2 safe-section files migrated, no validator change needed
- AS #100 (`c411d2a`) — 3 safe-section files migrated, no validator change needed

The validator change in this PR is Functions-only because Functions runs `validate_content_sources.py` as a soft (`continue-on-error: true`) CI step that surfaces gaps in older Functions content. ACA's and AS's equivalents already error on dict-form without diagrams when Mermaid is present, but their safe-section files always paired Mermaid with populated `diagrams:` metadata, so they didn't need the legacy escape. Functions's safe-section files often don't have per-diagram provenance yet, so the escape is required during the migration window.

## Phase 2d.2b roadmap

- ✅ 2d.2b-prep: defensive reader (merged)
- ✅ 2d.2b0: tool only (merged)
- ✅ 2d.2b1 (ACA + AS): safe-section data migration in ACA + AS (merged)
- ⏳ **2d.2b1-functions** (this PR): Functions validator update + Functions safe-section migration
- ⏳ 2d.2b2: data migration `troubleshooting/` (all 3 repos)
- ⏳ 2d.2b3+: data migration `language-guides/` (batched)
- ⏳ Final: tighten validator to reject legacy shapes, add CI doctest step
