### PR TITLE
chore(ci,docs): canonical deploy URL + pin Mermaid to 10.9.1 + mkdocs nav validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
   deploy:
     environment:
       name: github-pages
-      url: ${{ github.event.deployment.payload.web_url || 'N/A' }}
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ extra_css:
   - stylesheets/extra.css
 
 extra_javascript:
-  - https://unpkg.com/mermaid@10/dist/mermaid.min.js
+  - https://unpkg.com/mermaid@10.9.1/dist/mermaid.min.js
   - javascripts/mermaid-zoom.js
 
 plugins:
@@ -77,6 +77,8 @@ markdown_extensions:
 validation:
   nav:
     omitted_files: warn
+    not_found: warn
+    absolute_links: warn
   links:
     not_found: warn
     anchors: warn


### PR DESCRIPTION
## Phase 3 Cross-Repo Alignment (Functions)

Brings Functions repo into alignment with sibling ACA + AS guides for CI deploy URL, Mermaid version pinning, and `mkdocs.yml` policy.

### Changes

**`.github/workflows/docs.yml`:**
- Switch deploy URL from `${{ github.event.deployment.payload.web_url || 'N/A' }}` to canonical `${{ steps.deployment.outputs.page_url }}` (matches GitHub Pages action documentation)

**`mkdocs.yml`:**
- Pin Mermaid CDN from `@10` (floating) to `@10.9.1` (deterministic, matches ACA)
- Add `nav.not_found: warn` + `nav.absolute_links: warn` to `validation.nav` block (completes the validation block; matches ACA's existing config)

### Notes (per Oracle review)

- `nav.absolute_links: warn` was included as part of completing **ACA parity** after verifying ACA's real `mkdocs.yml` already has this key, not as a new policy expansion.
- Functions validator legacy `references` escape on Mermaid pages remains as documented in `AGENTS.md` — that's a separate decision binding indefinitely until the Functions repo owner explicitly decides per-diagram provenance is required policy.

### Validation (local)

- `mkdocs build --strict`: **PASS** (27.79s)
- Mermaid renders cleanly across all diagram-heavy pages

### Cross-repo context

Part of Phase 3 final alignment pass across:
- ACA: yeongseon/azure-container-apps-practical-guide PR (pinned Mermaid + lenient mslearn URLs)
- AS: yeongseon/azure-app-service-practical-guide PR (align validate-content-sources workflow + deploy URL + nav validation)
- Functions (this PR): canonical deploy URL + pin Mermaid + nav validation

Oracle reviewed and approved all 3 PRs together.