### PR TITLE
feat(docs): migrate content_sources to canonical references shape in language-guides batch 3a (tutorial chooser pages)

### DIFF
--- a/docs/language-guides/dotnet/tutorial/index.md
+++ b/docs/language-guides/dotnet/tutorial/index.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
 ---
 # Tutorial — Choose Your Hosting Plan
 

--- a/docs/language-guides/java/tutorial/index.md
+++ b/docs/language-guides/java/tutorial/index.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
 ---
 # Tutorial — Choose Your Hosting Plan
 

--- a/docs/language-guides/nodejs/tutorial/index.md
+++ b/docs/language-guides/nodejs/tutorial/index.md
@@ -1,10 +1,11 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 ---
 # Tutorial - Choose Your Hosting Plan
 

--- a/docs/language-guides/python/tutorial/index.md
+++ b/docs/language-guides/python/tutorial/index.md
@@ -1,16 +1,17 @@
 ---
 content_sources:
 
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/migration/migrate-plan-consumption-to-flex
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
-  - type: mslearn-adapted
-    url: https://learn.microsoft.com/en-us/azure/azure-functions/pricing
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/migration/migrate-plan-consumption-to-flex
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/pricing
 ---
 # Tutorial — Choose Your Hosting Plan
 


### PR DESCRIPTION
## Summary

Migrates `content_sources` frontmatter to the canonical `{references: [...]}` dict shape for the 4 tutorial chooser pages under `docs/language-guides/{dotnet,java,nodejs,python}/tutorial/index.md`. This is **PR 2d.2b4 batch 3a** in the Functions repo — the smallest of the remaining batches and the first slice of the 124-file tutorial migration.

## Scope (4 files)

- `docs/language-guides/dotnet/tutorial/index.md`
- `docs/language-guides/java/tutorial/index.md`
- `docs/language-guides/nodejs/tutorial/index.md`
- `docs/language-guides/python/tutorial/index.md`

Per-language tutorial section landing pages that introduce hosting plan options and link to plan-specific runbooks.

Path slice: `docs/language-guides/*/tutorial/index.md` (Oracle-recommended precise glob)

## Change

Pure schema migration: `[{type, url}, ...]` → `{references: [{type, url}, ...]}` via `scripts/normalize_content_sources_schema.py --apply --paths-glob 'language-guides/*/tutorial/index.md'`. Body preserved byte-exact.

## Why batched this way

Per Oracle's binding grouping in PR #55 review (`ses_153d7466fffeY3Nft41nzkjZN5`) — option **(b)**:

> "For batch 3+, use (b): one small PR for the 4 `tutorial/index.md` chooser pages, then 4 PRs by hosting plan family (consumption, dedicated, flex-consumption, premium). The 4 chooser pages are semantically different from the plan runbooks, so separating them keeps the plan PRs homogeneous and easier to review."

Subsequent PRs (all by hosting plan family):
- **Batch 3b**: 28 consumption files (7 per lang × 4 langs)
- **Batch 3c**: 32 flex-consumption files (8 per lang × 4 langs, +1 `02a-*` file vs consumption)
- **Batch 3d**: 32 premium files (8 per lang × 4 langs, +1 `02a-*` file)
- **Batch 3e**: 28 dedicated files (7 per lang × 4 langs)

## Homogeneity verified

All 4 chooser pages contain at least one Mermaid diagram (Python's has 5). They continue to sit on the references-only Mermaid legacy-permissive path. The Functions validator was NOT touched in this PR.

## Verification

Drift dropped from **124 → 120** (exactly 4 fewer = batch 3a size). All strict checks pass:

| Check | Result |
|---|---|
| `normalize_yaml_frontmatter --check` | 0 drift across 303 files |
| `normalize_content_sources_schema --check` | 120 drift (batches 3b-3e remain) |
| `validate_content_sources` | 0 errors |
| `validate_mermaid_format` | 0 errors |
| `validate_mermaid_syntax` | 0 errors across 498 diagrams |
| `normalize_mslearn_locale --check` | 0 drift |
| `content_scope.py` doctest | 14/14 passed |
| `mkdocs build --strict` | exit 0 |

## Cross-references

- Direct predecessor: Functions PR #55 (PR 2d.2b4 batch 2 recipes, merged 3e836dd)
- Prior PRs in sequence (all merged): Functions #46-#55; ACA #193-#198; App Service #98-#101
