### PR TITLE
fix: use missing-locale placeholder in AGENTS.md anti-pattern URL example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,11 +290,13 @@ Canonical form:
 https://learn.microsoft.com/en-us/azure/{service}/...
 ```
 
-Avoid locale-less URLs:
+Avoid locale-less URLs (URLs missing the `/en-us/` segment immediately after the hostname):
 
 ```text
-https://learn.microsoft.com/azure/{service}/...
+https://learn.microsoft.com/<missing-locale>/azure/{service}/...
 ```
+
+The `<missing-locale>` placeholder marks the position where `/en-us/` must appear. A real locale-less URL would omit that segment entirely; the placeholder is used here only so this anti-pattern example does not trip the `scripts/normalize_mslearn_locale.py` CI gate.
 
 Reason:
 


### PR DESCRIPTION
## Summary

Fixes CI regression on `main` caused by PR #65 (series-wide documentation contract rollout).

## The Bug

The `## Microsoft Learn URL Locale` section in `AGENTS.md` contains an anti-pattern code fence showing a locale-less Microsoft Learn URL:

```text
https://learn.microsoft.com/azure/azure-functions/...
```

This is intentional documentation — readers must NOT use locale-less URLs. However, `scripts/normalize_mslearn_locale.py --check` (which runs in CI on every push touching `.md` files) cannot distinguish an intentional anti-pattern example from a real URL that needs fixing. Result: `main` CI failing with `DRIFT AGENTS.md (1 URL)`.

## The Fix

Apply the `<missing-locale>` placeholder pattern already used in the sibling `azure-container-apps-practical-guide` repo, plus an explanatory paragraph that spells out why the placeholder exists. The URL is still shown as an anti-pattern (readers must NOT use it); the placeholder simply prevents the enforcement script from misclassifying the example as a real drift target.

## Verification

- `python3 scripts/normalize_mslearn_locale.py --check` locally: `Files with locale drift: 0`
- CI `Validate Content Sources` must go GREEN on this PR before merge

## Related

This is one of 8 sibling PRs applying the same fix across the series. Two repos (this one + `azure-app-service-practical-guide`) currently have `main` CI failing. Six others (VM, Networking, Storage, ACS, Architecture, Monitoring) have the same latent buggy text but no enforcement script yet.
