### PR TITLE
chore: add baseline .gitignore entries for agent scratch artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,13 @@ labs/*/artifacts/
 .env.local
 *.pem
 apps/dotnet/publish/
+
+# Root-level debug/scratch screenshots (docs/assets/**/*.png stays legitimate)
+/*.png
+
+# Sisyphus (AI agent working files)
+.sisyphus/
+
+# Playwright MCP artifacts
+.playwright-mcp/
+.playwright-scripts/


### PR DESCRIPTION
## Summary

Adds baseline `.gitignore` entries per [yeongseon/azure-architecture-practical-guide#48](https://github.com/yeongseon/azure-architecture-practical-guide/issues/48) (P5 Baseline Completeness — Follow-up Hygiene Sweep).

## Change

Adds missing entries so agent scratch artifacts and root-level debug screenshots are ignored by default. Only appends new entries; existing `.gitignore` content untouched.

## Why

Empirical audit (2026-07-09) found the baseline `.gitignore` template (`.sisyphus/`, `.playwright-mcp/`, `.playwright-scripts/`, `/*.png`) present in `azure-container-apps-practical-guide` only. This PR propagates the agent-artifact + root-PNG guard entries to prevent accidental commits.

`docs/assets/**/*.png` remains legitimate — only root-level debug residue is blocked by `/*.png`.

## Non-goals

- No tracked files removed
- No other `.gitignore` sections modified
- Full baseline template adoption (Python/Node/.NET sections harmonization) is a separate PR

## Related

- Meta: yeongseon/azure-architecture-practical-guide#48
- Parent P5 tracker: yeongseon/azure-architecture-practical-guide#39