### PR TITLE
feat(docs): migrate content_sources to canonical references shape in language-guides batch 1 (guide roots / reference-like)

### DIFF
--- a/docs/language-guides/dotnet/cli-cheatsheet.md
+++ b/docs/language-guides/dotnet/cli-cheatsheet.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 ---
 # CLI Cheatsheet
 

--- a/docs/language-guides/dotnet/dotnet-runtime.md
+++ b/docs/language-guides/dotnet/dotnet-runtime.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
 ---
 # .NET Runtime
 

--- a/docs/language-guides/dotnet/environment-variables.md
+++ b/docs/language-guides/dotnet/environment-variables.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 ---
 # Environment Variables
 

--- a/docs/language-guides/dotnet/host-json.md
+++ b/docs/language-guides/dotnet/host-json.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 ---
 # host.json Reference
 

--- a/docs/language-guides/dotnet/index.md
+++ b/docs/language-guides/dotnet/index.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
 ---
 # .NET Language Guide
 

--- a/docs/language-guides/dotnet/isolated-worker-model.md
+++ b/docs/language-guides/dotnet/isolated-worker-model.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # .NET Isolated Worker Model
 

--- a/docs/language-guides/dotnet/platform-limits.md
+++ b/docs/language-guides/dotnet/platform-limits.md
@@ -1,14 +1,15 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
 ---
 # Platform Limits
 

--- a/docs/language-guides/dotnet/troubleshooting.md
+++ b/docs/language-guides/dotnet/troubleshooting.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 ---
 # Troubleshooting
 

--- a/docs/language-guides/index.md
+++ b/docs/language-guides/index.md
@@ -1,14 +1,15 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 ---
 # Language Guides
 

--- a/docs/language-guides/java/annotation-programming-model.md
+++ b/docs/language-guides/java/annotation-programming-model.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Java Annotation Programming Model
 

--- a/docs/language-guides/java/cli-cheatsheet.md
+++ b/docs/language-guides/java/cli-cheatsheet.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 ---
 # CLI Cheatsheet
 

--- a/docs/language-guides/java/environment-variables.md
+++ b/docs/language-guides/java/environment-variables.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 ---
 # Environment Variables
 

--- a/docs/language-guides/java/host-json.md
+++ b/docs/language-guides/java/host-json.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 ---
 # host.json Reference
 

--- a/docs/language-guides/java/index.md
+++ b/docs/language-guides/java/index.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-java
 ---
 # Java Language Guide
 

--- a/docs/language-guides/java/java-runtime.md
+++ b/docs/language-guides/java/java-runtime.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 ---
 # Java Runtime
 

--- a/docs/language-guides/java/platform-limits.md
+++ b/docs/language-guides/java/platform-limits.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 ---
 # Platform Limits
 

--- a/docs/language-guides/java/troubleshooting.md
+++ b/docs/language-guides/java/troubleshooting.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 ---
 # Troubleshooting
 

--- a/docs/language-guides/nodejs/cli-cheatsheet.md
+++ b/docs/language-guides/nodejs/cli-cheatsheet.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
 ---
 # CLI Cheatsheet
 

--- a/docs/language-guides/nodejs/environment-variables.md
+++ b/docs/language-guides/nodejs/environment-variables.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 ---
 # Environment Variables
 

--- a/docs/language-guides/nodejs/host-json.md
+++ b/docs/language-guides/nodejs/host-json.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 ---
 # host.json Reference
 

--- a/docs/language-guides/nodejs/index.md
+++ b/docs/language-guides/nodejs/index.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4
 ---
 # Node.js Language Guide
 

--- a/docs/language-guides/nodejs/nodejs-runtime.md
+++ b/docs/language-guides/nodejs/nodejs-runtime.md
@@ -1,12 +1,13 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
 ---
 # Node.js Runtime
 

--- a/docs/language-guides/nodejs/platform-limits.md
+++ b/docs/language-guides/nodejs/platform-limits.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
 ---
 # Platform Limits
 

--- a/docs/language-guides/nodejs/troubleshooting.md
+++ b/docs/language-guides/nodejs/troubleshooting.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-diagnostics
 ---
 # Troubleshooting
 

--- a/docs/language-guides/nodejs/v4-programming-model.md
+++ b/docs/language-guides/nodejs/v4-programming-model.md
@@ -1,12 +1,13 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
 ---
 # Node.js v4 Programming Model
 

--- a/docs/language-guides/python/cli-cheatsheet.md
+++ b/docs/language-guides/python/cli-cheatsheet.md
@@ -1,12 +1,13 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/functionapp
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 ---
 # CLI Cheatsheet
 

--- a/docs/language-guides/python/environment-variables.md
+++ b/docs/language-guides/python/environment-variables.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 ---
 # Environment Variables
 

--- a/docs/language-guides/python/host-json.md
+++ b/docs/language-guides/python/host-json.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 ---
 # host.json Reference
 

--- a/docs/language-guides/python/index.md
+++ b/docs/language-guides/python/index.md
@@ -1,12 +1,13 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 ---
 # Python Language Guide
 

--- a/docs/language-guides/python/platform-limits.md
+++ b/docs/language-guides/python/platform-limits.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale#service-limits
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account
 ---
 # Platform Limits
 

--- a/docs/language-guides/python/python-runtime.md
+++ b/docs/language-guides/python/python-runtime.md
@@ -1,14 +1,15 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/supported-languages
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-how-to
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
 ---
 # Python Runtime
 

--- a/docs/language-guides/python/troubleshooting.md
+++ b/docs/language-guides/python/troubleshooting.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
 ---
 # Troubleshooting
 

--- a/docs/language-guides/python/v2-programming-model.md
+++ b/docs/language-guides/python/v2-programming-model.md
@@ -1,14 +1,15 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python
 ---
 # Python v2 Programming Model
 


### PR DESCRIPTION
## Summary

Migrates `content_sources` frontmatter to the canonical `{references: [...]}` dict shape for 33 guide roots and reference-like pages under `docs/language-guides/`. This is **PR 2d.2b4 batch 1** in the Functions repo — the first of three template-family batches planned to clear the remaining 205 drift files identified after PR 2d.2b3 merged.

## Scope (33 files)

- `docs/language-guides/index.md` (top-level section landing)
- 4 per-language landings: `{dotnet,java,nodejs,python}/index.md`
- 24 per-language reference-like pages: `cli-cheatsheet.md`, `environment-variables.md`, `host-json.md`, `platform-limits.md`, `troubleshooting.md`, and the language-specific runtime/programming-model pages (`dotnet-runtime.md`, `isolated-worker-model.md`, `java-runtime.md`, `annotation-programming-model.md`, `nodejs-runtime.md`, `v4-programming-model.md`, `python-runtime.md`, `v2-programming-model.md`)

## Change

Each file's `content_sources` migrated from legacy list-form (`content_sources: [{type, url}, ...]`) to canonical dict-form (`content_sources: {references: [{type, url}, ...]}`) using the shared `scripts/normalize_content_sources_schema.py` tool. **Pure schema migration** — no prose, code, or diagram changes. Body preserved byte-exact per the normalizer's contract.

## Why batched

Per Oracle's binding ordering in PR 2d.2b3 review (`ses_153d7466fffeY3Nft41nzkjZN5`):

> "Batch by template family, not by whole repo sweep: guide roots/reference-like pages first, then recipes, then tutorial plan families."

This PR handles only the first family. Subsequent PRs:
- **Batch 2**: 48 recipes/* files
- **Batch 3+**: 124 tutorial/* files
- **Phase 2d Final PR**: tighten Functions validator, audit all validator-skipped generated dashboards, repo-wide references-only Mermaid report, explicit removal/quarantine of `scripts/update_mermaid_metadata.py`

## Homogeneity verified

All 33 batch 1 files contain at least one Mermaid diagram. They therefore continue to sit on the references-only Mermaid legacy-permissive path per Oracle's binding watch-out (PR 2d.2b2):

> "Mermaid pages on the `{references: [...]}` path still bypass per-diagram count enforcement until the final hardening PR. Do not tighten the Functions validator early; that would convert this approved migration into a false-negative wave."

## Verification

Drift dropped from **205 → 172** (exactly 33 fewer = batch 1 size). All strict checks pass:

| Check | Result |
|---|---|
| `normalize_yaml_frontmatter --check` | 0 drift across 303 files |
| `normalize_content_sources_schema --check` | 172 drift (batches 2 + 3 remain) |
| `validate_content_sources` | 0 errors across 303 files |
| `validate_mermaid_format` | 0 errors across 303 files |
| `validate_mermaid_syntax` | 0 errors across 498 diagrams |
| `normalize_mslearn_locale --check` | 0 drift across 381 files |
| `content_scope.py` doctest | 14/14 passed |
| `mkdocs build --strict` | exit 0 |

## Cross-references

- Prior PRs in this sequence (all merged): Functions #46, #47, #48, #49, #50, #51, #52, #53; ACA #193, #194, #195, #196, #197, #198; App Service #98, #99, #100, #101
- Final-phase deferred cleanup queue tracked in PR 2d.2b3 commit messages
