### PR TITLE
feat(docs): migrate content_sources to canonical references shape in language-guides batch 2 (recipes)

### DIFF
--- a/docs/language-guides/dotnet/recipes/blob-storage.md
+++ b/docs/language-guides/dotnet/recipes/blob-storage.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Blob Storage
 

--- a/docs/language-guides/dotnet/recipes/cosmosdb.md
+++ b/docs/language-guides/dotnet/recipes/cosmosdb.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Cosmos DB
 

--- a/docs/language-guides/dotnet/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/dotnet/recipes/custom-domain-certificates.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Custom Domain and Certificates
 

--- a/docs/language-guides/dotnet/recipes/durable-orchestration.md
+++ b/docs/language-guides/dotnet/recipes/durable-orchestration.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Durable Orchestration
 

--- a/docs/language-guides/dotnet/recipes/event-grid.md
+++ b/docs/language-guides/dotnet/recipes/event-grid.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Event Grid
 

--- a/docs/language-guides/dotnet/recipes/http-api.md
+++ b/docs/language-guides/dotnet/recipes/http-api.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # HTTP API Patterns
 

--- a/docs/language-guides/dotnet/recipes/http-auth.md
+++ b/docs/language-guides/dotnet/recipes/http-auth.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # HTTP Authentication
 

--- a/docs/language-guides/dotnet/recipes/index.md
+++ b/docs/language-guides/dotnet/recipes/index.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
 ---
 # .NET Recipes
 

--- a/docs/language-guides/dotnet/recipes/key-vault.md
+++ b/docs/language-guides/dotnet/recipes/key-vault.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Key Vault
 

--- a/docs/language-guides/dotnet/recipes/managed-identity.md
+++ b/docs/language-guides/dotnet/recipes/managed-identity.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Managed Identity
 

--- a/docs/language-guides/dotnet/recipes/queue.md
+++ b/docs/language-guides/dotnet/recipes/queue.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Queue
 

--- a/docs/language-guides/dotnet/recipes/timer.md
+++ b/docs/language-guides/dotnet/recipes/timer.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Timer Trigger
 

--- a/docs/language-guides/java/recipes/blob-storage.md
+++ b/docs/language-guides/java/recipes/blob-storage.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 ---
 # Blob Storage Integration
 

--- a/docs/language-guides/java/recipes/cosmosdb.md
+++ b/docs/language-guides/java/recipes/cosmosdb.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
 ---
 # Cosmos DB Integration
 

--- a/docs/language-guides/java/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/java/recipes/custom-domain-certificates.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
 ---
 # Custom Domain and Certificates
 

--- a/docs/language-guides/java/recipes/durable-orchestration.md
+++ b/docs/language-guides/java/recipes/durable-orchestration.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings
 ---
 # Durable Orchestration
 

--- a/docs/language-guides/java/recipes/event-grid.md
+++ b/docs/language-guides/java/recipes/event-grid.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
 ---
 # Event Grid Trigger
 

--- a/docs/language-guides/java/recipes/http-api.md
+++ b/docs/language-guides/java/recipes/http-api.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 ---
 # HTTP API Patterns
 

--- a/docs/language-guides/java/recipes/http-auth.md
+++ b/docs/language-guides/java/recipes/http-auth.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger#working-with-client-identities
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger#working-with-client-identities
 ---
 # HTTP Authentication
 

--- a/docs/language-guides/java/recipes/index.md
+++ b/docs/language-guides/java/recipes/index.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Recipes
 

--- a/docs/language-guides/java/recipes/key-vault.md
+++ b/docs/language-guides/java/recipes/key-vault.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-java
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-java
 ---
 # Key Vault Integration
 

--- a/docs/language-guides/java/recipes/managed-identity.md
+++ b/docs/language-guides/java/recipes/managed-identity.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/java/api/overview/azure/identity-readme
 ---
 # Managed Identity
 

--- a/docs/language-guides/java/recipes/queue.md
+++ b/docs/language-guides/java/recipes/queue.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
 ---
 # Queue Storage Integration
 

--- a/docs/language-guides/java/recipes/timer.md
+++ b/docs/language-guides/java/recipes/timer.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 ---
 # Timer Trigger
 

--- a/docs/language-guides/nodejs/recipes/blob-storage.md
+++ b/docs/language-guides/nodejs/recipes/blob-storage.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
 ---
 # Blob Storage Patterns
 

--- a/docs/language-guides/nodejs/recipes/cosmosdb.md
+++ b/docs/language-guides/nodejs/recipes/cosmosdb.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference#configure-an-identity-based-connection
 ---
 # Cosmos DB Integration
 

--- a/docs/language-guides/nodejs/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/nodejs/recipes/custom-domain-certificates.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-bindings
 ---
 # Custom Domains and Certificates
 

--- a/docs/language-guides/nodejs/recipes/durable-orchestration.md
+++ b/docs/language-guides/nodejs/recipes/durable-orchestration.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
 ---
 # Durable Orchestration
 

--- a/docs/language-guides/nodejs/recipes/event-grid.md
+++ b/docs/language-guides/nodejs/recipes/event-grid.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest
 ---
 # Event Grid Events
 

--- a/docs/language-guides/nodejs/recipes/http-api.md
+++ b/docs/language-guides/nodejs/recipes/http-api.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
 ---
 # HTTP API Patterns
 

--- a/docs/language-guides/nodejs/recipes/http-auth.md
+++ b/docs/language-guides/nodejs/recipes/http-auth.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
 ---
 # HTTP Authentication
 

--- a/docs/language-guides/nodejs/recipes/index.md
+++ b/docs/language-guides/nodejs/recipes/index.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Node.js Recipes
 

--- a/docs/language-guides/nodejs/recipes/key-vault.md
+++ b/docs/language-guides/nodejs/recipes/key-vault.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/keyvault-secrets-readme
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/javascript/api/overview/azure/keyvault-secrets-readme
 ---
 # Key Vault Access
 

--- a/docs/language-guides/nodejs/recipes/managed-identity.md
+++ b/docs/language-guides/nodejs/recipes/managed-identity.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 ---
 # Managed Identity
 

--- a/docs/language-guides/nodejs/recipes/queue.md
+++ b/docs/language-guides/nodejs/recipes/queue.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
 ---
 # Queue Processing
 

--- a/docs/language-guides/nodejs/recipes/timer.md
+++ b/docs/language-guides/nodejs/recipes/timer.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
 ---
 # Timer Jobs
 

--- a/docs/language-guides/python/recipes/blob-storage.md
+++ b/docs/language-guides/python/recipes/blob-storage.md
@@ -1,14 +1,15 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan#trigger-support
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-blob-trigger
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan#trigger-support
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 ---
 # Blob Storage
 

--- a/docs/language-guides/python/recipes/cosmosdb.md
+++ b/docs/language-guides/python/recipes/cosmosdb.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 ---
 # Cosmos DB Integration
 

--- a/docs/language-guides/python/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/python/recipes/custom-domain-certificates.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-custom-domain
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
 ---
 # Custom Domains and Certificates
 

--- a/docs/language-guides/python/recipes/durable-orchestration.md
+++ b/docs/language-guides/python/recipes/durable-orchestration.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 ---
 # Durable Functions
 

--- a/docs/language-guides/python/recipes/event-grid.md
+++ b/docs/language-guides/python/recipes/event-grid.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
 ---
 # Event Grid Trigger
 

--- a/docs/language-guides/python/recipes/http-api.md
+++ b/docs/language-guides/python/recipes/http-api.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
 ---
 # HTTP API Patterns
 

--- a/docs/language-guides/python/recipes/http-auth.md
+++ b/docs/language-guides/python/recipes/http-auth.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/overview-authentication-authorization
 ---
 # HTTP Authentication
 

--- a/docs/language-guides/python/recipes/index.md
+++ b/docs/language-guides/python/recipes/index.md
@@ -1,12 +1,13 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
 ---
 # Python Recipes
 

--- a/docs/language-guides/python/recipes/key-vault.md
+++ b/docs/language-guides/python/recipes/key-vault.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 ---
 # Key Vault Integration
 

--- a/docs/language-guides/python/recipes/managed-identity.md
+++ b/docs/language-guides/python/recipes/managed-identity.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
 ---
 # Managed Identity
 

--- a/docs/language-guides/python/recipes/queue.md
+++ b/docs/language-guides/python/recipes/queue.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
 ---
 # Queue Storage
 

--- a/docs/language-guides/python/recipes/timer.md
+++ b/docs/language-guides/python/recipes/timer.md
@@ -1,8 +1,9 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-timer
 ---
 # Timer Trigger
 


### PR DESCRIPTION
## Summary

Migrates `content_sources` frontmatter to the canonical `{references: [...]}` dict shape for 48 recipe pages under `docs/language-guides/{dotnet,java,nodejs,python}/recipes/`. This is **PR 2d.2b4 batch 2** in the Functions repo — the second of three template-family batches planned to clear the 205 drift files identified after PR 2d.2b3 merged.

## Scope (48 files = 12 recipes × 4 languages)

12 recipes per language: `blob-storage.md`, `cosmosdb.md`, `custom-domain-certificates.md`, `durable-orchestration.md`, `event-grid.md`, `http-api.md`, `http-auth.md`, `index.md`, `key-vault.md`, `managed-identity.md`, `queue.md`, `timer.md`

Path slice: `docs/language-guides/*/recipes/*.md` (Oracle's recommended scope from PR #54 review)

## Change

Each file's `content_sources` migrated from legacy list-form (`content_sources: [{type, url}, ...]`) to canonical dict-form (`content_sources: {references: [{type, url}, ...]}`) using the shared `scripts/normalize_content_sources_schema.py` tool with `--paths-glob 'language-guides/*/recipes/*.md'`. **Pure schema migration** — no prose, code, or diagram changes. Body preserved byte-exact per the normalizer's contract.

## Why batched

Per Oracle's binding ordering in PR #54 review (`ses_153d7466fffeY3Nft41nzkjZN5`):

> "Use recipes/ as batch 2. My spot-check shows the remaining 48 recipe files are still uniformly list-form and Mermaid-bearing. Just keep the slice limited to `docs/language-guides/*/recipes/*.md`."

Subsequent PR planned:
- **Batch 3+**: 124 tutorial/* files, batched per hosting plan family per Oracle: *"I'd keep reviewability by batching per hosting plan family rather than one 124-file sweep"*

## Homogeneity verified

All 48 batch 2 files contain at least one Mermaid diagram (verified by `grep -l "^\`\`\`mermaid"`). They continue to sit on the references-only Mermaid legacy-permissive path per Oracle's PR 2d.2b2 binding watch-out:

> "Mermaid pages on the `{references: [...]}` path still bypass per-diagram count enforcement until the final hardening PR. Do not tighten the Functions validator early; that would convert this approved migration into a false-negative wave."

The Functions validator was NOT touched in this PR.

## Verification

Drift dropped from **172 → 124** (exactly 48 fewer = batch 2 size). All strict checks pass:

| Check | Result |
|---|---|
| `normalize_yaml_frontmatter --check` | 0 drift across 303 files |
| `normalize_content_sources_schema --check` | 124 drift (batch 3+ tutorial remains) |
| `validate_content_sources` | 0 errors across 303 files |
| `validate_mermaid_format` | 0 errors across 303 files |
| `validate_mermaid_syntax` | 0 errors across 498 diagrams |
| `normalize_mslearn_locale --check` | 0 drift across 381 files |
| `content_scope.py` doctest | 14/14 passed |
| `mkdocs build --strict` | exit 0 |

## Cross-references

- Direct predecessor: Functions PR #54 (PR 2d.2b4 batch 1, merged a8d41cc)
- Prior PRs in sequence (all merged): Functions #46-#54; ACA #193-#198; App Service #98-#101
- Final-phase deferred cleanup queue tracked in PR 2d.2b3 commit messages
