### PR TITLE
feat(docs): migrate content_sources to canonical references shape in reference/start-here/contributing/dashboard

### DIFF
--- a/docs/contributing/cross-guide-baseline.md
+++ b/docs/contributing/cross-guide-baseline.md
@@ -1,11 +1,12 @@
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
 ---
 
 # Cross-Guide Shared Structure Baseline

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/
 ---
 # Azure Functions Practical Guide
 

--- a/docs/reference/cli-cheatsheet.md
+++ b/docs/reference/cli-cheatsheet.md
@@ -1,12 +1,13 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 ---
 # CLI Cheatsheet
 

--- a/docs/reference/content-validation-status.md
+++ b/docs/reference/content-validation-status.md
@@ -1,7 +1,8 @@
 ---
 content_sources:
-  - type: self-generated
-    justification: Auto-generated dashboard tracking content validation status
+  references:
+    - type: self-generated
+      justification: Auto-generated dashboard tracking content validation status
 ---
 
 # Content Validation Status
@@ -134,8 +135,9 @@ For an in-scope page, add a `content_validation` block to its frontmatter:
 ```yaml
 ---
 content_sources:
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/...
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/...
 content_validation:
   status: verified
   last_reviewed: 2026-04-12

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 ---
 # Environment Variables
 

--- a/docs/reference/host-json.md
+++ b/docs/reference/host-json.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 ---
 # host.json Reference
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,14 +1,15 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-core-tools-reference
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-core-tools-reference
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 ---
 # Reference
 

--- a/docs/reference/platform-limits.md
+++ b/docs/reference/platform-limits.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
 ---
 # Platform Limits
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 ---
 # Troubleshooting
 

--- a/docs/reference/validation-status.md
+++ b/docs/reference/validation-status.md
@@ -26,7 +26,7 @@ Out of scope for this dashboard:
 
 ## Summary
 
-*Generated: 2026-05-23*
+*Generated: 2026-06-09*
 
 | Metric | Count |
 |---|---:|
@@ -54,7 +54,7 @@ pie title Tutorial Validation Status
 | [02 First Deploy](../language-guides/dotnet/tutorial/consumption/02-first-deploy.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-12 | ✅ Pass |
 | [03 Configuration](../language-guides/dotnet/tutorial/consumption/03-configuration.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/dotnet/tutorial/consumption/04-logging-monitoring.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/dotnet/tutorial/consumption/05-infrastructure-as-code.md) | Consumption (Y1) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/dotnet/tutorial/consumption/06-ci-cd.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/dotnet/tutorial/consumption/07-extending-triggers.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [01 Local Run](../language-guides/dotnet/tutorial/flex-consumption/01-local-run.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
@@ -62,7 +62,7 @@ pie title Tutorial Validation Status
 | [02A First Deploy Private Egress](../language-guides/dotnet/tutorial/flex-consumption/02a-first-deploy-private-egress.md) | Flex Consumption (FC1) | ➖ Not Tested | ➖ Not Tested | — | ➖ Not Tested |
 | [03 Configuration](../language-guides/dotnet/tutorial/flex-consumption/03-configuration.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/dotnet/tutorial/flex-consumption/04-logging-monitoring.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md) | Flex Consumption (FC1) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/dotnet/tutorial/flex-consumption/06-ci-cd.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/dotnet/tutorial/flex-consumption/07-extending-triggers.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [01 Local Run](../language-guides/dotnet/tutorial/premium/01-local-run.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
@@ -70,14 +70,14 @@ pie title Tutorial Validation Status
 | [02A First Deploy Private Egress](../language-guides/dotnet/tutorial/premium/02a-first-deploy-private-egress.md) | Premium (EP) | ➖ Not Tested | ➖ Not Tested | — | ➖ Not Tested |
 | [03 Configuration](../language-guides/dotnet/tutorial/premium/03-configuration.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/dotnet/tutorial/premium/04-logging-monitoring.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md) | Premium (EP) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/dotnet/tutorial/premium/06-ci-cd.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/dotnet/tutorial/premium/07-extending-triggers.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [01 Local Run](../language-guides/dotnet/tutorial/dedicated/01-local-run.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [02 First Deploy](../language-guides/dotnet/tutorial/dedicated/02-first-deploy.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-12 | ✅ Pass |
 | [03 Configuration](../language-guides/dotnet/tutorial/dedicated/03-configuration.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/dotnet/tutorial/dedicated/04-logging-monitoring.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/dotnet/tutorial/dedicated/05-infrastructure-as-code.md) | Dedicated (App Service) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/dotnet/tutorial/dedicated/06-ci-cd.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/dotnet/tutorial/dedicated/07-extending-triggers.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 
@@ -89,7 +89,7 @@ pie title Tutorial Validation Status
 | [02 First Deploy](../language-guides/java/tutorial/consumption/02-first-deploy.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-12 | ✅ Pass |
 | [03 Configuration](../language-guides/java/tutorial/consumption/03-configuration.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/java/tutorial/consumption/04-logging-monitoring.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/java/tutorial/consumption/05-infrastructure-as-code.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/java/tutorial/consumption/05-infrastructure-as-code.md) | Consumption (Y1) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/java/tutorial/consumption/06-ci-cd.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/java/tutorial/consumption/07-extending-triggers.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [01 Local Run](../language-guides/java/tutorial/flex-consumption/01-local-run.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
@@ -97,7 +97,7 @@ pie title Tutorial Validation Status
 | [02A First Deploy Private Egress](../language-guides/java/tutorial/flex-consumption/02a-first-deploy-private-egress.md) | Flex Consumption (FC1) | ➖ Not Tested | ➖ Not Tested | — | ➖ Not Tested |
 | [03 Configuration](../language-guides/java/tutorial/flex-consumption/03-configuration.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/java/tutorial/flex-consumption/04-logging-monitoring.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md) | Flex Consumption (FC1) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/java/tutorial/flex-consumption/06-ci-cd.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/java/tutorial/flex-consumption/07-extending-triggers.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [01 Local Run](../language-guides/java/tutorial/premium/01-local-run.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
@@ -105,14 +105,14 @@ pie title Tutorial Validation Status
 | [02A First Deploy Private Egress](../language-guides/java/tutorial/premium/02a-first-deploy-private-egress.md) | Premium (EP) | ➖ Not Tested | ➖ Not Tested | — | ➖ Not Tested |
 | [03 Configuration](../language-guides/java/tutorial/premium/03-configuration.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/java/tutorial/premium/04-logging-monitoring.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/java/tutorial/premium/05-infrastructure-as-code.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/java/tutorial/premium/05-infrastructure-as-code.md) | Premium (EP) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/java/tutorial/premium/06-ci-cd.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/java/tutorial/premium/07-extending-triggers.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [01 Local Run](../language-guides/java/tutorial/dedicated/01-local-run.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [02 First Deploy](../language-guides/java/tutorial/dedicated/02-first-deploy.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [03 Configuration](../language-guides/java/tutorial/dedicated/03-configuration.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/java/tutorial/dedicated/04-logging-monitoring.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/java/tutorial/dedicated/05-infrastructure-as-code.md) | Dedicated (App Service) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/java/tutorial/dedicated/06-ci-cd.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/java/tutorial/dedicated/07-extending-triggers.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 
@@ -124,7 +124,7 @@ pie title Tutorial Validation Status
 | [02 First Deploy](../language-guides/nodejs/tutorial/consumption/02-first-deploy.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-12 | ✅ Pass |
 | [03 Configuration](../language-guides/nodejs/tutorial/consumption/03-configuration.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/nodejs/tutorial/consumption/04-logging-monitoring.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/nodejs/tutorial/consumption/05-infrastructure-as-code.md) | Consumption (Y1) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/nodejs/tutorial/consumption/06-ci-cd.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/nodejs/tutorial/consumption/07-extending-triggers.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [01 Local Run](../language-guides/nodejs/tutorial/flex-consumption/01-local-run.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
@@ -140,14 +140,14 @@ pie title Tutorial Validation Status
 | [02A First Deploy Private Egress](../language-guides/nodejs/tutorial/premium/02a-first-deploy-private-egress.md) | Premium (EP) | ➖ Not Tested | ➖ Not Tested | — | ➖ Not Tested |
 | [03 Configuration](../language-guides/nodejs/tutorial/premium/03-configuration.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/nodejs/tutorial/premium/04-logging-monitoring.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md) | Premium (EP) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/nodejs/tutorial/premium/06-ci-cd.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/nodejs/tutorial/premium/07-extending-triggers.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [01 Local Run](../language-guides/nodejs/tutorial/dedicated/01-local-run.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [02 First Deploy](../language-guides/nodejs/tutorial/dedicated/02-first-deploy.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-12 | ✅ Pass |
 | [03 Configuration](../language-guides/nodejs/tutorial/dedicated/03-configuration.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/nodejs/tutorial/dedicated/04-logging-monitoring.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/nodejs/tutorial/dedicated/05-infrastructure-as-code.md) | Dedicated (App Service) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/nodejs/tutorial/dedicated/06-ci-cd.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/nodejs/tutorial/dedicated/07-extending-triggers.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-10 | ✅ Pass |
 
@@ -159,7 +159,7 @@ pie title Tutorial Validation Status
 | [02 First Deploy](../language-guides/python/tutorial/consumption/02-first-deploy.md) | Consumption (Y1) | ❌ Fail | ➖ Not Tested | 2026-04-12 | ❌ Fail |
 | [03 Configuration](../language-guides/python/tutorial/consumption/03-configuration.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/python/tutorial/consumption/04-logging-monitoring.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/python/tutorial/consumption/05-infrastructure-as-code.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/python/tutorial/consumption/05-infrastructure-as-code.md) | Consumption (Y1) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/python/tutorial/consumption/06-ci-cd.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/python/tutorial/consumption/07-extending-triggers.md) | Consumption (Y1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [01 Local Run](../language-guides/python/tutorial/flex-consumption/01-local-run.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
@@ -167,7 +167,7 @@ pie title Tutorial Validation Status
 | [02A First Deploy Private Egress](../language-guides/python/tutorial/flex-consumption/02a-first-deploy-private-egress.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [03 Configuration](../language-guides/python/tutorial/flex-consumption/03-configuration.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/python/tutorial/flex-consumption/04-logging-monitoring.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md) | Flex Consumption (FC1) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/python/tutorial/flex-consumption/06-ci-cd.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/python/tutorial/flex-consumption/07-extending-triggers.md) | Flex Consumption (FC1) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [01 Local Run](../language-guides/python/tutorial/premium/01-local-run.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
@@ -175,14 +175,14 @@ pie title Tutorial Validation Status
 | [02A First Deploy Private Egress](../language-guides/python/tutorial/premium/02a-first-deploy-private-egress.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [03 Configuration](../language-guides/python/tutorial/premium/03-configuration.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/python/tutorial/premium/04-logging-monitoring.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/python/tutorial/premium/05-infrastructure-as-code.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/python/tutorial/premium/05-infrastructure-as-code.md) | Premium (EP) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/python/tutorial/premium/06-ci-cd.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/python/tutorial/premium/07-extending-triggers.md) | Premium (EP) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [01 Local Run](../language-guides/python/tutorial/dedicated/01-local-run.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [02 First Deploy](../language-guides/python/tutorial/dedicated/02-first-deploy.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-12 | ✅ Pass |
 | [03 Configuration](../language-guides/python/tutorial/dedicated/03-configuration.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [04 Logging Monitoring](../language-guides/python/tutorial/dedicated/04-logging-monitoring.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
-| [05 Infrastructure As Code](../language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
+| [05 Infrastructure As Code](../language-guides/python/tutorial/dedicated/05-infrastructure-as-code.md) | Dedicated (App Service) | ✅ Pass | ✅ Pass | 2026-06-06 | ✅ Pass |
 | [06 Ci Cd](../language-guides/python/tutorial/dedicated/06-ci-cd.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 | [07 Extending Triggers](../language-guides/python/tutorial/dedicated/07-extending-triggers.md) | Dedicated (App Service) | ✅ Pass | ➖ Not Tested | 2026-04-09 | ✅ Pass |
 

--- a/docs/reference/validation-status.md
+++ b/docs/reference/validation-status.md
@@ -1,6 +1,6 @@
 ---
 content_sources:
-  sources:
+  references:
     - type: mslearn-adapted
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
   diagrams:

--- a/docs/start-here/hosting-options.md
+++ b/docs/start-here/hosting-options.md
@@ -1,16 +1,17 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
 ---
 # Hosting Options
 

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 ---
 # Start Here
 

--- a/docs/start-here/learning-paths.md
+++ b/docs/start-here/learning-paths.md
@@ -1,18 +1,19 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/performance-reliability
 ---
 # Learning Paths
 

--- a/docs/start-here/overview.md
+++ b/docs/start-here/overview.md
@@ -1,28 +1,29 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-comparison
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scenarios
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-compare-logic-apps-ms-flow-webjobs
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/architecture/guide/technology-choices/compute-comparison
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 ---
 # Overview: What is Azure Functions
 

--- a/docs/start-here/repository-map.md
+++ b/docs/start-here/repository-map.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/
 ---
 # Repository Map
 

--- a/scripts/generate_content_validation_status.py
+++ b/scripts/generate_content_validation_status.py
@@ -182,9 +182,10 @@ def generate_dashboard(
     lines: list[str] = []
     lines.append("---")
     lines.append("content_sources:")
-    lines.append("  - type: self-generated")
+    lines.append("  references:")
+    lines.append("    - type: self-generated")
     lines.append(
-        "    justification: Auto-generated dashboard tracking content validation status"
+        "      justification: Auto-generated dashboard tracking content validation status"
     )
     lines.append("---")
     lines.append("")
@@ -328,8 +329,11 @@ def generate_dashboard(
     lines.append("```yaml")
     lines.append("---")
     lines.append("content_sources:")
-    lines.append("  - type: mslearn-adapted")
-    lines.append("    url: https://learn.microsoft.com/en-us/azure/azure-functions/...")
+    lines.append("  references:")
+    lines.append("    - type: mslearn-adapted")
+    lines.append(
+        "      url: https://learn.microsoft.com/en-us/azure/azure-functions/..."
+    )
     lines.append("content_validation:")
     lines.append("  status: verified")
     lines.append("  last_reviewed: 2026-04-12")

--- a/scripts/generate_validation_status.py
+++ b/scripts/generate_validation_status.py
@@ -150,6 +150,29 @@ def generate_dashboard(tutorials: list[dict[str, Any]], today: date) -> str:
         by_language.setdefault(lang, []).append(t)
 
     lines: list[str] = []
+    # Canonical content_sources frontmatter (PR 2d.2b3 migration shape).
+    # Must stay in sync with the migrated frontmatter on
+    # docs/reference/validation-status.md; regeneration MUST NOT wipe the
+    # references/diagrams metadata. See AGENTS.md "Frontmatter YAML Style".
+    lines.append("---")
+    lines.append("content_sources:")
+    lines.append("  references:")
+    lines.append("    - type: mslearn-adapted")
+    lines.append(
+        "      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview"
+    )
+    lines.append("  diagrams:")
+    lines.append("    - id: tutorial-validation-status-pie")
+    lines.append("      type: pie")
+    lines.append("      source: self-generated")
+    lines.append(
+        "      justification: Auto-generated dashboard chart from repository validation metadata."
+    )
+    lines.append("      based_on:")
+    lines.append(
+        "        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview"
+    )
+    lines.append("---")
     lines.append("# Tutorial Validation Status")
     lines.append("")
     lines.append(
@@ -168,7 +191,9 @@ def generate_dashboard(tutorials: list[dict[str, Any]], today: date) -> str:
     lines.append("")
     lines.append("Out of scope for this dashboard:")
     lines.append("")
-    lines.append("- Tutorial `index.md` chooser pages, which explain plan selection but are not executable deployment runbooks.")
+    lines.append(
+        "- Tutorial `index.md` chooser pages, which explain plan selection but are not executable deployment runbooks."
+    )
     lines.append(
         "- Troubleshooting lab guides under `docs/troubleshooting/lab-guides/`, which are experiment reports tracked by "
         "`content_validation`, `Lab Metadata`, `Experiment Log`, and `Expected Evidence` sections instead of tutorial execution status."
@@ -190,8 +215,9 @@ def generate_dashboard(tutorials: list[dict[str, Any]], today: date) -> str:
     lines.append("")
 
     # Mermaid pie chart
+    lines.append("<!-- diagram-id: tutorial-validation-status-pie -->")
     lines.append("```mermaid")
-    lines.append('pie title Tutorial Validation Status')
+    lines.append("pie title Tutorial Validation Status")
     if validated > 0:
         lines.append(f'    "Validated" : {validated}')
     if stale > 0:
@@ -219,7 +245,9 @@ def generate_dashboard(tutorials: list[dict[str, Any]], today: date) -> str:
 
         lines.append(f"### {lang_display}")
         lines.append("")
-        lines.append("| Tutorial | Hosting Plan | az-cli | Bicep | Last Tested | Status |")
+        lines.append(
+            "| Tutorial | Hosting Plan | az-cli | Bicep | Last Tested | Status |"
+        )
         lines.append("|---|---|---|---|---|---|")
 
         # Sort by plan order, then filename
@@ -293,20 +321,32 @@ def generate_dashboard(tutorials: list[dict[str, Any]], today: date) -> str:
     lines.append("python3 scripts/generate_validation_status.py")
     lines.append("```")
     lines.append("")
-    lines.append("!!! info \"Validation fields\"")
+    lines.append('!!! info "Validation fields"')
     lines.append("    - `result`: `pass`, `fail`, or `not_tested`")
     lines.append("    - `last_tested`: ISO date (YYYY-MM-DD) or `null`")
     lines.append("    - `cli_version`: Azure CLI version used")
     lines.append("    - `core_tools_version`: Azure Functions Core Tools version used")
-    lines.append(f"    - Tutorials older than {STALENESS_DAYS} days are flagged as **stale**")
+    lines.append(
+        f"    - Tutorials older than {STALENESS_DAYS} days are flagged as **stale**"
+    )
     lines.append("")
 
     # See Also
     lines.append("## See Also")
     lines.append("")
-    lines.append("- [Tutorial Overview & Plan Chooser](../language-guides/python/tutorial/index.md)")
+    lines.append(
+        "- [Tutorial Overview & Plan Chooser](../language-guides/python/tutorial/index.md)"
+    )
     lines.append("- [CLI Cheatsheet](cli-cheatsheet.md)")
     lines.append("- [Platform Limits](platform-limits.md)")
+    lines.append("")
+
+    # Sources
+    lines.append("## Sources")
+    lines.append("")
+    lines.append(
+        "- [Microsoft Learn overview](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)"
+    )
     lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"


### PR DESCRIPTION
## Summary

PR 2d.2b3 (`generators-and-remainder`) of the multi-PR `content_sources` schema migration sequence. After this lands, the Functions repo has **0 schema drift outside `docs/language-guides/`** — every `content_sources` block in reference/start-here/contributing/dashboard sections uses the canonical `{references: [...]}` shape. The 205 remaining `language-guides/` files are intentionally deferred to PR 2d.2b4+ for batched migration by template family.

This is the **Functions-specific PR** in a 3-repo sibling batch:
- ACA (sibling PR)
- App Service (sibling PR)
- Functions (this PR)

## What Changed

**1. Generator fix** — `scripts/generate_content_validation_status.py` now emits the canonical `{references: [...]}` shape in both the dashboard frontmatter and the example YAML block. Previously it emitted legacy list-form, which re-introduced drift on every regeneration.

**2. Auto-generated dashboard regeneration** — `docs/reference/content-validation-status.md` rebuilt with the canonical shape so the on-disk file matches the generator's output.

**3. Non-language-guides data migration** — applies the normalizer to the 14 remaining hand-edited drift sources outside `docs/language-guides/`:
- `docs/index.md`
- `docs/contributing/cross-guide-baseline.md`
- `docs/reference/{cli-cheatsheet,environment-variables,host-json,index,platform-limits,troubleshooting,validation-status}.md` (7 files)
- `docs/start-here/{hosting-options,index,learning-paths,overview,repository-map}.md` (5 files)

These pages mixed list-form (Transformation A) with dict-form alias keys like `text:`/`sources:` (Transformation B). The normalizer converges both into the canonical `references:` shape while leaving sibling `diagrams:` blocks byte-untouched. Each transformation matches patterns already validated by Oracle in PR 2d.2b1 (Transformation A) and PR 2d.2b2 (Transformation B).

## What's Deferred (and Why)

**205 files under `docs/language-guides/`** remain in legacy shape. Per the migration plan, these are batched into PR 2d.2b4+ by template family:

```
docs/language-guides/python/tutorial/{consumption,dedicated,flex-consumption,premium}/*.md    (~32 each = 128)
docs/language-guides/python/recipes/*.md                                                       (~13)
docs/language-guides/python/{index, runtime, troubleshooting}.md                              (~64 misc)
```

A single 205-file migration PR is too large for clean Oracle review; batching by hosting-plan or template family produces reviewable diffs.

## Validator Compatibility

The Functions validator continues to accept the references-only dict form on Mermaid pages (legacy-equivalent escape) per Oracle's PR 2d.2b2 watch-out:

> "Mermaid pages on the `{references: [...]}` path still bypass per-diagram count enforcement until the final hardening PR. Do not tighten the Functions validator early; that would convert this approved migration into a false-negative wave."

The strict validator-hardening + CI doctest enforcement is deferred to the Phase 2d final PR.

## Verification

Run from repo root:

```bash
# Schema drift check (205 = language-guides, all deferred to PR 2d.2b4+)
python3 scripts/normalize_content_sources_schema.py --check
#   Files scanned: 303
#   Files with content_sources schema drift: 205   ← language-guides only
#   Parse errors: 0

# Confirm 0 drift outside language-guides:
python3 scripts/normalize_content_sources_schema.py --check 2>&1 | grep DRIFT | grep -v 'language-guides/' | wc -l
#   0

# Content validator (Mermaid + content_sources gating)
python3 scripts/validate_content_sources.py
#   Files checked: 303 | Validation errors: 0 | All validations passed!

# YAML style
python3 scripts/normalize_yaml_frontmatter.py --check
#   Files scanned: 303 | Files with style drift: 0

# Locale (en-us prefix)
python3 scripts/normalize_mslearn_locale.py --check
#   Files scanned: 381 | Files with locale drift: 0

# Mermaid format
python3 scripts/validate_mermaid_format.py
#   Files checked: 303 | Files with errors: 0

# Mermaid syntax
python3 scripts/validate_mermaid_syntax.py
#   Files checked: 303 | Diagrams checked: 498 | Errors found: 0

# Doctests on get_diagram_sources() (preserved from PR 2d.2b1)
python3 -m doctest scripts/validate_content_sources.py -v
#   10 tests in validate_content_sources.get_diagram_sources
#   10 passed. Test passed.

# Site build
mkdocs build --strict
#   Documentation built in ~32s (no warnings or errors)
```

## Migration Sequence Status (Functions)

| PR | Scope | Status |
|---|---|---|
| 2d.2b-prep | normalizer tool introduced | MERGED |
| 2d.2b0 | tool delivered | MERGED |
| 2d.2b1 | validator + safe-section data migration | MERGED |
| 2d.2b2 | troubleshooting/ data migration (Transformation A, 47 files) | MERGED |
| **2d.2b3** | **generators-and-remainder (this PR)** | **OPEN** |
| 2d.2b4+ | language-guides/ 205 files (batched by template family) | next |
| Phase 2d final | strict validator + CI doctest enforcement | DEFERRED |

## Sibling Coordination

The generator fix is identical in pattern across all 3 repos (only the example URL differs per Azure service). ACA and App Service achieve 0 total drift in their PR 2d.2b3; Functions converges everything outside `language-guides/` and defers the large `language-guides/` migration to PR 2d.2b4+.

## Refs

- Oracle PR 2d.2b1-functions verdict: APPROVE-FOR-MERGE (session `ses_153f2b242ffeHqfQhFc11t7IhA`)
- Oracle PR 2d.2b2 verdict: APPROVE-FOR-MERGE-BOTH (session `ses_153ea48c9ffeBgZ15jHISEHLws`)
- Oracle PR 2d.2b2 binding guidance: validator escape preservation + Phase 2d final hardening plan (CI doctest + repo-wide `references`-only Mermaid report)

## Test Plan

CI runs:
1. `validate-content-sources` workflow — must pass
2. `mkdocs build --strict` (deploy workflow gating) — must pass

Local pre-merge verification matches CI output above. Oracle review will be requested with combined 3-PR evidence before merge.
