### PR TITLE
chore: P5 baseline conformance (wave extension) — F8/F11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Azure Functions Practical Guide
 
+📘 **Documentation site:** <https://yeongseon.github.io/azure-functions-practical-guide/>
+
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
 ![Docs](https://github.com/yeongseon/azure-functions-practical-guide/actions/workflows/docs.yml/badge.svg)


### PR DESCRIPTION
## Summary

- **F8**: Add documentation site link near top of `README.md`.
- **F11**: Applied canonical topic set (9 topics) via `gh repo edit`.

## Scope decision — Localized READMEs

Localized READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) are **intentionally unchanged** for parity with the sibling baseline. Empirical audit of the 8 open sibling P5 PRs shows F8 is applied to `README.md` only in 7 of 8 cases (the sole exception, ACS #17, is creating localized READMEs for the first time — not adding F8 to pre-existing ones). Applying F8 to localized READMEs here would establish a new precedent rather than conform to the existing baseline. Multilingual harmonization is deferred as future work if desired.

## Topics applied

`azure, azure-functions, serverless, flex-consumption, python, nodejs, java, dotnet, mkdocs`

Applied via `gh repo edit --add-topic` (additive, not replace). Verified via `gh api repos/... --jq '.topics'` after apply.

## Verification

- `mkdocs build --strict` passed (35.22s, no errors, no warnings other than the Material for MkDocs 2.0 announcement)
- `git status`: only `README.md` staged (no `site/` or other residue)
- `git ls-files site/` = 0 tracked (properly ignored)
- Topics verified: `["azure","azure-functions","dotnet","flex-consumption","java","mkdocs","nodejs","python","serverless"]`

## Wave extension context

This PR is a **scope extension** of the P5 baseline conformance wave (originally excluded per initial user directive, later amended to include Functions). Not a new standard — see meta tracker `yeongseon/azure-architecture-practical-guide#39` for cross-repo context.

Closes #68
Related to yeongseon/azure-architecture-practical-guide#39