### PR TITLE
docs: clarify Functions storage connectivity scenarios and add central reference

### DIFF
--- a/docs/language-guides/dotnet/recipes/dependency-injection.md
+++ b/docs/language-guides/dotnet/recipes/dependency-injection.md
@@ -1,0 +1,128 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  diagrams:
+    - id: dependency-injection
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+        - https://learn.microsoft.com/en-us/dotnet/azure/sdk/dependency-injection
+---
+# Dependency Injection
+
+The .NET isolated worker model uses the standard .NET dependency injection (DI) container. You register services in `Program.cs` and receive them through constructor injection on your function classes. This is the idiomatic way to share clients (HTTP, Azure SDK) across invocations, which is critical for connection reuse in a serverless environment.
+
+## Architecture
+
+<!-- diagram-id: dependency-injection -->
+```mermaid
+flowchart TD
+    PROG[Program.cs] --> SC[IServiceCollection]
+    SC --> REG[Register services: Singleton/Scoped/Transient]
+    REG --> HOST[Build IHost]
+    HOST --> FUNC[Function class constructor]
+    FUNC --> SVC[Injected service instance]
+```
+
+## Registering Services
+
+The isolated worker exposes the full host builder pipeline. Register services before calling `Build()`. Two builder styles are supported.
+
+### IHostApplicationBuilder (core packages 2.x)
+
+```csharp
+using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var builder = FunctionsApplication.CreateBuilder(args);
+builder.ConfigureFunctionsWebApplication();
+
+builder.Services.AddSingleton<IOrderService, OrderService>();
+builder.Services.AddHttpClient();
+
+builder.Build().Run();
+```
+
+### IHostBuilder (core packages 1.x)
+
+```csharp
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .ConfigureServices(services =>
+    {
+        services.AddSingleton<IOrderService, OrderService>();
+        services.AddHttpClient();
+    })
+    .Build();
+
+host.Run();
+```
+
+## Constructor Injection into Functions
+
+Function classes should use instance methods so services are injected through the constructor. The framework also injects `ILogger<T>` automatically.
+
+```csharp
+public class OrderFunction
+{
+    private readonly IOrderService _orders;
+    private readonly ILogger<OrderFunction> _logger;
+
+    public OrderFunction(IOrderService orders, ILogger<OrderFunction> logger)
+    {
+        _orders = orders;
+        _logger = logger;
+    }
+
+    [Function("SubmitOrder")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req)
+    {
+        await _orders.SubmitAsync(await req.ReadAsStringAsync() ?? string.Empty);
+        return req.CreateResponse(HttpStatusCode.Accepted);
+    }
+}
+```
+
+## Service Lifetimes
+
+| Lifetime | Method | Use for |
+|----------|--------|---------|
+| Singleton | `AddSingleton` | Stateless, thread-safe clients (Azure SDK clients, `HttpClient` factory) |
+| Scoped | `AddScoped` | One instance per function invocation |
+| Transient | `AddTransient` | Lightweight, stateless helpers created on each request |
+
+!!! tip "Reuse heavy clients as singletons"
+    Register Azure SDK clients as singletons so connections and auth tokens are reused across invocations. Use the `Microsoft.Extensions.Azure` package and `AddAzureClients()` to register them with managed-identity credentials.
+
+## Registering Azure SDK Clients
+
+```csharp
+builder.Services.AddAzureClients(clients =>
+{
+    clients.AddBlobServiceClient(builder.Configuration.GetSection("MyStorageConnection"))
+        .WithName("outputBlob");
+});
+```
+
+Inject the client through `IAzureClientFactory<BlobServiceClient>` and call `CreateClient("outputBlob")`.
+
+## See Also
+
+- [Blob Storage Integration](blob-storage.md)
+- [Managed Identity](managed-identity.md)
+- [Middleware](middleware.md)
+
+## Sources
+
+- [Guide for running C# Azure Functions in an isolated worker process (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Dependency injection with the Azure SDK for .NET (Microsoft Learn)](https://learn.microsoft.com/en-us/dotnet/azure/sdk/dependency-injection)

--- a/docs/language-guides/dotnet/recipes/durable-advanced.md
+++ b/docs/language-guides/dotnet/recipes/durable-advanced.md
@@ -1,0 +1,134 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of sub-orchestration composition, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+---
+# Durable Functions: Advanced Patterns
+
+This recipe covers advanced Durable Functions patterns for .NET (isolated worker) beyond the basic chaining and fan-out/fan-in flows: sub-orchestrations, eternal orchestrations, activity retries, and safe versioning. For the fundamentals, see [Durable Orchestration](durable-orchestration.md).
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PARENT[Parent orchestrator] -->|CallSubOrchestratorAsync| SUB1[Sub-orchestrator A]
+    PARENT -->|CallSubOrchestratorAsync| SUB2[Sub-orchestrator B]
+    SUB1 --> ACT1[Activities]
+    SUB2 --> ACT2[Activities]
+    SUB1 --> PARENT
+    SUB2 --> PARENT
+```
+
+## Sub-Orchestrations
+
+Break a large workflow into reusable orchestrators. A parent calls a sub-orchestrator with `CallSubOrchestratorAsync`, and can fan out over several the same way it fans out over activities.
+
+```csharp
+[Function("ParentOrchestrator")]
+public static async Task<int> ParentOrchestrator(
+    [OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    string[] regions = context.GetInput<string[]>() ?? Array.Empty<string>();
+
+    // Fan out over sub-orchestrations, one per region.
+    var tasks = regions
+        .Select(region => context.CallSubOrchestratorAsync<string>("ProcessRegion", region))
+        .ToList();
+
+    string[] results = await Task.WhenAll(tasks);
+    return results.Length;
+}
+
+[Function("ProcessRegion")]
+public static async Task<string> ProcessRegion(
+    [OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    string region = context.GetInput<string>()!;
+    string validated = await context.CallActivityAsync<string>("ValidateRegion", region);
+    return await context.CallActivityAsync<string>("LoadRegion", validated);
+}
+```
+
+## Eternal Orchestrations
+
+For a workflow that runs indefinitely (aggregators, periodic jobs), do **not** use an unbounded loop — the history would grow forever. Call `context.ContinueAsNew` to restart the orchestration with fresh state and a clean history.
+
+```csharp
+[Function("PeriodicCleanup")]
+public static async Task PeriodicCleanup(
+    [OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    var state = context.GetInput<CleanupState>() ?? new CleanupState();
+
+    await context.CallActivityAsync("RunCleanup", state);
+    state.Runs += 1;
+
+    // Durable sleep, then restart with new state and empty history.
+    DateTime nextRun = context.CurrentUtcDateTime.AddHours(1);
+    await context.CreateTimer(nextRun, CancellationToken.None);
+    context.ContinueAsNew(state);
+}
+```
+
+## Activity Retries
+
+Wrap flaky activities with a retry policy instead of hand-coding retry loops. The orchestration replays cleanly because retries are recorded in history.
+
+```csharp
+[Function("ResilientOrchestrator")]
+public static async Task<string> ResilientOrchestrator(
+    [OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    var order = context.GetInput<Order>()!;
+
+    var options = TaskOptions.FromRetryPolicy(new RetryPolicy(
+        maxNumberOfAttempts: 3,
+        firstRetryInterval: TimeSpan.FromSeconds(5)));
+
+    return await context.CallActivityAsync<string>("ChargeCustomer", order, options);
+}
+```
+
+| Element | Explanation |
+|---|---|
+| `CallSubOrchestratorAsync` | Invokes another orchestrator as a child; compose and fan out like activities. |
+| `ContinueAsNew` | Restarts the orchestration with new input and a trimmed history for eternal loops. |
+| `TaskOptions.FromRetryPolicy` | Declarative retry policy passed to `CallActivityAsync`. |
+
+## Versioning
+
+Orchestrations replay from history, so changing an orchestrator's code while instances are in flight can break replay (non-determinism). Safe strategies:
+
+- **Deploy side by side**: give the changed orchestrator a new name and route new instances to it, letting existing instances drain on the old version.
+- **Do not reorder or remove** existing activity calls in a deployed orchestrator.
+- **Terminate and restart** in-flight instances if a breaking change is unavoidable.
+
+!!! warning "Determinism still applies"
+    Advanced patterns do not relax the determinism rule. Never call `DateTime.Now`, generate random values, or do direct I/O inside an orchestrator — use activities and `context.CurrentUtcDateTime`.
+
+## See Also
+
+- [Durable Orchestration](durable-orchestration.md)
+- [Durable Entities](durable-entities.md)
+- [Platform: Durable Functions](../../../platform/durable-functions.md)
+
+## Sources
+
+- [Sub-orchestrations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations)
+- [Eternal orchestrations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations)
+- [Versioning (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning)
+</content>

--- a/docs/language-guides/dotnet/recipes/durable-entities.md
+++ b/docs/language-guides/dotnet/recipes/durable-entities.md
@@ -1,0 +1,123 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities
+  diagrams:
+    - id: durable-entities
+      type: flowchart
+      source: self-generated
+      justification: Flow view of durable entities, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities
+        - https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+---
+# Durable Entities
+
+Manage small pieces of explicit, addressable state with Durable Entities in the .NET isolated worker model. Each entity processes its operations serially, so no locks are needed.
+
+<!-- diagram-id: durable-entities -->
+```mermaid
+flowchart TD
+    A[Client / Orchestrator] --> B[Entity Counter@key]
+    B --> C[State persisted in Durable Store]
+    C --> D[readEntityState / GetEntityAsync]
+```
+
+## Topic/Command Groups
+
+### Class-based entity
+
+`TaskEntity<TState>` maps class methods to operations. `State` is the persisted value.
+
+```csharp
+public class Counter : TaskEntity<int>
+{
+    public void Add(int amount) => this.State += amount;
+    public void Reset() => this.State = 0;
+    public int Get() => this.State;
+
+    [Function(nameof(Counter))]
+    public Task RunEntityAsync([EntityTrigger] TaskEntityDispatcher dispatcher)
+        => dispatcher.DispatchAsync(this);
+}
+```
+
+### Signal an entity from a client function
+
+Signaling is one-way (fire-and-forget). Client functions can signal and read state, but cannot call for a return value.
+
+```csharp
+[Function("AddFromQueue")]
+public Task Run(
+    [QueueTrigger("counter-ops")] string input,
+    [DurableClient] DurableTaskClient client)
+{
+    var entityId = new EntityInstanceId(nameof(Counter), "myCounter");
+    int amount = int.Parse(input);
+    return client.Entities.SignalEntityAsync(entityId, nameof(Counter.Add), amount);
+}
+```
+
+### Read entity state from a client function
+
+```csharp
+[Function("QueryCounter")]
+public static async Task<HttpResponseData> QueryCounter(
+    [HttpTrigger(AuthorizationLevel.Function, "get", Route = "counter/{key}")] HttpRequestData req,
+    [DurableClient] DurableTaskClient client,
+    string key)
+{
+    var entityId = new EntityInstanceId(nameof(Counter), key);
+    EntityMetadata<int>? entity = await client.Entities.GetEntityAsync<int>(entityId);
+
+    if (entity is null)
+    {
+        return req.CreateResponse(HttpStatusCode.NotFound);
+    }
+
+    var response = req.CreateResponse(HttpStatusCode.OK);
+    await response.WriteAsJsonAsync(entity);
+    return response;
+}
+```
+
+### Call and signal from an orchestrator
+
+Orchestrators can both call (two-way) and signal (one-way) entities.
+
+```csharp
+[Function("CounterOrchestration")]
+public static async Task<int> Run([OrchestrationTrigger] TaskOrchestrationContext context)
+{
+    var entityId = new EntityInstanceId(nameof(Counter), "myCounter");
+
+    // Two-way call: read the committed value and wait for the response.
+    int currentValue = await context.Entities.CallEntityAsync<int>(entityId, nameof(Counter.Get));
+
+    if (currentValue < 10)
+    {
+        // One-way signal: update the value without waiting.
+        await context.Entities.SignalEntityAsync(entityId, nameof(Counter.Add), 1);
+    }
+
+    return currentValue;
+}
+```
+
+## Review Matrix
+
+| Review area | Page-specific check |
+|---|---|
+| Scope | Confirm the guidance applies to Durable Entities in the isolated worker model. |
+| Source basis | Validate the recommendation against the Microsoft Learn sources in this page. |
+| Evidence | Capture command output, portal state, metrics, logs, or screenshots before treating the result as proven. |
+
+## See Also
+- [Durable Orchestration](durable-orchestration.md)
+- [.NET Language Guide](../index.md)
+- [Troubleshooting](../troubleshooting.md)
+
+## Sources
+- [Durable entities (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities)
+- [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)

--- a/docs/language-guides/dotnet/recipes/event-grid.md
+++ b/docs/language-guides/dotnet/recipes/event-grid.md
@@ -49,6 +49,44 @@ az eventgrid event-subscription create   --name "sub-func-events"   --source-res
 | Variables | `$RG`, `$APP_NAME` |
 | Expected result | Azure CLI returns provisioning details; confirm the resource name and successful provisioning state before continuing. |
 
+### Event Grid output (publish to a custom topic)
+
+Use the `EventGridOutput` attribute to publish events to a custom topic. The attribute reads the topic endpoint and access key from app settings; never hard-code the topic URI. For a single event, return a JSON-serializable type:
+
+```csharp
+public class PublishFunction
+{
+    [Function(nameof(PublishFunction))]
+    [EventGridOutput(TopicEndpointUri = "MyEventGridTopicUriSetting", TopicKeySetting = "MyEventGridTopicKeySetting")]
+    public MyEvent Run([TimerTrigger("0 */5 * * * *")] TimerInfo timer)
+    {
+        return new MyEvent
+        {
+            Id = "unique-id",
+            Subject = "orders/created",
+            EventType = "Contoso.Order.Created",
+            EventTime = DateTime.UtcNow,
+            Data = new Dictionary<string, object> { { "orderId", 12345 } },
+        };
+    }
+}
+```
+
+To publish multiple events, return an array of the event type. For CloudEvents 1.0 output or advanced scenarios (batching, custom schema), register an `EventGridPublisherClient` from `Azure.Messaging.EventGrid` via dependency injection instead of the output binding.
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "MyEventGridTopicUriSetting=$TOPIC_ENDPOINT" "MyEventGridTopicKeySetting=$TOPIC_KEY"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$TOPIC_ENDPOINT`, `$TOPIC_KEY` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm both settings are present before continuing. |
 
 ## See Also
 - [Recipes Index](index.md)
@@ -58,3 +96,4 @@ az eventgrid event-subscription create   --name "sub-func-events"   --source-res
 ## Sources
 - [Azure Functions .NET isolated worker guide](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
 - [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Event Grid output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-output)

--- a/docs/language-guides/dotnet/recipes/event-hub.md
+++ b/docs/language-guides/dotnet/recipes/event-hub.md
@@ -1,0 +1,97 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+  diagrams:
+    - id: event-hub
+      type: flowchart
+      source: self-generated
+      justification: Flow view of event-hub, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger
+---
+# Event Hubs
+
+Consume high-throughput event streams with the Event Hubs trigger and publish events with the output binding in the .NET isolated worker model.
+
+<!-- diagram-id: event-hub -->
+```mermaid
+flowchart TD
+    A[Event Producers] --> B[(Event Hub Partitions)]
+    B --> C[EventHubTrigger Function]
+    C --> D[Downstream Store]
+    C --> E[EventHubOutput]
+```
+
+## Topic/Command Groups
+
+### Batch trigger + output binding
+
+Delivering an array of events per invocation maximizes throughput. Keep the handler idempotent because delivery is at-least-once.
+
+```csharp
+[Function("ProcessTelemetry")]
+[EventHubOutput("downstream", Connection = "EventHubConnection")]
+public string[] ProcessTelemetry(
+    [EventHubTrigger("telemetry", Connection = "EventHubConnection",
+        ConsumerGroup = "$Default")] string[] events,
+    FunctionContext context)
+{
+    var logger = context.GetLogger("ProcessTelemetry");
+    logger.LogInformation("Batch size: {Count}", events.Length);
+
+    foreach (var evt in events)
+    {
+        // Keep processing idempotent.
+        logger.LogInformation("Processing event: {Event}", evt);
+    }
+
+    return events;
+}
+```
+
+### Identity-based connection
+
+Use a setting prefix with `__fullyQualifiedNamespace` and grant the managed identity the **Azure Event Hubs Data Receiver** (and **Data Sender** for output) role:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "EventHubConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
+```
+
+### Host settings and checkpointing
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "eventHubs": {
+      "maxEventBatchSize": 100,
+      "batchCheckpointFrequency": 1,
+      "prefetchCount": 300
+    }
+  }
+}
+```
+
+## Review Matrix
+
+| Review area | Page-specific check |
+|---|---|
+| Scope | Confirm the guidance applies to Event Hubs trigger and output bindings. |
+| Source basis | Validate the recommendation against the Microsoft Learn sources in this page. |
+| Evidence | Capture command output, portal state, metrics, logs, or screenshots before treating the result as proven. |
+
+## See Also
+- [Recipes Index](index.md)
+- [.NET Language Guide](../index.md)
+- [Troubleshooting](../troubleshooting.md)
+
+## Sources
+- [Azure Event Hubs bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs)
+- [Azure Event Hubs trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger)
+- [Azure Event Hubs output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-output)

--- a/docs/language-guides/dotnet/recipes/index.md
+++ b/docs/language-guides/dotnet/recipes/index.md
@@ -31,6 +31,7 @@ flowchart TD
 |--------|-------------|
 | [HTTP API Patterns](http-api.md) | Route, request, response, and validation patterns. |
 | [HTTP Authentication](http-auth.md) | Function keys, platform auth, and token validation. |
+| [OpenAPI and Swagger](openapi.md) | Auto-generating OpenAPI docs and Swagger UI with the isolated worker OpenAPI extension. |
 
 ### Storage
 | Recipe | Description |
@@ -38,6 +39,7 @@ flowchart TD
 | [Cosmos DB](cosmosdb.md) | Input and output binding usage in isolated worker. |
 | [Blob Storage](blob-storage.md) | Blob trigger and blob output handling. |
 | [Queue](queue.md) | Queue trigger, poison message, and output binding pattern. |
+| [Table Storage](table-storage.md) | Table input and output binding usage in isolated worker. |
 
 ### Security
 | Recipe | Description |
@@ -51,7 +53,17 @@ flowchart TD
 |--------|-------------|
 | [Timer](timer.md) | Cron schedules and idempotent scheduled jobs. |
 | [Durable Orchestration](durable-orchestration.md) | Stateful workflows and fan-out/fan-in. |
+| [Durable Entities](durable-entities.md) | Stateful, addressable per-key state (actor-style) with serialized operations. |
+| [Durable Advanced](durable-advanced.md) | Sub-orchestrations, eternal orchestrations, activity retries, and versioning. |
 | [Event Grid](event-grid.md) | Event-driven integration patterns. |
+| [Event Hubs](event-hub.md) | High-throughput event stream consumption with batch trigger and output binding. |
+| [Service Bus](service-bus.md) | Enterprise messaging with queue/topic triggers, dead-lettering, and output binding. |
+| [SignalR Service](signalr.md) | Real-time messaging via the negotiate endpoint and output binding. |
+| [Dependency Injection](dependency-injection.md) | Registering services and constructor injection in the isolated worker container. |
+| [Retry Policies](retry.md) | Runtime retry policies (fixed delay, exponential backoff) for Timer, Event Hubs, and Cosmos DB triggers. |
+| [Middleware](middleware.md) | Cross-cutting behavior with the isolated worker `IFunctionsWorkerMiddleware` pipeline. |
+| [Unit Testing](testing.md) | Host-free unit testing with xUnit, constructor injection, and Moq. |
+| [Migrate to Isolated](migrate-to-isolated.md) | Migrating a .NET in-process app to the isolated worker model before the in-process retirement. |
 
 ## See Also
 - [.NET Language Guide](../index.md)

--- a/docs/language-guides/dotnet/recipes/middleware.md
+++ b/docs/language-guides/dotnet/recipes/middleware.md
@@ -1,0 +1,133 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+---
+# Middleware
+
+The .NET isolated worker model has a first-class middleware pipeline. Middleware runs on every function invocation, wrapping the execution so you can add cross-cutting behavior — logging, authentication, exception handling, or response header stamping — in one place instead of repeating it in every function.
+
+## Prerequisites
+
+- A .NET isolated worker Function App (`Microsoft.Azure.Functions.Worker.Sdk` 1.9.0 or later).
+- The app configured with `FunctionsApplication.CreateBuilder` or `HostBuilder` in `Program.cs`.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    REQ[Trigger fires] --> M1[Middleware 1: pre-logic]
+    M1 --> M2[Middleware 2: pre-logic]
+    M2 --> FUNC[Function execution]
+    FUNC --> M2B[Middleware 2: post-logic]
+    M2B --> M1B[Middleware 1: post-logic]
+    M1B --> RESP[Response returned]
+```
+
+## Implement a Middleware
+
+Middleware implements `IFunctionsWorkerMiddleware` from the `Microsoft.Azure.Functions.Worker.Middleware` namespace. Call `next` to continue the pipeline; code before `next` runs on the way in, code after `next` runs on the way out.
+
+```csharp
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Logging;
+
+public sealed class ExceptionLoggingMiddleware : IFunctionsWorkerMiddleware
+{
+    private readonly ILogger<ExceptionLoggingMiddleware> _logger;
+
+    public ExceptionLoggingMiddleware(ILogger<ExceptionLoggingMiddleware> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+    {
+        _logger.LogInformation("Executing {Function}", context.FunctionDefinition.Name);
+        try
+        {
+            await next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled error in {Function}", context.FunctionDefinition.Name);
+            throw;
+        }
+    }
+}
+```
+
+Constructor injection works because middleware is resolved from the DI container. See [Dependency Injection](dependency-injection.md).
+
+## Register the Pipeline
+
+Register middleware in `Program.cs`. Order matters — the first registered runs outermost.
+
+```csharp
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults(builder =>
+    {
+        builder.UseMiddleware<ExceptionLoggingMiddleware>();
+        builder.UseMiddleware<StampHeadersMiddleware>();
+    })
+    .Build();
+
+host.Run();
+```
+
+## Conditional Middleware
+
+Use `UseWhen` to run middleware only when a predicate over the `FunctionContext` is true — for example, only for HTTP-triggered functions.
+
+```csharp
+builder.UseWhen<StampHeadersMiddleware>((context) =>
+{
+    // Run only when the function has an HTTP trigger.
+    return context.FunctionDefinition.InputBindings.Values
+        .Any(b => b.Type == "httpTrigger");
+});
+```
+
+## Access the HTTP Request and Response
+
+Inside middleware you can read the HTTP request and write to the response through the invocation context.
+
+```csharp
+public async Task Invoke(FunctionContext context, FunctionExecutionDelegate next)
+{
+    await next(context);
+
+    var httpResponse = context.GetHttpResponseData();
+    httpResponse?.Headers.Add("x-processed-by", "functions-middleware");
+}
+```
+
+| Element | Explanation |
+|---|---|
+| `IFunctionsWorkerMiddleware` | Interface with a single `Invoke(FunctionContext, FunctionExecutionDelegate)` method. |
+| `next(context)` | Advances the pipeline; awaiting it runs the remaining middleware and the function. |
+| `UseMiddleware<T>()` | Registers middleware unconditionally, outermost-first. |
+| `UseWhen<T>(predicate)` | Registers middleware that runs only when the predicate is true. |
+| `GetHttpResponseData()` | Retrieves the HTTP response after `next` for header/status manipulation. |
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [HTTP API](http-api.md)
+
+## Sources
+
+- [Guide for running C# Azure Functions in the isolated worker model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)

--- a/docs/language-guides/dotnet/recipes/migrate-to-isolated.md
+++ b/docs/language-guides/dotnet/recipes/migrate-to-isolated.md
@@ -1,0 +1,158 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of the migration decision path, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model
+        - https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+---
+# Migrate .NET In-Process to Isolated Worker
+
+The .NET in-process model is retired: support for the in-process model ends on 10 November 2026, and all new development targets the **isolated worker model**. This recipe walks through migrating an existing in-process (`Microsoft.NET.Sdk.Functions`) app to the isolated worker model, where your functions run in a separate process from the Functions host.
+
+## Prerequisites
+
+- An existing .NET in-process Function App targeting an LTS .NET version.
+- .NET SDK and Azure Functions Core Tools 4.x installed.
+
+## Why Migrate
+
+| Aspect | In-process (retiring) | Isolated worker |
+|---|---|---|
+| Process | Runs inside the host process | Runs in a separate process |
+| .NET versions | Tied to the host's .NET version | Decoupled; run any supported .NET, including non-LTS |
+| Dependency conflicts | Shares assemblies with the host | Full control of dependencies |
+| Middleware / DI | Limited | First-class middleware pipeline and DI |
+| Support | Ends 10 November 2026 | Current and future model |
+
+## Migration Path
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    START[In-process app] --> PROJ[Update project file and TFM]
+    PROJ --> PKG[Swap NuGet packages]
+    PKG --> HOST[Add Program.cs host builder]
+    HOST --> SIG[Update function signatures + attributes]
+    SIG --> HTTP[Convert HTTP model types]
+    HTTP --> CFG[Update host.json / local.settings.json]
+    CFG --> TEST[Test locally with func start]
+    TEST --> DEPLOY[Set FUNCTIONS_WORKER_RUNTIME + deploy]
+```
+
+## Step 1: Update the Project File
+
+Change the SDK references and target framework. Replace the in-process SDK package with the isolated worker SDK.
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net8.0</TargetFramework>
+  <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+  <OutputType>Exe</OutputType>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
+  <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
+</ItemGroup>
+```
+
+Remove `Microsoft.NET.Sdk.Functions`. Add the isolated-worker extension packages for each binding you use (for example `Microsoft.Azure.Functions.Worker.Extensions.Http`, `...Extensions.Timer`).
+
+| Element | Explanation |
+|---|---|
+| `OutputType` = `Exe` | The isolated worker runs as its own executable process. |
+| `Microsoft.Azure.Functions.Worker.Sdk` | Replaces `Microsoft.NET.Sdk.Functions`. |
+| Extension packages | Each trigger/binding needs its `Worker.Extensions.*` package; confirm all bindings are covered before deploying. |
+
+## Step 2: Add Program.cs
+
+The isolated model requires an explicit host entry point. This replaces the implicit host startup and any `Startup.cs` (`FunctionsStartup`) you had.
+
+```csharp
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWorkerDefaults()
+    .Build();
+
+host.Run();
+```
+
+Move any `IFunctionsHostBuilder` service registrations into `ConfigureServices` here. See [Dependency Injection](dependency-injection.md).
+
+## Step 3: Update Function Signatures
+
+Attributes and types change. The `[FunctionName]` attribute becomes `[Function]`, and `ILogger` is obtained from `FunctionContext` (or injected).
+
+```csharp
+// In-process (before)
+[FunctionName("Greet")]
+public static IActionResult Run(
+    [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequest req,
+    ILogger log) { ... }
+
+// Isolated (after)
+[Function("Greet")]
+public HttpResponseData Run(
+    [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req,
+    FunctionContext context)
+{
+    var logger = context.GetLogger("Greet");
+    var response = req.CreateResponse(System.Net.HttpStatusCode.OK);
+    response.WriteString("hello");
+    return response;
+}
+```
+
+Key type changes:
+
+| In-process | Isolated worker |
+|---|---|
+| `[FunctionName]` | `[Function]` |
+| `HttpRequest` / `IActionResult` | `HttpRequestData` / `HttpResponseData` |
+| `ILogger` parameter | `context.GetLogger(...)` or injected `ILogger<T>` |
+| `FunctionsStartup` (`Startup.cs`) | `HostBuilder` in `Program.cs` |
+| Static methods common | Instance methods with constructor injection |
+
+## Step 4: Update Configuration
+
+- In `local.settings.json`, set `"FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"`.
+- Review `host.json` — most settings carry over, but verify extension bundle references are removed (isolated apps reference extensions as NuGet packages, not bundles).
+
+## Step 5: Test and Deploy
+
+```bash
+func start
+```
+
+After local verification, update the deployed app's runtime setting and redeploy:
+
+```bash
+az functionapp config appsettings set --resource-group $RG --name $APP_NAME --settings FUNCTIONS_WORKER_RUNTIME=dotnet-isolated
+```
+
+| Element | Explanation |
+|---|---|
+| `func start` | Runs the isolated worker locally; confirm every function loads and responds before deploying. |
+| `FUNCTIONS_WORKER_RUNTIME=dotnet-isolated` | Tells the platform to host the isolated worker; must be set before deploying isolated code. |
+| Expected result | All functions appear in `func start` output and respond as before migration. |
+
+!!! warning "Deploy runtime and code together"
+    Deploying isolated code to an app still configured for the in-process runtime will fail to start. Update `FUNCTIONS_WORKER_RUNTIME` as part of the same release.
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [Middleware](middleware.md)
+- [Unit Testing](testing.md)
+
+## Sources
+
+- [Migrate .NET apps from the in-process model to the isolated worker model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model)
+- [Guide for running C# Azure Functions in the isolated worker model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)

--- a/docs/language-guides/dotnet/recipes/openapi.md
+++ b/docs/language-guides/dotnet/recipes/openapi.md
@@ -1,0 +1,97 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition
+---
+# OpenAPI and Swagger
+
+The .NET isolated worker model has a mature, first-class OpenAPI story through the `Microsoft.Azure.Functions.Worker.Extensions.OpenApi` extension. You annotate HTTP trigger functions with attributes, and the extension generates the OpenAPI (Swagger) document and hosts a Swagger UI automatically — no separate build step or hand-authored spec.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    ATTR[OpenApi attributes on functions] --> EXT[OpenApi extension]
+    EXT --> DOC[Generated openapi.json/v3.json]
+    EXT --> UI[Hosted Swagger UI endpoint]
+    DOC --> APIM[Optional: import into API Management]
+```
+
+## Install the Extension
+
+Add the isolated-worker OpenAPI package to your project.
+
+```bash
+dotnet add package Microsoft.Azure.Functions.Worker.Extensions.OpenApi
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `dotnet add package` |
+| Key flags | package id `Microsoft.Azure.Functions.Worker.Extensions.OpenApi` |
+| Variables | None |
+| Expected result | The package reference is added to the `.csproj`; restore succeeds before continuing. |
+
+## Annotate a Function
+
+The attributes describe the operation, parameters, request body, and each response. The extension reads these to build the OpenAPI document.
+
+```csharp
+public class OrderApi
+{
+    [Function(nameof(GetOrder))]
+    [OpenApiOperation(operationId: "getOrder", tags: new[] { "orders" },
+        Summary = "Get an order", Description = "Returns a single order by id.")]
+    [OpenApiParameter(name: "id", In = ParameterLocation.Path, Required = true,
+        Type = typeof(string), Description = "The order id")]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json",
+        bodyType: typeof(Order), Description = "The requested order")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound,
+        Description = "Order not found")]
+    public async Task<HttpResponseData> GetOrder(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "orders/{id}")] HttpRequestData req,
+        string id)
+    {
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(new Order { Id = id });
+        return response;
+    }
+}
+```
+
+Use `[OpenApiRequestBody(contentType: "application/json", bodyType: typeof(Order), Required = true)]` for `POST`/`PUT` operations, and `[OpenApiSecurity(...)]` to document authentication schemes.
+
+## Access the Generated Document and UI
+
+Once the extension is installed and the app is running, these endpoints are served automatically:
+
+| Endpoint | Purpose |
+|---|---|
+| `/api/swagger/ui` | Interactive Swagger UI |
+| `/api/openapi/v3.json` | OpenAPI 3.0 document (JSON) |
+| `/api/swagger.json` | Swagger 2.0 document (JSON) |
+
+## Publish to API Management
+
+For a production API gateway, import the generated definition into Azure API Management. In the portal, open your function app, select **API Management**, create or link an instance, then **Link API** to import the HTTP-triggered endpoints. API Management can also generate an OpenAPI definition for function apps in any supported language.
+
+!!! tip "Keep the document in source control"
+    Export `openapi/v3.json` during CI so API changes are reviewable in pull requests, and use it to drive contract tests against your endpoints.
+
+## See Also
+
+- [HTTP API Patterns](http-api.md)
+- [Managed Identity](managed-identity.md)
+
+## Sources
+
+- [Expose serverless APIs from HTTP endpoints using Azure API Management (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition)

--- a/docs/language-guides/dotnet/recipes/retry.md
+++ b/docs/language-guides/dotnet/recipes/retry.md
@@ -1,0 +1,106 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+---
+# Retry Policies
+
+Azure Functions runtime-enforced retry policies rerun a failed execution until it succeeds or the maximum retry count is reached. In the .NET isolated worker model you attach a policy with the `[FixedDelayRetry]` or `[ExponentialBackoffRetry]` attribute on the function method. Retry policies are only supported for a specific set of trigger types; other triggers rely on their own built-in retry behavior.
+
+## Supported Triggers
+
+Runtime retry policies apply only to these triggers:
+
+| Trigger | Retry source |
+|---|---|
+| Timer | Retry policies |
+| Event Hubs | Retry policies |
+| Azure Cosmos DB | Retry policies |
+| Kafka | Retry policies |
+
+Queue Storage, Blob Storage, and Service Bus triggers do **not** use retry policies — they retry through their own binding extensions (poison-queue handling, `maxDeliveryCount`, dead-lettering). HTTP triggers have no automatic retry; the caller must retry.
+
+## Required Packages
+
+Function-level retries in the isolated worker require these NuGet packages:
+
+- `Microsoft.Azure.Functions.Worker.Sdk` version 1.9.0 or later
+- `Microsoft.Azure.Functions.Worker.Extensions.EventHubs` version 5.2.0 or later (for Event Hubs)
+- `Microsoft.Azure.Functions.Worker.Extensions.Timer` version 4.2.0 or later (for Timer)
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    EXEC[Function execution] --> ERR{Uncaught exception?}
+    ERR -->|No| DONE[Success: checkpoint/commit]
+    ERR -->|Yes| COUNT{RetryCount < Max?}
+    COUNT -->|Yes| WAIT[Wait per strategy] --> EXEC
+    COUNT -->|No| FAIL[Give up: execution fails]
+```
+
+## Fixed Delay
+
+A fixed amount of time elapses between each retry.
+
+```csharp
+[Function(nameof(ScheduledJob))]
+[FixedDelayRetry(5, "00:00:10")]
+public void ScheduledJob(
+    [TimerTrigger("0 */5 * * * *")] TimerInfo timerInfo,
+    FunctionContext context)
+{
+    var logger = context.GetLogger(nameof(ScheduledJob));
+    logger.LogInformation("Next schedule = {Next}", timerInfo.ScheduleStatus?.Next);
+    throw new InvalidOperationException("This is a retryable exception");
+}
+```
+
+## Exponential Backoff
+
+The first retry waits the minimum interval; each subsequent retry adds time exponentially (with small randomization) up to the maximum interval.
+
+```csharp
+[Function(nameof(ScheduledJob))]
+[ExponentialBackoffRetry(5, "00:00:04", "00:15:00")]
+public void ScheduledJob(
+    [TimerTrigger("0 */5 * * * *")] TimerInfo timerInfo,
+    FunctionContext context)
+{
+    var logger = context.GetLogger(nameof(ScheduledJob));
+    throw new InvalidOperationException("This is a retryable exception");
+}
+```
+
+## Attribute Properties
+
+| Property | Description |
+|---|---|
+| `MaxRetryCount` | Required. Max retries per execution. `-1` retries indefinitely. |
+| `DelayInterval` | Fixed-delay interval, format `HH:mm:ss`. |
+| `MinimumInterval` | Exponential-backoff minimum delay, format `HH:mm:ss`. |
+| `MaximumInterval` | Exponential-backoff maximum delay, format `HH:mm:ss`. |
+
+!!! warning "Max retry count is best-effort"
+    The retry count is stored in instance memory. If the instance fails between retries, the count is lost — Event Hubs resumes on a new instance with the count reset, while Timer does not resume. Design your functions to be idempotent.
+
+!!! note "Event Hubs checkpoint behavior"
+    Event Hubs checkpoints are not written until the retry policy finishes, so progress on that partition is paused until the current batch completes.
+
+## See Also
+
+- [Event Hubs](event-hub.md)
+- [Timer](timer.md)
+
+## Sources
+
+- [Azure Functions error handling and retry guidance (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages)

--- a/docs/language-guides/dotnet/recipes/service-bus.md
+++ b/docs/language-guides/dotnet/recipes/service-bus.md
@@ -1,0 +1,112 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+  diagrams:
+    - id: service-bus
+      type: flowchart
+      source: self-generated
+      justification: Flow view of service-bus, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
+---
+# Service Bus
+
+Consume Service Bus queue and topic messages with the trigger and publish messages with the output binding in the .NET isolated worker model.
+
+<!-- diagram-id: service-bus -->
+```mermaid
+flowchart TD
+    A[Producers] --> B[(Service Bus Queue/Topic)]
+    B --> C[ServiceBusTrigger Function]
+    C --> D[(Dead-Letter Queue)]
+    C --> E[ServiceBusOutput]
+```
+
+## Topic/Command Groups
+
+### Queue trigger
+
+Message settlement is automatic: returning settles the message, and throwing abandons it. After `maxDeliveryCount` the message is dead-lettered.
+
+```csharp
+[Function("ProcessOrder")]
+public void ProcessOrder(
+    [ServiceBusTrigger("orders", Connection = "ServiceBusConnection")] string message,
+    FunctionContext context)
+{
+    var logger = context.GetLogger("ProcessOrder");
+    logger.LogInformation("Processing message: {Message}", message);
+}
+```
+
+### Topic/subscription trigger
+
+```csharp
+[Function("ProcessEvent")]
+public void ProcessEvent(
+    [ServiceBusTrigger("events", "billing", Connection = "ServiceBusConnection")] string message,
+    FunctionContext context)
+{
+    context.GetLogger("ProcessEvent").LogInformation("Subscription message: {Message}", message);
+}
+```
+
+### Output binding
+
+```csharp
+[Function("Enqueue")]
+[ServiceBusOutput("orders", Connection = "ServiceBusConnection")]
+public string Enqueue(
+    [HttpTrigger(AuthorizationLevel.Function, "post", Route = "servicebus/enqueue")]
+    HttpRequestData request)
+{
+    return new StreamReader(request.Body).ReadToEnd();
+}
+```
+
+### Identity-based connection
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "ServiceBusConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
+```
+
+Grant the managed identity the **Azure Service Bus Data Receiver** (and **Data Sender** for output) role.
+
+### Host settings
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "serviceBus": {
+      "maxConcurrentCalls": 16,
+      "prefetchCount": 0,
+      "maxAutoLockRenewalDuration": "00:05:00"
+    }
+  }
+}
+```
+
+## Review Matrix
+
+| Review area | Page-specific check |
+|---|---|
+| Scope | Confirm the guidance applies to Service Bus trigger and output bindings. |
+| Source basis | Validate the recommendation against the Microsoft Learn sources in this page. |
+| Evidence | Capture command output, portal state, metrics, logs, or screenshots before treating the result as proven. |
+
+## See Also
+- [Recipes Index](index.md)
+- [.NET Language Guide](../index.md)
+- [Troubleshooting](../troubleshooting.md)
+
+## Sources
+- [Azure Service Bus bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus)
+- [Azure Service Bus trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger)
+- [Azure Service Bus output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-output)

--- a/docs/language-guides/dotnet/recipes/signalr.md
+++ b/docs/language-guides/dotnet/recipes/signalr.md
@@ -1,0 +1,134 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+  diagrams:
+    - id: signalr
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-input
+---
+# SignalR Service
+
+This recipe covers adding real-time messaging to Azure Functions .NET isolated worker with Azure SignalR Service in serverless mode. It uses the `SignalRConnectionInfoInput` attribute to implement the required `negotiate` endpoint and the `SignalROutput` attribute to broadcast messages to connected clients.
+
+## Architecture
+
+<!-- diagram-id: signalr -->
+```mermaid
+flowchart TD
+    CLIENT[Browser Client] --> NEG[Negotiate Function]
+    NEG --> INFO[SignalRConnectionInfoInput]
+    INFO --> SR[(Azure SignalR Service)]
+    CLIENT -->|WebSocket| SR
+    PUB[Broadcast Function] --> OUT[SignalROutput]
+    OUT --> SR
+    SR -->|push| CLIENT
+```
+
+## Prerequisites
+
+Install the isolated worker SignalR extension package:
+
+```bash
+dotnet add package Microsoft.Azure.Functions.Worker.Extensions.SignalRService
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `dotnet add package` |
+| Key flags | (package name argument) |
+| Variables | None |
+| Expected result | The package reference is added to the `.csproj`; confirm the restore succeeds before continuing. |
+
+Configure the connection in app settings. A connection string (stored as `AzureSignalRConnectionString`) or an identity-based connection is supported:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "AzureSignalRConnectionString__serviceUri=https://$SIGNALR_NAME.service.signalr.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$SIGNALR_NAME` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+The SignalR Service instance must be in **Serverless** mode. When using an identity-based connection, grant the function app's managed identity the **SignalR Service Owner** role on the resource.
+
+## Command Groups
+
+### The negotiate Endpoint
+
+Before a client connects, it calls a `negotiate` endpoint to obtain the service URL and a short-lived access token. The `SignalRConnectionInfoInput` binding produces this payload. The framework serializes the connection info as camel case, which the SignalR client SDK requires.
+
+```csharp
+[Function(nameof(Negotiate))]
+public static string Negotiate(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req,
+    [SignalRConnectionInfoInput(HubName = "serverless")] string connectionInfo)
+{
+    return connectionInfo;
+}
+```
+
+### Broadcast a Message
+
+Return a `SignalRMessageAction` decorated with the `SignalROutput` attribute to send a message to all connected clients. The action specifies a `Target` (the client-side handler name) and `Arguments`.
+
+```csharp
+[Function(nameof(Broadcast))]
+[SignalROutput(HubName = "serverless")]
+public static async Task<SignalRMessageAction> Broadcast(
+    [HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req)
+{
+    string message = await req.ReadAsStringAsync() ?? string.Empty;
+
+    return new SignalRMessageAction("newMessage")
+    {
+        Arguments = new[] { (object)message },
+    };
+}
+```
+
+### Target a User or Group
+
+Set `UserId` or `GroupName` on the `SignalRMessageAction` to target a subset of clients instead of broadcasting.
+
+```csharp
+return new SignalRMessageAction("newMessage")
+{
+    UserId = "user1",
+    Arguments = new[] { (object)message },
+};
+```
+
+## Review Matrix
+
+| Property | Purpose |
+|----------|---------|
+| `Target` | Name of the client-side method invoked by SignalR |
+| `Arguments` | Arguments passed to the client method |
+| `UserId` | Restrict delivery to a single user identifier |
+| `GroupName` | Restrict delivery to members of a named group |
+
+!!! warning "Secure the negotiate endpoint"
+    The example uses `AuthorizationLevel.Anonymous` for clarity. In production, protect the endpoint with App Service Authentication and bind the authenticated user via `UserId = "{headers.x-ms-client-principal-id}"`.
+
+## See Also
+
+- [HTTP Authentication](http-auth.md)
+- [Managed Identity](managed-identity.md)
+
+## Sources
+
+- [Azure Functions SignalR Service bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service)
+- [SignalR Service input binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-input)
+- [SignalR Service output binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-output)

--- a/docs/language-guides/dotnet/recipes/table-storage.md
+++ b/docs/language-guides/dotnet/recipes/table-storage.md
@@ -1,0 +1,106 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+  diagrams:
+    - id: table-storage
+      type: flowchart
+      source: self-generated
+      justification: Flow view of table-storage, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-output
+---
+# Table Storage
+
+Read and write Azure Table Storage entities with the `TableInput` and `TableOutput` bindings in the .NET isolated worker model.
+
+<!-- diagram-id: table-storage -->
+```mermaid
+flowchart TD
+    A[Trigger] --> B[Function]
+    B -->|TableOutput| C[(Table: entity written)]
+    D[(Table: entity read)] -->|TableInput| B
+```
+
+## Topic/Command Groups
+
+### Entity type
+
+The output entity must implement `ITableEntity` or expose string `PartitionKey` and `RowKey` properties.
+
+```csharp
+public class MyTableData : Azure.Data.Tables.ITableEntity
+{
+    public string Text { get; set; }
+    public string PartitionKey { get; set; }
+    public string RowKey { get; set; }
+    public DateTimeOffset? Timestamp { get; set; }
+    public ETag ETag { get; set; }
+}
+```
+
+### Output binding: write an entity
+
+```csharp
+[Function("TableFunction")]
+[TableOutput("OutputTable", Connection = "TableConnection")]
+public static MyTableData Run(
+    [QueueTrigger("table-items", Connection = "AzureWebJobsStorage")] string input,
+    FunctionContext context)
+{
+    return new MyTableData
+    {
+        PartitionKey = "queue",
+        RowKey = Guid.NewGuid().ToString(),
+        Text = $"Record created from message: {input}"
+    };
+}
+```
+
+### Input binding: read an entity
+
+```csharp
+[Function("GetEntity")]
+public static MyTableData GetEntity(
+    [HttpTrigger(AuthorizationLevel.Function, "get", Route = "entities/{partitionKey}/{rowKey}")]
+    HttpRequestData req,
+    [TableInput("OutputTable", "{partitionKey}", "{rowKey}", Connection = "TableConnection")]
+    MyTableData entity)
+{
+    return entity;
+}
+```
+
+### Identity-based connection
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "TableConnection__tableServiceUri=https://$STORAGE_NAME.table.core.windows.net"
+```
+
+Grant the managed identity **Storage Table Data Reader** (input) and **Storage Table Data Contributor** (output).
+
+!!! note "Output binding creates new entities only"
+    The table output binding only creates new entities. To update or delete an entity, inject a `TableClient` from `Azure.Data.Tables` and call it directly.
+
+## Review Matrix
+
+| Review area | Page-specific check |
+|---|---|
+| Scope | Confirm the guidance applies to Table Storage input and output bindings. |
+| Source basis | Validate the recommendation against the Microsoft Learn sources in this page. |
+| Evidence | Capture command output, portal state, metrics, logs, or screenshots before treating the result as proven. |
+
+## See Also
+- [Recipes Index](index.md)
+- [.NET Language Guide](../index.md)
+- [Troubleshooting](../troubleshooting.md)
+
+## Sources
+- [Azure Table storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table)
+- [Azure Tables output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-output)
+- [Azure Tables input binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-input)

--- a/docs/language-guides/dotnet/recipes/testing.md
+++ b/docs/language-guides/dotnet/recipes/testing.md
@@ -1,0 +1,117 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+---
+# Unit Testing
+
+In the .NET isolated worker model a function is a plain class method, so you test it with xUnit by constructing the inputs and asserting on the return value. Because the function class supports constructor injection, you pass fakes or mocks directly. No Functions host is required.
+
+## Prerequisites
+
+- A .NET isolated worker Function App.
+- A test project referencing `xunit` and (optionally) `Moq`.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    TEST[xUnit test] --> INJECT[Construct class with fakes]
+    INJECT --> CALL[Call function method]
+    CALL --> ASSERT[Assert result]
+```
+
+## Testable Function
+
+Depend on an abstraction so tests can substitute the implementation. See [Dependency Injection](dependency-injection.md).
+
+```csharp
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+public class GreetFunction
+{
+    private readonly IGreeter _greeter;
+
+    public GreetFunction(IGreeter greeter) => _greeter = greeter;
+
+    [Function("Greet")]
+    public string Greet([TimerTrigger("0 */5 * * * *")] TimerInfo timer)
+    {
+        return _greeter.Greet("world");
+    }
+}
+
+public interface IGreeter
+{
+    string Greet(string name);
+}
+```
+
+## Test the Function
+
+Inject a fake implementation and assert on the returned value.
+
+```csharp
+using Xunit;
+
+public class GreetFunctionTests
+{
+    private sealed class FakeGreeter : IGreeter
+    {
+        public string Greet(string name) => $"hello {name}";
+    }
+
+    [Fact]
+    public void Greet_ReturnsGreeting()
+    {
+        var function = new GreetFunction(new FakeGreeter());
+
+        var result = function.Greet(new TimerInfo());
+
+        Assert.Equal("hello world", result);
+    }
+}
+```
+
+## Mocking With Moq
+
+For richer behavior verification, use Moq instead of a hand-written fake.
+
+```csharp
+var greeter = new Mock<IGreeter>();
+greeter.Setup(g => g.Greet(It.IsAny<string>())).Returns("hello world");
+
+var function = new GreetFunction(greeter.Object);
+var result = function.Greet(new TimerInfo());
+
+Assert.Equal("hello world", result);
+greeter.Verify(g => g.Greet("world"), Times.Once);
+```
+
+| Element | Explanation |
+|---|---|
+| Constructor injection | Lets tests pass fakes/mocks without a running host. |
+| Hand-written fake | Simplest test double for deterministic behavior. |
+| `Mock<T>` (Moq) | Enables setup and `Verify` for interaction testing. |
+
+!!! tip "HTTP trigger testing"
+    For HTTP functions, build a `FunctionContext` and `HttpRequestData` test double (or use a helper library). To exercise the full pipeline including bindings, run `func start` locally.
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [Middleware](middleware.md)
+
+## Sources
+
+- [Guide for running C# Azure Functions in the isolated worker model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)

--- a/docs/language-guides/index.md
+++ b/docs/language-guides/index.md
@@ -10,6 +10,8 @@ content_sources:
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
     - type: mslearn-adapted
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
   diagrams:
     - id: language-guides
       type: flowchart
@@ -20,10 +22,11 @@ content_sources:
         - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
         - https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library
         - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
 ---
 # Language Guides
 
-The Language Guides section maps Azure Functions platform concepts to language-specific implementation models for **Python**, **Node.js**, **.NET**, and **Java**.
+The Language Guides section maps Azure Functions platform concepts to language-specific implementation models for **Python**, **Node.js**, **.NET**, **Java**, and **PowerShell**.
 
 Use this section after reading platform fundamentals so you can apply the same architecture and operations decisions in the language stack your team ships.
 
@@ -34,6 +37,7 @@ flowchart TD
     LG --> N[Node.js]
     LG --> D[.NET]
     LG --> J[Java]
+    LG --> PS[PowerShell]
 ```
 
 !!! tip "Platform-first, then language"
@@ -48,6 +52,7 @@ flowchart TD
 | Node.js | [Node.js guide](nodejs/index.md) | Roadmap + starter content | [Node.js quick start](nodejs/index.md#quick-start-http-trigger-nodejs-v4-model) |
 | .NET | [.NET guide](dotnet/index.md) | Roadmap + starter content | [.NET isolated quick start](dotnet/index.md#quick-start-http-trigger-net-isolated) |
 | Java | [Java guide](java/index.md) | Roadmap + starter content | [Java quick start](java/index.md#quick-start-http-trigger-java) |
+| PowerShell | [PowerShell guide](powershell/index.md) | Full track (4 hosting plans) | [Tutorial plan chooser](powershell/tutorial/index.md) |
 
 ## Worker and programming model comparison
 
@@ -59,6 +64,7 @@ This table aligns with Microsoft Learn references for each language runtime.
 | Node.js | Out-of-process language worker (gRPC) | v4 code-first model (`app.http()`, `app.timer()`, `app.storageQueue()`) | Node.js 18, 20, 22 | Node.js developer guide |
 | .NET | In-process **or** isolated worker (recommended: isolated) | Attribute-based triggers and bindings | .NET 8 (LTS) for isolated worker in this guide baseline | .NET class library guide |
 | Java | Out-of-process language worker (JVM) | Annotation-based model (`@FunctionName`, trigger/binding annotations) | Java 8, 11, 17, 21 | Java developer guide |
+| PowerShell | Out-of-process language worker (PowerShell host) | Classic `function.json` model (`param` + `Push-OutputBinding`) | PowerShell 7.4 (7.6 preview) | PowerShell developer reference |
 
 ## How to use this section
 
@@ -100,6 +106,19 @@ This table aligns with Microsoft Learn references for each language runtime.
 - Covers annotation-based function model and runtime targeting.
 - Includes baseline HTTP trigger example and roadmap.
 
+### PowerShell
+
+- [PowerShell guide index](powershell/index.md)
+- [Tutorial](powershell/tutorial/index.md) — 4 hosting plan tracks × 7 tutorials each.
+- [Recipes](powershell/recipes/index.md) — practical integration patterns.
+- [PowerShell Programming Model](powershell/powershell-programming-model.md)
+- [PowerShell Runtime](powershell/powershell-runtime.md)
+- [CLI Cheatsheet](powershell/cli-cheatsheet.md)
+- [host.json Reference](powershell/host-json.md)
+- [Environment Variables](powershell/environment-variables.md)
+- [Platform Limits](powershell/platform-limits.md)
+- [Troubleshooting](powershell/troubleshooting.md)
+
 ## Design boundaries
 
 - **Platform docs** explain *why* to choose plan/network/reliability patterns.
@@ -119,3 +138,4 @@ This table aligns with Microsoft Learn references for each language runtime.
 - [Node.js developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
 - [.NET class library guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-class-library)
 - [Java developer guide](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [PowerShell developer reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/java/recipes/dependency-injection.md
+++ b/docs/language-guides/java/recipes/dependency-injection.md
@@ -1,0 +1,119 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+---
+# Dependency Injection
+
+The Java worker for Azure Functions does not ship a built-in dependency injection (DI) container. Function classes are instantiated by the runtime, so you cannot rely on constructor injection the way you would in Spring. The idiomatic approach is to share heavyweight clients (Azure SDK clients, HTTP clients) through lazily initialized static singletons and to wire your own dependencies manually. For a full DI container, use the Spring Cloud Function programming model as a separate option.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    TRIG[Trigger invocation] --> FUNC[Function class instance]
+    FUNC --> HOLDER[Static singleton holder]
+    HOLDER -->|initialized once| CLIENT[Shared Azure SDK client]
+    CLIENT --> REUSE[Connection reused across invocations]
+```
+
+## Why Not Constructor Injection
+
+Azure Functions instantiates your function class per invocation and does not resolve constructor parameters from a container. Creating a new Azure SDK client or `HttpClient` inside the function body on every invocation exhausts connections and adds latency. Instead, hold shared clients in a static field initialized once per worker process.
+
+## Shared Client as a Lazy Static Singleton
+
+Use the initialization-on-demand holder idiom so the client is created once, lazily, and in a thread-safe way without explicit locking.
+
+```java
+public final class Clients {
+
+    private Clients() {
+    }
+
+    private static final class BlobHolder {
+        static final BlobServiceClient INSTANCE = new BlobServiceClientBuilder()
+            .endpoint(System.getenv("STORAGE__blobServiceUri"))
+            .credential(new DefaultAzureCredentialBuilder().build())
+            .buildClient();
+    }
+
+    public static BlobServiceClient blob() {
+        return BlobHolder.INSTANCE;
+    }
+}
+```
+
+The holder class is not loaded until `blob()` is first called, and the JVM guarantees the static initializer runs exactly once.
+
+## Consuming the Shared Client in a Function
+
+```java
+public class UploadFunction {
+
+    @FunctionName("upload")
+    public HttpResponseMessage run(
+        @HttpTrigger(
+            name = "req",
+            methods = {HttpMethod.POST},
+            authLevel = AuthorizationLevel.FUNCTION
+        ) HttpRequestMessage<Optional<String>> request,
+        final ExecutionContext context
+    ) {
+        BlobServiceClient client = Clients.blob();
+        client.getBlobContainerClient("uploads")
+            .getBlobClient(context.getInvocationId())
+            .upload(BinaryData.fromString(request.getBody().orElse("")));
+
+        return request.createResponseBuilder(HttpStatus.ACCEPTED).build();
+    }
+}
+```
+
+## Manual Wiring for Your Own Services
+
+For your own service classes, construct the dependency graph once in a factory and expose it through the same holder idiom. This keeps business logic testable — you can instantiate `OrderService` directly in a unit test with a fake repository.
+
+```java
+public final class Services {
+
+    private Services() {
+    }
+
+    private static final class OrderHolder {
+        static final OrderService INSTANCE =
+            new OrderService(new TableOrderRepository(Clients.table()));
+    }
+
+    public static OrderService orders() {
+        return OrderHolder.INSTANCE;
+    }
+}
+```
+
+## Full DI Container: Spring Cloud Function
+
+When you need a real container with `@Autowired`, component scanning, and configuration binding, use the Spring Cloud Function model. Your business logic is expressed as `Function`, `Consumer`, or `Supplier` beans, and the Azure Functions adapter routes triggers to them. This is a distinct programming model — you opt into the full Spring lifecycle instead of the plain annotation model shown above.
+
+!!! tip "Keep singletons stateless"
+    Shared singletons run across concurrent invocations on the same worker. Only share thread-safe clients; never store per-request state in a static field.
+
+## See Also
+
+- [Managed Identity](managed-identity.md)
+- [Table Storage Integration](table-storage.md)
+
+## Sources
+
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Azure Functions best practices for reliability (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)

--- a/docs/language-guides/java/recipes/durable-advanced.md
+++ b/docs/language-guides/java/recipes/durable-advanced.md
@@ -1,0 +1,131 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of sub-orchestration composition, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+---
+# Durable Functions: Advanced Patterns
+
+This recipe covers advanced Durable Functions patterns for Java beyond the basic chaining and fan-out/fan-in flows: sub-orchestrations, eternal orchestrations, activity retries, and safe versioning. For the fundamentals, see [Durable Orchestration](durable-orchestration.md).
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PARENT[Parent orchestrator] -->|callSubOrchestrator| SUB1[Sub-orchestrator A]
+    PARENT -->|callSubOrchestrator| SUB2[Sub-orchestrator B]
+    SUB1 --> ACT1[Activities]
+    SUB2 --> ACT2[Activities]
+    SUB1 --> PARENT
+    SUB2 --> PARENT
+```
+
+## Sub-Orchestrations
+
+Break a large workflow into reusable orchestrators. A parent calls a sub-orchestrator with `ctx.callSubOrchestrator`, and can fan out over several the same way it fans out over activities.
+
+```java
+@FunctionName("ParentOrchestrator")
+public String parentOrchestrator(
+        @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx) {
+    List<String> regions = ctx.getInput(List.class);
+
+    // Fan out over sub-orchestrations, one per region.
+    List<Task<String>> tasks = new ArrayList<>();
+    for (String region : regions) {
+        tasks.add(ctx.callSubOrchestrator("ProcessRegion", region, String.class));
+    }
+    List<String> results = ctx.allOf(tasks).await();
+    return "Processed " + results.size() + " regions";
+}
+
+@FunctionName("ProcessRegion")
+public String processRegion(
+        @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx) {
+    String region = ctx.getInput(String.class);
+    String validated = ctx.callActivity("ValidateRegion", region, String.class).await();
+    return ctx.callActivity("LoadRegion", validated, String.class).await();
+}
+```
+
+## Eternal Orchestrations
+
+For a workflow that runs indefinitely (aggregators, periodic jobs), do **not** use an unbounded loop — the history would grow forever. Call `ctx.continueAsNew` to restart the orchestration with fresh state and a clean history.
+
+```java
+@FunctionName("PeriodicCleanup")
+public void periodicCleanup(
+        @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx) {
+    CleanupState state = ctx.getInput(CleanupState.class);
+    if (state == null) {
+        state = new CleanupState();
+    }
+
+    ctx.callActivity("RunCleanup", state).await();
+    state.runs += 1;
+
+    // Durable sleep, then restart with new state and empty history.
+    ctx.createTimer(Duration.ofHours(1)).await();
+    ctx.continueAsNew(state);
+}
+```
+
+## Activity Retries
+
+Wrap flaky activities with a retry policy instead of hand-coding retry loops. The orchestration replays cleanly because retries are recorded in history.
+
+```java
+@FunctionName("ResilientOrchestrator")
+public String resilientOrchestrator(
+        @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx) {
+    Order order = ctx.getInput(Order.class);
+
+    RetryPolicy policy = new RetryPolicy(3, Duration.ofSeconds(5));
+    TaskOptions options = new TaskOptions(policy);
+
+    return ctx.callActivity("ChargeCustomer", order, options, String.class).await();
+}
+```
+
+| Element | Explanation |
+|---|---|
+| `callSubOrchestrator` | Invokes another orchestrator as a child; compose and fan out like activities. |
+| `continueAsNew` | Restarts the orchestration with new input and a trimmed history for eternal loops. |
+| `RetryPolicy` / `TaskOptions` | Declarative retry policy passed to `callActivity`. |
+
+## Versioning
+
+Orchestrations replay from history, so changing an orchestrator's code while instances are in flight can break replay (non-determinism). Safe strategies:
+
+- **Deploy side by side**: give the changed orchestrator a new name and route new instances to it, letting existing instances drain on the old version.
+- **Do not reorder or remove** existing activity calls in a deployed orchestrator.
+- **Terminate and restart** in-flight instances if a breaking change is unavoidable.
+
+!!! warning "Determinism still applies"
+    Advanced patterns do not relax the determinism rule. Never call `Instant.now()`, generate random values, or do direct I/O inside an orchestrator — use activities and `ctx.getCurrentInstant()`.
+
+## See Also
+
+- [Durable Orchestration](durable-orchestration.md)
+- [Durable Entities](durable-entities.md)
+- [Platform: Durable Functions](../../../platform/durable-functions.md)
+
+## Sources
+
+- [Sub-orchestrations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations)
+- [Eternal orchestrations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations)
+- [Versioning (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning)
+</content>

--- a/docs/language-guides/java/recipes/durable-entities.md
+++ b/docs/language-guides/java/recipes/durable-entities.md
@@ -1,0 +1,193 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities
+  diagrams:
+    - id: entity-lifecycle
+      type: flowchart
+      source: self-generated
+      justification: Flow view of the durable entity lifecycle, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+---
+# Durable Entities
+
+This recipe covers Durable Entities (the stateful entity model) with Azure Functions Java. Durable Functions for Java supports entities using a class-based syntax from version 1.9.0 or later.
+
+## Overview
+
+Durable Entities manage small pieces of explicit state — tiny, addressable, single-threaded objects that live in durable storage. Unlike orchestrator functions, which represent state implicitly through control flow, an entity reads and writes its state explicitly through operations.
+
+Entities are ideal for aggregation (counters, running totals), fan-in of high-volume signals without lock contention, and actor-style per-key state.
+
+| Concept | Description |
+|---------|-------------|
+| **Entity class** | Extends `AbstractTaskEntity<TState>`; each public method is an operation. |
+| **Entity ID** | An `EntityInstanceId` pair: the **entity name** (e.g. `Counter`) plus the **entity key** (the unique instance). |
+| **Operation** | A named method invoked by name (for example `add`, `reset`, `get`), with optional input. |
+| **Serialized access** | A single entity processes its operations one at a time, so you never need locks. |
+
+<!-- diagram-id: entity-lifecycle -->
+```mermaid
+flowchart TD
+    CLIENT["Client Function\nsignalEntity() / getEntityMetadata()"] -->|"signal (one-way)"| ENT["Entity Function\nCounter@key\noperations run serially"]
+    ORC["Orchestrator Function\ncallEntity() / signalEntity()"] -->|"call (two-way)"| ENT
+    ENT -->|"state persisted"| STORE["Durable Store\npersisted entity state"]
+    STORE -->|"readStateAs()"| CLIENT
+```
+
+## Prerequisites
+
+Ensure your project references Durable Functions for Java 1.9.0 or later. Entities persist state in Azure Storage (`AzureWebJobsStorage`), like orchestrations.
+
+## Define an Entity Class
+
+Extend `AbstractTaskEntity<TState>`. Each public method is an operation; `initializeState` supplies the default state.
+
+```java
+package com.contoso.functions;
+
+import com.microsoft.durabletask.AbstractTaskEntity;
+import com.microsoft.durabletask.TaskEntityOperation;
+
+public class CounterEntity extends AbstractTaskEntity<Integer> {
+
+    public void add(int value) {
+        this.state += value;
+    }
+
+    public void subtract(int value) {
+        this.state -= value;
+    }
+
+    public int get() {
+        return this.state;
+    }
+
+    public void reset() {
+        this.state = 0;
+    }
+
+    @Override
+    protected Integer initializeState(TaskEntityOperation operation) {
+        return 0;
+    }
+
+    @Override
+    protected Class<Integer> getStateType() {
+        return Integer.class;
+    }
+}
+```
+
+Bind the entity class to an entity trigger function:
+
+```java
+import com.microsoft.azure.functions.annotation.*;
+import com.microsoft.durabletask.azurefunctions.DurableEntityTrigger;
+import com.microsoft.durabletask.EntityRunner;
+
+public class EntityFunctions {
+
+    @FunctionName("Counter")
+    public String counterEntity(
+        @DurableEntityTrigger(name = "req") String req) {
+        return EntityRunner.loadAndRun(req, CounterEntity::new);
+    }
+}
+```
+
+## Signal an Entity from a Client Function
+
+Signaling is one-way (fire-and-forget). Use the `DurableClientContext`.
+
+```java
+@FunctionName("SignalCounter")
+public HttpResponseMessage signalCounter(
+    @HttpTrigger(name = "req", methods = {HttpMethod.POST},
+        authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<Void> request,
+    @DurableClientInput(name = "durableContext") DurableClientContext durableContext) {
+
+    String key = request.getQueryParameters().getOrDefault("key", "myCounter");
+    int value = Integer.parseInt(request.getQueryParameters().getOrDefault("value", "1"));
+
+    EntityInstanceId entityId = new EntityInstanceId("Counter", key);
+    durableContext.signalEntity(entityId, "add", value);
+
+    return request.createResponseBuilder(HttpStatus.ACCEPTED)
+        .body("Signaled add on entity '" + key + "'")
+        .build();
+}
+```
+
+## Read Entity State from a Client Function
+
+Reading returns the entity's most recently persisted (committed) state.
+
+```java
+@FunctionName("GetCounter")
+public HttpResponseMessage getCounter(
+    @HttpTrigger(name = "req", methods = {HttpMethod.GET},
+        authLevel = AuthorizationLevel.FUNCTION) HttpRequestMessage<Void> request,
+    @DurableClientInput(name = "durableContext") DurableClientContext durableContext) {
+
+    String key = request.getQueryParameters().getOrDefault("key", "myCounter");
+    EntityInstanceId entityId = new EntityInstanceId("Counter", key);
+
+    EntityMetadata metadata = durableContext.getEntityMetadata(entityId, true);
+    if (metadata == null) {
+        return request.createResponseBuilder(HttpStatus.NOT_FOUND)
+            .body("Entity '" + key + "' not found").build();
+    }
+
+    Integer state = metadata.readStateAs(Integer.class);
+    return request.createResponseBuilder(HttpStatus.OK)
+        .header("Content-Type", "application/json")
+        .body("{\"key\": \"" + key + "\", \"value\": " + state + "}")
+        .build();
+}
+```
+
+## Call and Signal an Entity from an Orchestrator
+
+Orchestrators can both signal (one-way) and call (two-way) entities.
+
+```java
+@FunctionName("CounterOrchestration")
+public String counterOrchestration(
+    @DurableOrchestrationTrigger(name = "ctx") TaskOrchestrationContext ctx) {
+
+    String key = ctx.getInput(String.class);
+    EntityInstanceId entityId = new EntityInstanceId("Counter", key);
+
+    // Fire-and-forget signals.
+    ctx.signalEntity(entityId, "add", 10);
+    ctx.signalEntity(entityId, "subtract", 3);
+
+    // Two-way call: wait for the result.
+    int value = ctx.callEntity(entityId, "get", Integer.class).await();
+
+    return "Counter '" + key + "' final value: " + value;
+}
+```
+
+## Access Rules Summary
+
+| Caller | Signal (one-way) | Call (two-way) | Read state |
+|--------|:---:|:---:|:---:|
+| **Client function** | Yes | No | Yes |
+| **Orchestrator function** | Yes | Yes | No (call `get` instead) |
+| **Entity function** | Yes | No | — |
+
+## See Also
+
+- [Durable Orchestration](durable-orchestration.md)
+- [Platform: Durable Functions](../../../platform/durable-functions.md)
+- [HTTP API Patterns](http-api.md)
+
+## Sources
+
+- [Durable entities (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities)
+- [Durable Functions overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview)

--- a/docs/language-guides/java/recipes/event-grid.md
+++ b/docs/language-guides/java/recipes/event-grid.md
@@ -92,6 +92,54 @@ public class EventGridFunctions {
 - Keep handlers idempotent because duplicate event delivery can occur.
 - Route by `eventType` and `subject` to isolate processing paths.
 
+## Event Grid Output: Publish to a Custom Topic
+
+Use the `@EventGridOutput` annotation to publish events to a custom topic. The annotation reads the topic endpoint and access key from app settings, so never hard-code the topic URI in the annotation properties. You can output a JSON string or a POJO.
+
+```java
+public class PublishFunction {
+    @FunctionName("publishEvent")
+    public void run(
+            @TimerTrigger(name = "timer", schedule = "0 */5 * * * *") String timerInfo,
+            @EventGridOutput(
+                name = "outputEvent",
+                topicEndpointUri = "MyEventGridTopicUriSetting",
+                topicKeySetting = "MyEventGridTopicKeySetting")
+                OutputBinding<EventGridEvent> outputEvent,
+            final ExecutionContext context) {
+        EventGridEvent event = new EventGridEvent();
+        event.setId("1807");
+        event.setEventType("Contoso.Order.Created");
+        event.setSubject("orders/created");
+        event.setEventTime("2026-01-01T00:00:00+00:00");
+        event.setDataVersion("1.0");
+        event.setData("{ orderId: 12345 }");
+        outputEvent.setValue(event);
+    }
+}
+```
+
+Here `EventGridEvent` is a plain POJO with `id`, `eventType`, `subject`, `eventTime`, `dataVersion`, and `data` fields and their getters/setters.
+
+Configure the two app settings the annotation references:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "MyEventGridTopicUriSetting=$TOPIC_ENDPOINT" "MyEventGridTopicKeySetting=$TOPIC_KEY"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$TOPIC_ENDPOINT`, `$TOPIC_KEY` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm both settings are present before continuing. |
+
+!!! note "CloudEvents schema"
+    The output binding emits the Event Grid schema. To publish in the **CloudEvents 1.0** schema, create the custom topic with `--input-schema cloudeventschemav1.0` and produce the payload in CloudEvents shape (`specversion`, `type`, `source`, `id`, `data`).
+
 ## See Also
 
 - [Queue Storage Integration](queue.md)
@@ -101,4 +149,5 @@ public class EventGridFunctions {
 ## Sources
 
 - [Event Grid trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger)
+- [Event Grid output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-output)
 - [Create event subscriptions with Azure CLI (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest)

--- a/docs/language-guides/java/recipes/event-hub.md
+++ b/docs/language-guides/java/recipes/event-hub.md
@@ -1,0 +1,148 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger
+---
+# Event Hubs Integration
+
+This recipe demonstrates Java Event Hubs trigger and output bindings — consuming a high-throughput event stream (single and batch delivery), reading event metadata, and publishing events downstream.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PROD[Event Producers] --> EH[(Event Hub Partitions)]
+    EH --> TRIG[EventHubTrigger worker]
+    TRIG --> FA[Function App]
+    FA --> OUT[EventHubOutput downstream]
+```
+
+## Prerequisites
+
+Provide the connection in app settings. A connection-string setting or an identity-based connection is supported. Identity-based connections use a setting prefix with `__fullyQualifiedNamespace`:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "EventHubConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$NAMESPACE` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+When using an identity-based connection, grant the function app's managed identity the **Azure Event Hubs Data Receiver** (and **Data Sender** for output) role on the namespace.
+
+## Java Implementation
+
+Setting `cardinality = Cardinality.MANY` delivers a batch of events per invocation, which dramatically improves throughput. Keep the handler idempotent because delivery is at-least-once.
+
+```java
+package com.contoso.functions;
+
+import com.microsoft.azure.functions.*;
+import com.microsoft.azure.functions.annotation.*;
+
+public class EventHubFunctions {
+
+    @FunctionName("processTelemetry")
+    public void processTelemetry(
+        @EventHubTrigger(
+            name = "events",
+            eventHubName = "telemetry",
+            connection = "EventHubConnection",
+            consumerGroup = "$Default",
+            cardinality = Cardinality.MANY
+        ) String[] events,
+        @EventHubOutput(
+            name = "downstream",
+            eventHubName = "downstream",
+            connection = "EventHubConnection"
+        ) OutputBinding<String[]> output,
+        final ExecutionContext context
+    ) {
+        context.getLogger().info("Batch size: " + events.length);
+
+        String[] forwarded = new String[events.length];
+        for (int i = 0; i < events.length; i++) {
+            // Keep processing idempotent.
+            context.getLogger().info("Processing event: " + events[i]);
+            forwarded[i] = events[i];
+        }
+
+        output.setValue(forwarded);
+    }
+}
+```
+
+## Reading Event Metadata
+
+Use the `@BindingName` annotation to bind partition context and system properties such as sequence numbers and enqueued timestamps:
+
+```java
+@FunctionName("processWithMetadata")
+public void processWithMetadata(
+    @EventHubTrigger(
+        name = "event",
+        eventHubName = "telemetry",
+        connection = "EventHubConnection"
+    ) String event,
+    @BindingName("SequenceNumber") long sequenceNumber,
+    @BindingName("EnqueuedTimeUtc") String enqueuedTimeUtc,
+    final ExecutionContext context
+) {
+    context.getLogger().info("Sequence: " + sequenceNumber);
+    context.getLogger().info("Enqueued: " + enqueuedTimeUtc);
+}
+```
+
+## Host Configuration and Checkpointing
+
+Tune batch size and checkpoint frequency in `host.json`:
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "eventHubs": {
+      "maxEventBatchSize": 100,
+      "batchCheckpointFrequency": 1,
+      "prefetchCount": 300
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `maxEventBatchSize` | 100 | Maximum number of events delivered per batch invocation |
+| `batchCheckpointFrequency` | 1 | Number of batches processed before a checkpoint is written |
+| `prefetchCount` | 300 | Number of events the underlying client prefetches |
+
+!!! note "Checkpointing"
+    The Event Hubs extension checkpoints progress to the storage account referenced by `AzureWebJobsStorage`. A higher `batchCheckpointFrequency` reduces storage writes but increases the volume of events reprocessed after a restart.
+
+## See Also
+
+- [Queue Storage Integration](queue.md)
+- [Managed Identity](managed-identity.md)
+
+## Sources
+
+- [Azure Event Hubs bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs)
+- [Azure Event Hubs trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger)
+- [Azure Event Hubs output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-output)

--- a/docs/language-guides/java/recipes/index.md
+++ b/docs/language-guides/java/recipes/index.md
@@ -29,11 +29,12 @@ flowchart TD
 
 | Area | Recipe |
 |------|--------|
-| HTTP | [HTTP API Patterns](http-api.md), [HTTP Authentication](http-auth.md) |
-| Data | [Cosmos DB Integration](cosmosdb.md), [Blob Storage Integration](blob-storage.md), [Queue Storage Integration](queue.md) |
+| HTTP | [HTTP API Patterns](http-api.md), [HTTP Authentication](http-auth.md), [OpenAPI and Swagger](openapi.md) |
+| Data | [Cosmos DB Integration](cosmosdb.md), [Blob Storage Integration](blob-storage.md), [Queue Storage Integration](queue.md), [Table Storage Integration](table-storage.md) |
 | Security | [Key Vault Integration](key-vault.md), [Managed Identity](managed-identity.md) |
-| Eventing | [Timer Trigger](timer.md), [Event Grid Trigger](event-grid.md), [Durable Orchestration](durable-orchestration.md) |
+| Eventing | [Timer Trigger](timer.md), [Event Grid Trigger](event-grid.md), [Event Hubs Integration](event-hub.md), [Service Bus Integration](service-bus.md), [SignalR Service](signalr.md), [Durable Orchestration](durable-orchestration.md), [Durable Entities](durable-entities.md), [Durable Advanced](durable-advanced.md) |
 | Platform edge | [Custom Domain and Certificates](custom-domain-certificates.md) |
+| Patterns | [Dependency Injection](dependency-injection.md), [Retry Policies](retry.md), [Middleware](middleware.md), [Unit Testing](testing.md) |
 
 ## See Also
 

--- a/docs/language-guides/java/recipes/middleware.md
+++ b/docs/language-guides/java/recipes/middleware.md
@@ -1,0 +1,97 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+---
+# Middleware
+
+The Java programming model has **no built-in middleware pipeline**. Unlike the .NET isolated worker or the Node.js v4 hook system, the runtime does not provide a way to wrap every invocation. The idiomatic alternative is a shared helper method (or a small base class) that your function handlers delegate to, centralizing cross-cutting behavior — logging, timing, error handling — in one place.
+
+## Prerequisites
+
+- A Java Function App using the `com.microsoft.azure.functions` annotation model.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    REQ[Trigger fires] --> WRAP[Shared executor: pre-logic]
+    WRAP --> FUNC[Business logic]
+    FUNC --> POST[Shared executor: post-logic]
+    POST --> RESP[Response returned]
+```
+
+## Shared Executor Method
+
+Define a reusable method that takes the business logic as a functional interface (`Supplier`), wrapping it with the cross-cutting concerns.
+
+```java
+import com.microsoft.azure.functions.ExecutionContext;
+import java.util.function.Supplier;
+
+public final class Invoker {
+    private Invoker() { }
+
+    public static <T> T run(ExecutionContext context, Supplier<T> logic) {
+        long start = System.currentTimeMillis();
+        context.getLogger().info("Starting " + context.getFunctionName());
+        try {
+            return logic.get();
+        } catch (RuntimeException ex) {
+            context.getLogger().severe("Unhandled error: " + ex.getMessage());
+            throw ex;
+        } finally {
+            long elapsed = System.currentTimeMillis() - start;
+            context.getLogger().info("Finished in " + elapsed + "ms");
+        }
+    }
+}
+```
+
+## Use It From a Function
+
+```java
+import com.microsoft.azure.functions.*;
+import com.microsoft.azure.functions.annotation.*;
+import java.util.Optional;
+
+public class OrderFunction {
+    @FunctionName("createOrder")
+    public HttpResponseMessage createOrder(
+            @HttpTrigger(name = "req", methods = {HttpMethod.POST},
+                    authLevel = AuthorizationLevel.FUNCTION)
+            HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+
+        return Invoker.run(context, () ->
+            request.createResponseBuilder(HttpStatus.CREATED).body("created").build());
+    }
+}
+```
+
+| Element | Explanation |
+|---|---|
+| `Supplier<T>` | Wraps the function body so the executor can run pre- and post-logic around it. |
+| `ExecutionContext` | Passed through so the shared method can log with the correct function name. |
+| `try/catch/finally` | Centralizes error handling and guaranteed post-logic. |
+
+!!! tip "Spring Cloud Function"
+    If you host Azure Functions with Spring Cloud Function, you can use Spring's `@Around` aspects or `FunctionInvocationWrapper` instead of a hand-written executor, giving you a more conventional interceptor model.
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [Retry Policies](retry.md)
+
+## Sources
+
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)

--- a/docs/language-guides/java/recipes/openapi.md
+++ b/docs/language-guides/java/recipes/openapi.md
@@ -1,0 +1,80 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition
+---
+# OpenAPI and Swagger
+
+Unlike the .NET isolated worker, the Java worker has no first-class, Microsoft-supported OpenAPI extension that generates a spec from your `@FunctionName` annotations. The idiomatic approaches are: (1) let Azure API Management generate the OpenAPI definition when you import your HTTP endpoints, and (2) hand-author an `openapi.json` document and serve it — plus optionally a Swagger UI — from an HTTP function.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    FUNC[HTTP trigger functions] --> APIM[API Management import]
+    APIM --> GEN[Generated OpenAPI definition]
+    SPEC[Hand-authored openapi.json] --> SERVE[HTTP function serves /openapi.json]
+    SERVE --> UI[Swagger UI page]
+```
+
+## Option 1: Generate via API Management
+
+Azure API Management can import your HTTP-triggered function endpoints and produce an OpenAPI definition. This works for function apps in any supported language, including Java. In the portal, open your function app, select **API Management**, create or link an instance, then **Link API** to import the endpoints and **Download OpenAPI definition**.
+
+This is the lowest-effort path when you already front your functions with API Management.
+
+## Option 2: Serve a Hand-Authored Spec
+
+Keep an `openapi.json` file on the classpath (for example under `src/main/resources`) and serve it from an HTTP function. This gives you a versioned, source-controlled contract without a code-generation dependency.
+
+```java
+public class OpenApiFunction {
+
+    @FunctionName("openapi")
+    public HttpResponseMessage openapi(
+        @HttpTrigger(
+            name = "req",
+            methods = {HttpMethod.GET},
+            authLevel = AuthorizationLevel.ANONYMOUS,
+            route = "openapi.json"
+        ) HttpRequestMessage<Optional<String>> request
+    ) throws IOException {
+        String spec;
+        try (InputStream in = getClass().getResourceAsStream("/openapi.json")) {
+            spec = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        return request.createResponseBuilder(HttpStatus.OK)
+            .header("Content-Type", "application/json")
+            .body(spec)
+            .build();
+    }
+}
+```
+
+## Serve Swagger UI
+
+Serve a minimal HTML page from another HTTP function that loads Swagger UI from a CDN and points it at the spec endpoint (`/api/openapi.json`). Store the HTML as a resource file and return it with `Content-Type: text/html`, mirroring the pattern above.
+
+!!! note "Keep the spec in sync"
+    Because the spec is hand-authored, it can drift from your actual routes. Add a contract test that loads `openapi.json` and asserts every documented path has a matching `@FunctionName` route.
+
+!!! tip "SpringDoc for Spring Cloud Function"
+    If you run the Spring Cloud Function programming model instead of the plain annotation model, you can generate OpenAPI documentation with SpringDoc, the same way you would in a standard Spring Boot application.
+
+## See Also
+
+- [HTTP API Patterns](http-api.md)
+- [HTTP Authentication](http-auth.md)
+
+## Sources
+
+- [Expose serverless APIs from HTTP endpoints using Azure API Management (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition)

--- a/docs/language-guides/java/recipes/retry.md
+++ b/docs/language-guides/java/recipes/retry.md
@@ -1,0 +1,97 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+---
+# Retry Policies
+
+Azure Functions runtime-enforced retry policies rerun a failed execution until it succeeds or the maximum retry count is reached. In Java you attach a policy with the `@FixedDelayRetry` or `@ExponentialBackoffRetry` annotation on the function method. Retry policies are only supported for a specific set of trigger types; other triggers rely on their own built-in retry behavior.
+
+## Supported Triggers
+
+Runtime retry policies apply only to these triggers:
+
+| Trigger | Retry source |
+|---|---|
+| Timer | Retry policies |
+| Event Hubs | Retry policies |
+| Azure Cosmos DB | Retry policies |
+| Kafka | Retry policies |
+
+Queue Storage, Blob Storage, and Service Bus triggers do **not** use retry policies — they retry through their own binding extensions (poison-queue handling, `maxDeliveryCount`, dead-lettering). HTTP triggers have no automatic retry; the caller must retry.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    EXEC[Function execution] --> ERR{Uncaught exception?}
+    ERR -->|No| DONE[Success: checkpoint/commit]
+    ERR -->|Yes| COUNT{retryCount < max?}
+    COUNT -->|Yes| WAIT[Wait per strategy] --> EXEC
+    COUNT -->|No| FAIL[Give up: execution fails]
+```
+
+## Fixed Delay
+
+A fixed amount of time elapses between each retry.
+
+```java
+@FunctionName("scheduledJob")
+@FixedDelayRetry(maxRetryCount = 4, delayInterval = "00:00:10")
+public void run(
+    @TimerTrigger(name = "timerInfo", schedule = "0 */5 * * * *") String timerInfo,
+    final ExecutionContext context
+) {
+    context.getLogger().info("Timer executed at: " + LocalDateTime.now());
+    throw new RuntimeException("This is a retryable exception");
+}
+```
+
+## Exponential Backoff
+
+The first retry waits the minimum interval; each subsequent retry adds time exponentially (with small randomization) up to the maximum interval.
+
+```java
+@FunctionName("scheduledJob")
+@ExponentialBackoffRetry(maxRetryCount = 5, minimumInterval = "00:00:10", maximumInterval = "00:15:00")
+public void run(
+    @TimerTrigger(name = "timerInfo", schedule = "0 */5 * * * *") String timerInfo,
+    final ExecutionContext context
+) {
+    context.getLogger().info("Timer executed at: " + LocalDateTime.now());
+    throw new RuntimeException("This is a retryable exception");
+}
+```
+
+## Policy Properties
+
+| Element | Description |
+|---|---|
+| `maxRetryCount` | Required. Max retries per execution. `-1` retries indefinitely. |
+| `delayInterval` | Fixed-delay interval, format `HH:mm:ss`. |
+| `minimumInterval` | Exponential-backoff minimum delay, format `HH:mm:ss`. |
+| `maximumInterval` | Exponential-backoff maximum delay, format `HH:mm:ss`. |
+
+!!! warning "Max retry count is best-effort"
+    The retry count is stored in instance memory. If the instance fails between retries, the count is lost — Event Hubs resumes on a new instance with the count reset, while Timer does not resume. Design your functions to be idempotent.
+
+!!! note "Event Hubs checkpoint behavior"
+    Event Hubs checkpoints are not written until the retry policy finishes, so progress on that partition is paused until the current batch completes.
+
+## See Also
+
+- [Event Hubs Integration](event-hub.md)
+- [Timer Trigger](timer.md)
+
+## Sources
+
+- [Azure Functions error handling and retry guidance (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages)

--- a/docs/language-guides/java/recipes/service-bus.md
+++ b/docs/language-guides/java/recipes/service-bus.md
@@ -1,0 +1,136 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
+---
+# Service Bus Integration
+
+This recipe demonstrates Java Service Bus queue and topic triggers with output bindings, dead-letter behavior, and host tuning.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PROD[Producers] --> SBQ[(Service Bus Queue/Topic)]
+    SBQ --> TRIG[ServiceBusQueueTrigger worker]
+    TRIG --> FA[Function App]
+    FA --> DLQ[(Dead-Letter Queue)]
+    FA --> OUT[ServiceBusQueueOutput]
+```
+
+## Prerequisites
+
+Provide the connection in app settings. A connection-string setting or an identity-based connection is supported. Identity-based connections use a setting prefix with `__fullyQualifiedNamespace`:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "ServiceBusConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$NAMESPACE` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+When using an identity-based connection, grant the function app's managed identity the **Azure Service Bus Data Receiver** (and **Data Sender** for output) role on the namespace.
+
+## Java Implementation
+
+```java
+package com.contoso.functions;
+
+import com.microsoft.azure.functions.*;
+import com.microsoft.azure.functions.annotation.*;
+
+public class ServiceBusFunctions {
+
+    @FunctionName("processOrder")
+    public void processOrder(
+        @ServiceBusQueueTrigger(
+            name = "message",
+            queueName = "orders",
+            connection = "ServiceBusConnection"
+        ) String message,
+        final ExecutionContext context
+    ) {
+        context.getLogger().info("Processing Service Bus message: " + message);
+        // Throwing abandons the message; after maxDeliveryCount it is
+        // moved to the dead-letter queue automatically.
+    }
+
+    @FunctionName("processEvent")
+    public void processEvent(
+        @ServiceBusTopicTrigger(
+            name = "message",
+            topicName = "events",
+            subscriptionName = "billing",
+            connection = "ServiceBusConnection"
+        ) String message,
+        final ExecutionContext context
+    ) {
+        context.getLogger().info("Subscription message: " + message);
+    }
+
+    @FunctionName("enqueue")
+    @ServiceBusQueueOutput(name = "output", queueName = "orders", connection = "ServiceBusConnection")
+    public String enqueue(
+        @HttpTrigger(
+            name = "request",
+            methods = {HttpMethod.POST},
+            authLevel = AuthorizationLevel.FUNCTION,
+            route = "servicebus/enqueue"
+        ) HttpRequestMessage<String> request
+    ) {
+        return request.getBody();
+    }
+}
+```
+
+## Host Configuration
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "serviceBus": {
+      "maxConcurrentCalls": 16,
+      "prefetchCount": 0,
+      "maxAutoLockRenewalDuration": "00:05:00"
+    }
+  }
+}
+```
+
+| Setting | Description |
+|---------|-------------|
+| `maxConcurrentCalls` | Maximum concurrent message handlers per instance |
+| `prefetchCount` | Number of messages the client prefetches to reduce latency |
+| `maxAutoLockRenewalDuration` | How long the runtime keeps renewing the message lock during processing |
+
+!!! note "Sessions and ordering"
+    Set `isSessionsEnabled = true` on the trigger to process session-enabled queues/subscriptions, which guarantees ordered, single-consumer processing per session ID.
+
+## See Also
+
+- [Queue Storage Integration](queue.md)
+- [Event Hubs Integration](event-hub.md)
+
+## Sources
+
+- [Azure Service Bus bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus)
+- [Azure Service Bus trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger)
+- [Azure Service Bus output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-output)

--- a/docs/language-guides/java/recipes/signalr.md
+++ b/docs/language-guides/java/recipes/signalr.md
@@ -1,0 +1,130 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-input
+---
+# SignalR Service Integration
+
+This recipe covers adding real-time messaging to Azure Functions Java with Azure SignalR Service in serverless mode. It uses the `@SignalRConnectionInfoInput` annotation to implement the required `negotiate` endpoint and the `@SignalROutput` annotation to broadcast messages to connected clients.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    CLIENT[Browser Client] --> NEG[negotiate Function]
+    NEG --> INFO[SignalRConnectionInfo Input]
+    INFO --> SR[(Azure SignalR Service)]
+    CLIENT -->|WebSocket| SR
+    PUB[broadcast Function] --> OUT[SignalR Output]
+    OUT --> SR
+    SR -->|push| CLIENT
+```
+
+## Prerequisites
+
+To use the SignalR Service annotations in Java functions, add the SignalR library dependency to your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>com.microsoft.azure.functions</groupId>
+    <artifactId>azure-functions-java-library-signalr</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+Configure the connection in app settings. A connection string (stored as `AzureSignalRConnectionString`) or an identity-based connection is supported:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "AzureSignalRConnectionString__serviceUri=https://$SIGNALR_NAME.service.signalr.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$SIGNALR_NAME` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+The SignalR Service instance must be in **Serverless** mode. When using an identity-based connection, grant the function app's managed identity the **SignalR Service Owner** role on the resource.
+
+## The negotiate Endpoint
+
+Before a client connects, it calls a `negotiate` endpoint to obtain the service URL and a short-lived access token. The `@SignalRConnectionInfoInput` binding produces this payload.
+
+```java
+@FunctionName("negotiate")
+public SignalRConnectionInfo negotiate(
+        @HttpTrigger(
+            name = "req",
+            methods = { HttpMethod.POST },
+            authLevel = AuthorizationLevel.ANONYMOUS)
+            HttpRequestMessage<Optional<String>> req,
+        @SignalRConnectionInfoInput(
+            name = "connectionInfo",
+            hubName = "serverless") SignalRConnectionInfo connectionInfo) {
+    return connectionInfo;
+}
+```
+
+!!! warning "Secure the negotiate endpoint"
+    In production, protect the endpoint with App Service Authentication and bind the authenticated user via `userId = "{headers.x-ms-client-principal-id}"` so each token carries a user identity.
+
+## Output Binding: Broadcast a Message
+
+The `@SignalROutput` annotation sends a message to all connected clients. The `SignalRMessage` object specifies a `target` (the client-side handler name) and `arguments`.
+
+```java
+@FunctionName("broadcast")
+@SignalROutput(name = "$return", hubName = "serverless")
+public SignalRMessage broadcast(
+        @HttpTrigger(
+            name = "req",
+            methods = { HttpMethod.POST },
+            authLevel = AuthorizationLevel.FUNCTION)
+            HttpRequestMessage<Optional<String>> req) {
+    SignalRMessage message = new SignalRMessage();
+    message.target = "newMessage";
+    message.arguments.add(req.getBody().orElse(""));
+    return message;
+}
+```
+
+## Sending to a Specific User or Group
+
+Set `userId` or `groupName` on the `SignalRMessage` to target a subset of clients instead of broadcasting:
+
+```java
+message.userId = "user1";
+message.target = "newMessage";
+```
+
+| Field | Purpose |
+|-------|---------|
+| `target` | Name of the client-side method invoked by SignalR |
+| `arguments` | List of arguments passed to the client method |
+| `userId` | Restrict delivery to a single user identifier |
+| `groupName` | Restrict delivery to members of a named group |
+
+## See Also
+
+- [HTTP Authentication](http-auth.md)
+- [Managed Identity](managed-identity.md)
+
+## Sources
+
+- [Azure Functions SignalR Service bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service)
+- [SignalR Service input binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-input)
+- [SignalR Service output binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-output)

--- a/docs/language-guides/java/recipes/table-storage.md
+++ b/docs/language-guides/java/recipes/table-storage.md
@@ -1,0 +1,145 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-output
+---
+# Table Storage Integration
+
+This recipe demonstrates reading and writing Azure Table Storage entities from Java functions using the `@TableOutput` and `@TableInput` annotations.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    HTTP[HTTP Request] --> FA[Function App]
+    FA -->|TableOutput| WRITE[(Table: entity written)]
+    READ[(Table: entity read)] -->|TableInput| FA
+```
+
+## Prerequisites
+
+Provide the connection in app settings. A connection string or an identity-based connection is supported. Identity-based connections use a `__tableServiceUri` suffix:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "TableConnection__tableServiceUri=https://$STORAGE_NAME.table.core.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$STORAGE_NAME` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+For an identity-based connection, grant the managed identity **Storage Table Data Reader** (input) and **Storage Table Data Contributor** (output).
+
+## Entity Model
+
+```java
+public class Person {
+    private String PartitionKey;
+    private String RowKey;
+    private String Name;
+
+    public String getPartitionKey() { return this.PartitionKey; }
+    public void setPartitionKey(String key) { this.PartitionKey = key; }
+    public String getRowKey() { return this.RowKey; }
+    public void setRowKey(String key) { this.RowKey = key; }
+    public String getName() { return this.Name; }
+    public void setName(String name) { this.Name = name; }
+}
+```
+
+## Output Binding: Write an Entity
+
+```java
+public class TableFunctions {
+
+    @FunctionName("addPerson")
+    public HttpResponseMessage addPerson(
+        @HttpTrigger(
+            name = "req",
+            methods = {HttpMethod.POST},
+            authLevel = AuthorizationLevel.FUNCTION,
+            route = "persons/{partitionKey}/{rowKey}"
+        ) HttpRequestMessage<Optional<Person>> request,
+        @BindingName("partitionKey") String partitionKey,
+        @BindingName("rowKey") String rowKey,
+        @TableOutput(
+            name = "person",
+            partitionKey = "{partitionKey}",
+            rowKey = "{rowKey}",
+            tableName = "persons",
+            connection = "TableConnection"
+        ) OutputBinding<Person> person,
+        final ExecutionContext context
+    ) {
+        Person outPerson = new Person();
+        outPerson.setPartitionKey(partitionKey);
+        outPerson.setRowKey(rowKey);
+        outPerson.setName(request.getBody().get().getName());
+
+        person.setValue(outPerson);
+
+        return request.createResponseBuilder(HttpStatus.OK)
+            .header("Content-Type", "application/json")
+            .body(outPerson)
+            .build();
+    }
+}
+```
+
+## Input Binding: Read an Entity
+
+```java
+@FunctionName("getPerson")
+public HttpResponseMessage getPerson(
+    @HttpTrigger(
+        name = "req",
+        methods = {HttpMethod.GET},
+        authLevel = AuthorizationLevel.FUNCTION,
+        route = "persons/{partitionKey}/{rowKey}"
+    ) HttpRequestMessage<Optional<String>> request,
+    @TableInput(
+        name = "person",
+        partitionKey = "{partitionKey}",
+        rowKey = "{rowKey}",
+        tableName = "persons",
+        connection = "TableConnection"
+    ) Person person,
+    final ExecutionContext context
+) {
+    if (person == null) {
+        return request.createResponseBuilder(HttpStatus.NOT_FOUND).build();
+    }
+    return request.createResponseBuilder(HttpStatus.OK)
+        .header("Content-Type", "application/json")
+        .body(person)
+        .build();
+}
+```
+
+## See Also
+
+- [Blob Storage Integration](blob-storage.md)
+- [Queue Storage Integration](queue.md)
+- [Managed Identity](managed-identity.md)
+
+## Sources
+
+- [Azure Table storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table)
+- [Azure Tables output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-output)
+- [Azure Tables input binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-input)

--- a/docs/language-guides/java/recipes/testing.md
+++ b/docs/language-guides/java/recipes/testing.md
@@ -1,0 +1,106 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+---
+# Unit Testing
+
+A Java Azure Functions handler is an ordinary method, so you test it with JUnit 5 by mocking the `HttpRequestMessage` and `ExecutionContext` with Mockito and asserting on the returned `HttpResponseMessage`. No Functions host is required.
+
+## Prerequisites
+
+- A Java Function App using the `com.microsoft.azure.functions` annotation model.
+- JUnit 5 and Mockito on the test classpath (added by the Functions Maven archetype).
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    TEST[JUnit test] --> MOCK[Mock request + context]
+    MOCK --> CALL[Call handler directly]
+    CALL --> ASSERT[Assert status + body]
+```
+
+## Testable Handler
+
+```java
+import com.microsoft.azure.functions.*;
+import com.microsoft.azure.functions.annotation.*;
+import java.util.Optional;
+
+public class GreetFunction {
+    @FunctionName("greet")
+    public HttpResponseMessage greet(
+            @HttpTrigger(name = "req", methods = {HttpMethod.GET},
+                    authLevel = AuthorizationLevel.ANONYMOUS)
+            HttpRequestMessage<Optional<String>> request,
+            final ExecutionContext context) {
+
+        String name = request.getQueryParameters().getOrDefault("name", "world");
+        return request.createResponseBuilder(HttpStatus.OK).body("hello " + name).build();
+    }
+}
+```
+
+## Test the HTTP Trigger
+
+Mock the request so `createResponseBuilder` returns a builder you control, then assert on the result.
+
+```java
+import com.microsoft.azure.functions.*;
+import org.junit.jupiter.api.Test;
+import java.util.*;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GreetFunctionTest {
+    @Test
+    public void greetsWithName() {
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+        doReturn(new HashMap<>(Map.of("name", "ada"))).when(req).getQueryParameters();
+
+        final HttpResponseMessage.Builder builder = mock(HttpResponseMessage.Builder.class);
+        final HttpResponseMessage response = mock(HttpResponseMessage.class);
+        doReturn(builder).when(req).createResponseBuilder(any(HttpStatus.class));
+        doReturn(builder).when(builder).body(any());
+        doReturn(response).when(builder).build();
+        doReturn("hello ada").when(response).getBody();
+
+        ExecutionContext context = mock(ExecutionContext.class);
+        doReturn(java.util.logging.Logger.getGlobal()).when(context).getLogger();
+
+        HttpResponseMessage result = new GreetFunction().greet(req, context);
+
+        assertEquals("hello ada", result.getBody());
+        verify(builder).body("hello ada");
+    }
+}
+```
+
+| Element | Explanation |
+|---|---|
+| `mock(HttpRequestMessage.class)` | Stubs the trigger input without a running host. |
+| `createResponseBuilder(...)` | Must be stubbed to return a mocked builder so `.body().build()` chains work. |
+| `verify(builder).body("hello ada")` | Asserts the handler produced the expected body. |
+
+!!! tip "Integration testing"
+    To exercise routing and bindings end to end, run `mvn azure-functions:run` locally and issue HTTP requests. The unit test above stays host-free for speed.
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [HTTP API Patterns](http-api.md)
+
+## Sources
+
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)

--- a/docs/language-guides/nodejs/recipes/dependency-injection.md
+++ b/docs/language-guides/nodejs/recipes/dependency-injection.md
@@ -1,0 +1,121 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+        - https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections
+---
+# Dependency Injection
+
+The Node.js v4 programming model does not include a dependency injection (DI) container. Functions are registered as handler callbacks through the `app` object, so there is no class constructor to inject into. The idiomatic pattern is to create heavyweight clients once at module scope and reuse them across invocations. A single worker process serves many invocations, so a module-level singleton gives you the same connection-reuse benefit that a singleton DI registration would in other runtimes.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    LOAD[Module require] --> INIT[Create client at module scope]
+    INIT --> POOL[Client holds connection pool]
+    TRIG[Trigger invocation] --> HANDLER[Function handler]
+    HANDLER --> POOL
+    POOL --> REUSE[Connections reused across invocations]
+```
+
+## Why Module-Level Clients
+
+The worker loads your module once and then calls the registered handler repeatedly. Constructing an Azure SDK client inside the handler rebuilds the connection pool and re-authenticates on every request. Create the client at module scope so it is initialized once per worker process.
+
+```javascript
+const { app } = require("@azure/functions");
+const { BlobServiceClient } = require("@azure/storage-blob");
+const { DefaultAzureCredential } = require("@azure/identity");
+
+// Created once when the worker requires this module.
+const blobService = new BlobServiceClient(
+    process.env.STORAGE__blobServiceUri,
+    new DefaultAzureCredential()
+);
+
+app.http("upload", {
+    methods: ["POST"],
+    authLevel: "function",
+    handler: async (request, context) => {
+        const container = blobService.getContainerClient("uploads");
+        await container.uploadBlockBlob(
+            context.invocationId,
+            await request.text(),
+            Buffer.byteLength(await request.text())
+        );
+        return { status: 202 };
+    },
+});
+```
+
+## Lazy Initialization
+
+If a client is expensive and only some functions need it, initialize it lazily and cache the instance in a module variable so it is built at most once.
+
+```javascript
+let cachedClient;
+
+function getClient() {
+    if (!cachedClient) {
+        cachedClient = new BlobServiceClient(
+            process.env.STORAGE__blobServiceUri,
+            new DefaultAzureCredential()
+        );
+    }
+    return cachedClient;
+}
+```
+
+Node.js runs handler code on a single thread per worker, so no locking is required around lazy initialization.
+
+## Passing Dependencies to Business Logic
+
+Keep business logic in plain classes or functions that accept their dependencies as arguments. The handler performs the wiring; the logic stays testable because a unit test can construct the class with a fake client.
+
+```javascript
+class OrderService {
+    constructor(blobService) {
+        this.blobService = blobService;
+    }
+
+    async submit(orderId, payload) {
+        const container = this.blobService.getContainerClient("orders");
+        await container.uploadBlockBlob(orderId, payload, Buffer.byteLength(payload));
+    }
+}
+
+const orders = new OrderService(blobService);
+
+app.http("submitOrder", {
+    methods: ["POST"],
+    route: "orders/{id}",
+    authLevel: "function",
+    handler: async (request, context) => {
+        await orders.submit(request.params.id, await request.text());
+        return { status: 202 };
+    },
+});
+```
+
+!!! tip "Reuse clients, not per-request state"
+    Module-level singletons are shared by every invocation on the worker. Store only stateless clients at module scope; keep per-request data inside the handler.
+
+## See Also
+
+- [Managed Identity](managed-identity.md)
+- [Blob Storage Integration](blob-storage.md)
+
+## Sources
+
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Manage connections in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections)

--- a/docs/language-guides/nodejs/recipes/durable-advanced.md
+++ b/docs/language-guides/nodejs/recipes/durable-advanced.md
@@ -1,0 +1,131 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of sub-orchestration composition, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+---
+# Durable Functions: Advanced Patterns
+
+This recipe covers advanced Durable Functions patterns for Node.js (v4 programming model) beyond the basic chaining and fan-out/fan-in flows: sub-orchestrations, eternal orchestrations, activity retries, and safe versioning. For the fundamentals, see [Durable Orchestration](durable-orchestration.md).
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PARENT[Parent orchestrator] -->|callSubOrchestrator| SUB1[Sub-orchestrator A]
+    PARENT -->|callSubOrchestrator| SUB2[Sub-orchestrator B]
+    SUB1 --> ACT1[Activities]
+    SUB2 --> ACT2[Activities]
+    SUB1 --> PARENT
+    SUB2 --> PARENT
+```
+
+## Sub-Orchestrations
+
+Break a large workflow into reusable orchestrators. A parent calls a sub-orchestrator with `context.df.callSubOrchestrator`, and can fan out over several the same way it fans out over activities.
+
+```javascript
+const df = require("durable-functions");
+
+df.app.orchestration("parentOrchestrator", function* (context) {
+    const regions = context.df.getInput().regions;
+
+    // Fan out over sub-orchestrations, one per region.
+    const tasks = regions.map((region) =>
+        context.df.callSubOrchestrator("processRegion", region)
+    );
+    const results = yield context.df.Task.all(tasks);
+    return { regionsProcessed: results.length, results };
+});
+
+df.app.orchestration("processRegion", function* (context) {
+    const region = context.df.getInput();
+    const validated = yield context.df.callActivity("validateRegion", region);
+    return yield context.df.callActivity("loadRegion", validated);
+});
+```
+
+## Eternal Orchestrations
+
+For a workflow that runs indefinitely (aggregators, periodic jobs), do **not** use an unbounded loop — the history would grow forever. Call `context.df.continueAsNew` to restart the orchestration with fresh state and a clean history.
+
+```javascript
+const df = require("durable-functions");
+const moment = require("moment");
+
+df.app.orchestration("periodicCleanup", function* (context) {
+    const state = context.df.getInput() || { runs: 0 };
+
+    yield context.df.callActivity("runCleanup", state);
+    state.runs += 1;
+
+    // Durable sleep, then restart with new state and empty history.
+    const nextRun = moment.utc(context.df.currentUtcDateTime).add(1, "h");
+    yield context.df.createTimer(nextRun.toDate());
+    context.df.continueAsNew(state);
+});
+```
+
+## Activity Retries
+
+Wrap flaky activities with a retry policy instead of hand-coding retry loops. The orchestration replays cleanly because retries are recorded in history.
+
+```javascript
+const df = require("durable-functions");
+
+df.app.orchestration("resilientOrchestrator", function* (context) {
+    const order = context.df.getInput();
+
+    // firstRetryIntervalInMilliseconds, maxNumberOfAttempts
+    const retryOptions = new df.RetryOptions(5000, 3);
+
+    const result = yield context.df.callActivityWithRetry(
+        "chargeCustomer", retryOptions, order
+    );
+    return result;
+});
+```
+
+| Element | Explanation |
+|---|---|
+| `callSubOrchestrator` | Invokes another orchestrator as a child; compose and fan out like activities. |
+| `continueAsNew` | Restarts the orchestration with new input and a trimmed history for eternal loops. |
+| `RetryOptions` | Declarative retry policy applied via `callActivityWithRetry`. |
+
+## Versioning
+
+Orchestrations replay from history, so changing an orchestrator's code while instances are in flight can break replay (non-determinism). Safe strategies:
+
+- **Deploy side by side**: give the changed orchestrator a new name and route new instances to it, letting existing instances drain on the old version.
+- **Do not reorder or remove** existing activity calls in a deployed orchestrator.
+- **Terminate and restart** in-flight instances if a breaking change is unavoidable.
+
+!!! warning "Determinism still applies"
+    Advanced patterns do not relax the determinism rule. Never call `Date.now()`, generate random values, or do direct I/O inside an orchestrator — use activities and `context.df.currentUtcDateTime`.
+
+## See Also
+
+- [Durable Orchestration](durable-orchestration.md)
+- [Durable Entities](durable-entities.md)
+- [Platform: Durable Functions](../../../platform/durable-functions.md)
+
+## Sources
+
+- [Sub-orchestrations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations)
+- [Eternal orchestrations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations)
+- [Versioning (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning)
+</content>
+</invoke>

--- a/docs/language-guides/nodejs/recipes/durable-entities.md
+++ b/docs/language-guides/nodejs/recipes/durable-entities.md
@@ -1,0 +1,182 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade
+  diagrams:
+    - id: entity-lifecycle
+      type: flowchart
+      source: self-generated
+      justification: Flow view of the durable entity lifecycle, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade
+---
+# Durable Entities
+
+This recipe covers Durable Entities (the stateful entity model) with Azure Functions Node.js v4 using the `durable-functions` package. Entity functions require Durable Functions 2.0 or later.
+
+## Overview
+
+Durable Entities manage small pieces of explicit state — tiny, addressable, single-threaded objects that live in durable storage. Unlike orchestrator functions, which represent state implicitly through control flow, an entity reads and writes its state explicitly through operations.
+
+Entities are ideal for aggregation (counters, running totals), fan-in of high-volume signals without lock contention, and actor-style per-key state.
+
+| Concept | Description |
+|---------|-------------|
+| **Entity function** | Defines the operations that read and update state. Registered with `df.app.entity`. |
+| **Entity ID** | A pair of strings: the **entity name** (e.g. `Counter`) plus the **entity key** (the unique instance). Written as `@Counter@key`. |
+| **Operation** | A named action (for example `add`, `reset`, `get`), with optional input. |
+| **Serialized access** | A single entity processes its operations one at a time, so you never need locks. |
+
+<!-- diagram-id: entity-lifecycle -->
+```mermaid
+flowchart TD
+    CLIENT["Client Function\nsignalEntity() / readEntityState()"] -->|"signal (one-way)"| ENT["Entity Function\nCounter@key\noperations run serially"]
+    ORC["Orchestrator Function\ncallEntity()"] -->|"call (two-way)"| ENT
+    ENT -->|"setState()"| STORE["Durable Store\npersisted entity state"]
+    STORE -->|"readEntityState()"| CLIENT
+```
+
+## Prerequisites
+
+Install the durable package:
+
+```bash
+npm install durable-functions
+```
+
+Use extension bundle v4 in `host.json`:
+
+```json
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}
+```
+
+## Define an Entity Function
+
+The entity handler receives a context with `df` helpers. Read the current state (with a default factory), branch on the operation name, mutate the value, and persist it with `setState`. Use `return` to send a value to a two-way caller.
+
+```javascript
+const { app } = require("@azure/functions");
+const df = require("durable-functions");
+
+df.app.entity("Counter", function (context) {
+  const currentValue = context.df.getState(() => 0);
+
+  switch (context.df.operationName) {
+    case "add":
+      context.df.setState(currentValue + context.df.getInput());
+      break;
+    case "reset":
+      context.df.setState(0);
+      break;
+    case "get":
+      context.df.return(currentValue);
+      break;
+  }
+});
+```
+
+## Signal an Entity from a Client Function
+
+Signaling is one-way (fire-and-forget): the client sends an operation and does not wait for a result.
+
+```javascript
+app.http("addToCounter", {
+  methods: ["POST"],
+  route: "entities/counter/{key}/add",
+  authLevel: "function",
+  extraInputs: [df.input.durableClient()],
+  handler: async (request, context) => {
+    const client = df.getClient(context);
+    const key = request.params.key;
+    const amount = Number(new URL(request.url).searchParams.get("amount") ?? "1");
+
+    const entityId = new df.EntityId("Counter", key);
+    await client.signalEntity(entityId, "add", amount);
+
+    return { status: 202, jsonBody: { entity: `@Counter@${key}`, signaled: "add", amount } };
+  }
+});
+```
+
+## Read Entity State from a Client Function
+
+Reading returns the entity's most recently persisted (committed) state. It may be slightly stale but never reflects a half-completed operation.
+
+```javascript
+app.http("getCounter", {
+  methods: ["GET"],
+  route: "entities/counter/{key}",
+  authLevel: "function",
+  extraInputs: [df.input.durableClient()],
+  handler: async (request, context) => {
+    const client = df.getClient(context);
+    const key = request.params.key;
+    const entityId = new df.EntityId("Counter", key);
+
+    const state = await client.readEntityState(entityId);
+
+    return {
+      status: 200,
+      jsonBody: {
+        entity: `@Counter@${key}`,
+        exists: state.entityExists,
+        value: state.entityExists ? state.entityState : 0
+      }
+    };
+  }
+});
+```
+
+## Call an Entity from an Orchestrator
+
+Orchestrators can call an entity (two-way — wait for a result) to read shared state and make a decision.
+
+```javascript
+df.app.orchestration("reserveSeat", function* (context) {
+  const gameId = context.df.getInput();
+  const entityId = new df.EntityId("Counter", gameId);
+
+  // Two-way call: read the current seat count and wait for the result.
+  const current = yield context.df.callEntity(entityId, "get");
+
+  if (current >= 100) {
+    return { reserved: false, reason: "sold out", seatsTaken: current };
+  }
+
+  // Claim a seat.
+  yield context.df.callEntity(entityId, "add", 1);
+  return { reserved: true, seatNumber: current + 1 };
+});
+```
+
+!!! note "Signaling from an orchestrator"
+    In the Node.js model, orchestrators use `callEntity` (two-way) to communicate with entities. Fire-and-forget signaling is available from client and entity functions.
+
+## Access Rules Summary
+
+| Caller | Signal (one-way) | Call (two-way) | Read state |
+|--------|:---:|:---:|:---:|
+| **Client function** | Yes | No | Yes |
+| **Orchestrator function** | — | Yes | No (call `get` instead) |
+| **Entity function** | Yes | No | — |
+
+## See Also
+
+- [Durable Orchestration](durable-orchestration.md)
+- [Platform: Durable Functions](../../../platform/durable-functions.md)
+- [HTTP API](http-api.md)
+
+## Sources
+
+- [Durable entities (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-entities)
+- [Migrate Durable Functions app to Node.js v4 model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-node-model-upgrade)

--- a/docs/language-guides/nodejs/recipes/event-grid.md
+++ b/docs/language-guides/nodejs/recipes/event-grid.md
@@ -95,6 +95,57 @@ app.eventGrid("processStorageEvent", {
 - Keep event handlers idempotent because Event Grid provides at-least-once delivery.
 - Filter event types at subscription level to reduce unnecessary invocations.
 
+## Event Grid Output: Publish to a Custom Topic
+
+Use the Event Grid output binding to publish events to a custom topic. The binding reads the topic endpoint and access key from app settings — never hard-code the topic URI in the binding properties.
+
+```javascript
+const { app, output } = require("@azure/functions");
+
+const eventGridOutput = output.eventGrid({
+  topicEndpointUri: "MyEventGridTopicUriSetting",
+  topicKeySetting: "MyEventGridTopicKeySetting",
+});
+
+app.timer("publishEvents", {
+  schedule: "0 */5 * * * *",
+  return: eventGridOutput,
+  handler: (myTimer, context) => {
+    return {
+      id: "message-id",
+      subject: "orders/created",
+      dataVersion: "1.0",
+      eventType: "Contoso.Order.Created",
+      data: { orderId: 12345 },
+      eventTime: new Date().toISOString(),
+    };
+  },
+});
+```
+
+To publish multiple events in one invocation, return an array of event objects instead of a single object.
+
+Configure the two app settings the binding references:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "MyEventGridTopicUriSetting=$TOPIC_ENDPOINT" "MyEventGridTopicKeySetting=$TOPIC_KEY"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$TOPIC_ENDPOINT`, `$TOPIC_KEY` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm both settings are present before continuing. |
+
+!!! note "CloudEvents schema"
+    The v4 output binding emits the Event Grid schema shown above. To publish in the **CloudEvents 1.0** schema instead, create the custom topic with `--input-schema cloudeventschemav1.0` and publish with the `EventGridPublisherClient` from `@azure/eventgrid` configured for CloudEvents, rather than the output binding.
+
+For identity-based authentication (extension 3.3.x or higher), set a `connection` prefix instead of `topicKeySetting`, and grant the function app's managed identity the **EventGrid Data Sender** role on the topic.
+
 ## See Also
 - [Node.js Recipes Index](index.md)
 - [Blob Storage Patterns](blob-storage.md)
@@ -102,4 +153,5 @@ app.eventGrid("processStorageEvent", {
 
 ## Sources
 - [Event Grid trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-trigger)
+- [Event Grid output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid-output)
 - [Create Event Grid subscriptions with Azure CLI (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/eventgrid/event-subscription?view=azure-cli-latest)

--- a/docs/language-guides/nodejs/recipes/event-hub.md
+++ b/docs/language-guides/nodejs/recipes/event-hub.md
@@ -1,0 +1,153 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger
+---
+# Event Hubs
+
+This recipe covers integrating Azure Event Hubs with Azure Functions Node.js v4 — consuming a high-throughput event stream with the Event Hubs trigger (single and batch delivery), reading event metadata, and publishing events with the output binding.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PROD[Event Producers] --> EH[(Event Hub Partitions)]
+    EH --> TRIG[Event Hubs Trigger]
+    TRIG --> FA[Function App]
+    FA --> DOWN[Downstream Store]
+    FA --> OUT[Event Hubs Output]
+```
+
+## Prerequisites
+
+Event Hubs bindings ship in the default extension bundle. Ensure your `host.json` references it:
+
+```json
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}
+```
+
+Provide the connection in app settings. A connection-string setting or an identity-based connection is supported. Identity-based connections use a setting prefix with `__fullyQualifiedNamespace`:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "EventHubConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$NAMESPACE` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+When using an identity-based connection, grant the function app's managed identity the **Azure Event Hubs Data Receiver** (and **Data Sender** for output) role on the namespace.
+
+## Event Hubs Trigger
+
+By default the Node.js v4 Event Hubs trigger delivers a batch of events per invocation (`cardinality: "many"`), which maximizes throughput for high-volume streams. Design the handler to be idempotent because delivery is at-least-once.
+
+```javascript
+const { app, output } = require("@azure/functions");
+
+const downstreamOutput = output.eventHub({
+  eventHubName: "downstream",
+  connection: "EventHubConnection"
+});
+
+app.eventHub("processTelemetry", {
+  eventHubName: "telemetry",
+  connection: "EventHubConnection",
+  consumerGroup: "$Default",
+  cardinality: "many",
+  extraOutputs: [downstreamOutput],
+  handler: (events, context) => {
+    // With cardinality "many", events is an array.
+    context.log(`Batch size: ${events.length}`);
+
+    const forwarded = [];
+    for (const event of events) {
+      // Keep processing idempotent.
+      context.log("Processing event", { body: event });
+      forwarded.push({ processedUtc: new Date().toISOString(), source: event });
+    }
+
+    context.extraOutputs.set(downstreamOutput, forwarded);
+  }
+});
+```
+
+## Reading Event Metadata
+
+Enable `triggerMetadata` to access partition context, sequence numbers, and enqueued timestamps:
+
+```javascript
+app.eventHub("processWithMetadata", {
+  eventHubName: "telemetry",
+  connection: "EventHubConnection",
+  cardinality: "many",
+  handler: (events, context) => {
+    const props = context.triggerMetadata.propertiesArray;
+    const systemProps = context.triggerMetadata.systemPropertiesArray;
+
+    events.forEach((event, i) => {
+      context.log("Sequence:", systemProps?.[i]?.sequenceNumber);
+      context.log("Enqueued:", systemProps?.[i]?.enqueuedTimeUtc);
+    });
+  }
+});
+```
+
+## Host Configuration and Checkpointing
+
+Tune batch size and checkpoint frequency in `host.json`:
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "eventHubs": {
+      "maxEventBatchSize": 100,
+      "batchCheckpointFrequency": 1,
+      "prefetchCount": 300
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `maxEventBatchSize` | 100 | Maximum number of events delivered per batch invocation |
+| `batchCheckpointFrequency` | 1 | Number of batches processed before a checkpoint is written |
+| `prefetchCount` | 300 | Number of events the underlying client prefetches |
+
+!!! note "Checkpointing"
+    The Event Hubs extension checkpoints progress to the storage account referenced by `AzureWebJobsStorage`. A higher `batchCheckpointFrequency` reduces storage writes but increases the volume of events reprocessed after a restart.
+
+## See Also
+
+- [Queue](queue.md)
+- [Managed Identity](managed-identity.md)
+
+## Sources
+
+- [Azure Event Hubs bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs)
+- [Azure Event Hubs trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger)
+- [Azure Event Hubs output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-output)

--- a/docs/language-guides/nodejs/recipes/index.md
+++ b/docs/language-guides/nodejs/recipes/index.md
@@ -29,10 +29,11 @@ flowchart TD
 
 | Category | Recipes |
 |---|---|
-| HTTP | [HTTP API](http-api.md), [HTTP Auth](http-auth.md) |
-| Data | [Cosmos DB](cosmosdb.md), [Blob Storage](blob-storage.md), [Queue](queue.md) |
+| HTTP | [HTTP API](http-api.md), [HTTP Auth](http-auth.md), [OpenAPI and Swagger](openapi.md) |
+| Data | [Cosmos DB](cosmosdb.md), [Blob Storage](blob-storage.md), [Queue](queue.md), [Table Storage](table-storage.md) |
 | Security | [Key Vault](key-vault.md), [Managed Identity](managed-identity.md), [Custom Domains and Certificates](custom-domain-certificates.md) |
-| Eventing | [Timer](timer.md), [Durable Orchestration](durable-orchestration.md), [Event Grid](event-grid.md) |
+| Eventing | [Timer](timer.md), [Durable Orchestration](durable-orchestration.md), [Durable Entities](durable-entities.md), [Durable Advanced](durable-advanced.md), [Event Grid](event-grid.md), [Event Hubs](event-hub.md), [Service Bus](service-bus.md), [SignalR Service](signalr.md) |
+| Patterns | [Dependency Injection](dependency-injection.md), [Retry Policies](retry.md), [Middleware](middleware.md), [Unit Testing](testing.md) |
 
 ## See Also
 - [Node.js Language Guide](../index.md)

--- a/docs/language-guides/nodejs/recipes/middleware.md
+++ b/docs/language-guides/nodejs/recipes/middleware.md
@@ -1,0 +1,105 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+---
+# Middleware
+
+The Node.js v4 programming model provides **invocation hooks** that run before and after every function execution. Hooks are the idiomatic way to add cross-cutting behavior — logging, timing, enrichment, or cleanup — without repeating code in each function.
+
+## Prerequisites
+
+- A Node.js v4 Function App using the `@azure/functions` library.
+- Hooks registered once at app startup (for example, in a module imported by your entry point).
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    REQ[Trigger fires] --> PRE[preInvocation hook]
+    PRE --> FUNC[Function handler]
+    FUNC --> POST[postInvocation hook]
+    POST --> RESP[Response returned]
+```
+
+## Invocation Hooks
+
+Register `preInvocation` and `postInvocation` hooks through `app.hook`. Each callback receives a context object exposing the underlying `invocationContext`.
+
+```javascript
+const { app } = require("@azure/functions");
+
+app.hook.preInvocation((context) => {
+    context.invocationContext.log(
+        `Starting ${context.invocationContext.functionName}`
+    );
+    // Stash state for the matching postInvocation hook.
+    context.hookData.startTime = Date.now();
+});
+
+app.hook.postInvocation((context) => {
+    const elapsed = Date.now() - context.hookData.startTime;
+    context.invocationContext.log(
+        `Finished ${context.invocationContext.functionName} in ${elapsed}ms`
+    );
+});
+```
+
+## Inspecting and Modifying Arguments
+
+`preInvocation` exposes the trigger inputs through `context.inputs`; `postInvocation` exposes the return value through `context.result`, which you can overwrite.
+
+```javascript
+app.hook.postInvocation((context) => {
+    // Normalize every HTTP response body shape.
+    if (context.result && typeof context.result === "object") {
+        context.result = {
+            ...context.result,
+            headers: { "x-processed-by": "functions-hook" },
+        };
+    }
+});
+```
+
+## App-Level Hooks
+
+`appStart` and `appTerminate` run once per worker process — ideal for warming shared clients or flushing telemetry.
+
+```javascript
+app.hook.appStart((context) => {
+    context.hookData.startedAt = new Date().toISOString();
+});
+
+app.hook.appTerminate(() => {
+    // Flush buffers, close pooled connections.
+});
+```
+
+| Element | Explanation |
+|---|---|
+| `app.hook.preInvocation(fn)` | Runs before each function execution; can read/modify `context.inputs`. |
+| `app.hook.postInvocation(fn)` | Runs after each execution; can read/modify `context.result`. |
+| `context.invocationContext` | The same context passed to the function (`functionName`, `log`, etc.). |
+| `context.hookData` | Per-invocation scratch space shared between pre and post hooks. |
+| `app.hook.appStart` / `appTerminate` | Run once per worker process lifecycle. |
+
+!!! note "Hooks are not per-function"
+    A registered hook runs for **every** function in the app. Branch inside the hook on `context.invocationContext.functionName` if you need function-specific behavior.
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [HTTP API](http-api.md)
+
+## Sources
+
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)

--- a/docs/language-guides/nodejs/recipes/openapi.md
+++ b/docs/language-guides/nodejs/recipes/openapi.md
@@ -1,0 +1,91 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition
+---
+# OpenAPI and Swagger
+
+Unlike the .NET isolated worker, the Node.js v4 model has no first-class, Microsoft-supported OpenAPI extension that generates a spec from your handler registrations. The idiomatic approaches are: (1) let Azure API Management generate the OpenAPI definition when you import your HTTP endpoints, and (2) hand-author an `openapi.json` document and serve it — plus optionally a Swagger UI — from an HTTP function.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    FUNC[HTTP trigger functions] --> APIM[API Management import]
+    APIM --> GEN[Generated OpenAPI definition]
+    SPEC[Hand-authored openapi.json] --> SERVE[HTTP function serves /openapi.json]
+    SERVE --> UI[Swagger UI page]
+```
+
+## Option 1: Generate via API Management
+
+Azure API Management can import your HTTP-triggered function endpoints and produce an OpenAPI definition. This works for function apps in any supported language, including Node.js. In the portal, open your function app, select **API Management**, create or link an instance, then **Link API** to import the endpoints and **Download OpenAPI definition**.
+
+This is the lowest-effort path when you already front your functions with API Management.
+
+## Option 2: Serve a Hand-Authored Spec
+
+Keep an `openapi.json` file in your project and serve it from an HTTP function. This gives you a versioned, source-controlled contract without a code-generation dependency.
+
+```javascript
+const { app } = require("@azure/functions");
+const openApiSpec = require("../openapi.json");
+
+app.http("openapi", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    route: "openapi.json",
+    handler: async () => ({
+        jsonBody: openApiSpec,
+    }),
+});
+```
+
+## Serve Swagger UI
+
+Serve a minimal HTML page from another HTTP function that loads Swagger UI from a CDN and points it at the spec endpoint.
+
+```javascript
+const swaggerHtml = `<!DOCTYPE html>
+<html>
+  <head><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css"></head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script>
+      window.onload = () => SwaggerUIBundle({ url: "/api/openapi.json", dom_id: "#swagger-ui" });
+    </script>
+  </body>
+</html>`;
+
+app.http("docs", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    route: "docs",
+    handler: async () => ({
+        body: swaggerHtml,
+        headers: { "Content-Type": "text/html" },
+    }),
+});
+```
+
+!!! note "Keep the spec in sync"
+    Because the spec is hand-authored, it can drift from your actual routes. Add a contract test that loads `openapi.json` and asserts every documented path has a matching registered handler.
+
+## See Also
+
+- [HTTP API Patterns](http-api.md)
+- [HTTP Authentication](http-auth.md)
+
+## Sources
+
+- [Expose serverless APIs from HTTP endpoints using Azure API Management (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition)

--- a/docs/language-guides/nodejs/recipes/retry.md
+++ b/docs/language-guides/nodejs/recipes/retry.md
@@ -1,0 +1,110 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+---
+# Retry Policies
+
+Azure Functions runtime-enforced retry policies rerun a failed execution until it succeeds or the maximum retry count is reached. In the Node.js v4 model you set the policy in the trigger's `retry` option. Retry policies are only supported for a specific set of trigger types; other triggers rely on their own built-in retry behavior.
+
+## Supported Triggers
+
+Runtime retry policies apply only to these triggers:
+
+| Trigger | Retry source |
+|---|---|
+| Timer | Retry policies |
+| Event Hubs | Retry policies |
+| Azure Cosmos DB | Retry policies |
+| Kafka | Retry policies |
+
+Queue Storage, Blob Storage, and Service Bus triggers do **not** use retry policies — they retry through their own binding extensions (poison-queue handling, `maxDeliveryCount`, dead-lettering). HTTP triggers have no automatic retry; the caller must retry.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    EXEC[Function execution] --> ERR{Handler throws?}
+    ERR -->|No| DONE[Success: checkpoint/commit]
+    ERR -->|Yes| COUNT{retryCount < max?}
+    COUNT -->|Yes| WAIT[Wait per strategy] --> EXEC
+    COUNT -->|No| FAIL[Give up: execution fails]
+```
+
+## Fixed Delay
+
+A fixed amount of time elapses between each retry.
+
+```javascript
+const { app } = require("@azure/functions");
+
+app.timer("scheduledJob", {
+    schedule: "0 */5 * * * *",
+    retry: {
+        strategy: "fixedDelay",
+        delayInterval: { seconds: 10 },
+        maxRetryCount: 4,
+    },
+    handler: (myTimer, context) => {
+        if (context.retryContext?.retryCount < 2) {
+            throw new Error("Retry!");
+        }
+        context.log("Timer function processed request.");
+    },
+});
+```
+
+## Exponential Backoff
+
+The first retry waits the minimum interval; each subsequent retry adds time exponentially (with small randomization) up to the maximum interval.
+
+```javascript
+app.timer("scheduledJob", {
+    schedule: "0 */5 * * * *",
+    retry: {
+        strategy: "exponentialBackoff",
+        minimumInterval: { seconds: 10 },
+        maximumInterval: { minutes: 15 },
+        maxRetryCount: 5,
+    },
+    handler: (myTimer, context) => {
+        throw new Error("Retry!");
+    },
+});
+```
+
+## Policy Properties
+
+| Property | Description |
+|---|---|
+| `strategy` | Required. `fixedDelay` or `exponentialBackoff`. |
+| `maxRetryCount` | Required. Max retries per execution. `-1` retries indefinitely. |
+| `delayInterval` | Fixed-delay interval (duration object, e.g. `{ seconds: 10 }`). |
+| `minimumInterval` | Exponential-backoff minimum delay. |
+| `maximumInterval` | Exponential-backoff maximum delay. |
+
+Read the current attempt from `context.retryContext.retryCount` to decide whether to keep throwing or handle the failure gracefully on the final attempt.
+
+!!! warning "Max retry count is best-effort"
+    The retry count is stored in instance memory. If the instance fails between retries, the count is lost — Event Hubs resumes on a new instance with the count reset, while Timer does not resume. Design your functions to be idempotent.
+
+!!! note "Event Hubs checkpoint behavior"
+    Event Hubs checkpoints are not written until the retry policy finishes, so progress on that partition is paused until the current batch completes.
+
+## See Also
+
+- [Event Hubs](event-hub.md)
+- [Timer](timer.md)
+
+## Sources
+
+- [Azure Functions error handling and retry guidance (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages)

--- a/docs/language-guides/nodejs/recipes/service-bus.md
+++ b/docs/language-guides/nodejs/recipes/service-bus.md
@@ -1,0 +1,137 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
+---
+# Service Bus
+
+This recipe covers integrating Azure Service Bus with Azure Functions Node.js v4 — consuming queue and topic/subscription messages, handling dead-lettering, and publishing messages with the output binding.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PROD[Producers] --> SBQ[(Service Bus Queue/Topic)]
+    SBQ --> TRIG[Service Bus Trigger]
+    TRIG --> FA[Function App]
+    FA --> DLQ[(Dead-Letter Queue)]
+    FA --> OUT[Service Bus Output]
+```
+
+## Prerequisites
+
+Provide the connection in app settings. A connection-string setting or an identity-based connection is supported. Identity-based connections use a setting prefix with `__fullyQualifiedNamespace`:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "ServiceBusConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$NAMESPACE` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+When using an identity-based connection, grant the function app's managed identity the **Azure Service Bus Data Receiver** (and **Data Sender** for output) role on the namespace.
+
+## Queue Trigger
+
+Message settlement is automatic: completing the handler settles the message, and throwing abandons it. After `maxDeliveryCount` the message is dead-lettered.
+
+```javascript
+const { app, output } = require("@azure/functions");
+
+const ordersOutput = output.serviceBusQueue({
+  queueName: "orders",
+  connection: "ServiceBusConnection"
+});
+
+app.serviceBusQueue("processOrder", {
+  queueName: "orders",
+  connection: "ServiceBusConnection",
+  handler: (message, context) => {
+    context.log("Message ID:", context.triggerMetadata.messageId);
+    context.log("Delivery count:", context.triggerMetadata.deliveryCount);
+    context.log("Payload:", message);
+    // Throwing here abandons the message; after maxDeliveryCount it is
+    // moved to the dead-letter subqueue automatically.
+  }
+});
+```
+
+## Topic/Subscription Trigger
+
+```javascript
+app.serviceBusTopic("processEvent", {
+  topicName: "events",
+  subscriptionName: "billing",
+  connection: "ServiceBusConnection",
+  handler: (message, context) => {
+    context.log("Subscription message:", message);
+  }
+});
+```
+
+## Output Binding: Publish Messages
+
+```javascript
+app.http("enqueue", {
+  methods: ["POST"],
+  authLevel: "function",
+  extraOutputs: [ordersOutput],
+  handler: async (request, context) => {
+    const body = await request.json();
+    context.extraOutputs.set(ordersOutput, body);
+    return { status: 202, jsonBody: { status: "enqueued" } };
+  }
+});
+```
+
+## Host Configuration
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "serviceBus": {
+      "maxConcurrentCalls": 16,
+      "prefetchCount": 0,
+      "maxAutoLockRenewalDuration": "00:05:00"
+    }
+  }
+}
+```
+
+| Setting | Description |
+|---------|-------------|
+| `maxConcurrentCalls` | Maximum concurrent message handlers per instance |
+| `prefetchCount` | Number of messages the client prefetches to reduce latency |
+| `maxAutoLockRenewalDuration` | How long the runtime keeps renewing the message lock during processing |
+
+!!! note "Sessions and ordering"
+    Enable `isSessionsEnabled: true` on the trigger to process session-enabled queues/subscriptions, which guarantees ordered, single-consumer processing per session ID.
+
+## See Also
+
+- [Queue](queue.md)
+- [Event Hubs](event-hub.md)
+
+## Sources
+
+- [Azure Service Bus bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus)
+- [Azure Service Bus trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger)
+- [Azure Service Bus output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-output)

--- a/docs/language-guides/nodejs/recipes/signalr.md
+++ b/docs/language-guides/nodejs/recipes/signalr.md
@@ -1,0 +1,151 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-input
+---
+# SignalR Service
+
+This recipe covers adding real-time messaging to Azure Functions Node.js v4 with Azure SignalR Service in serverless mode. It uses the `SignalRConnectionInfo` input binding to implement the required `negotiate` endpoint and the SignalR output binding to broadcast messages. In the v4 model, SignalR bindings are declared with `input.generic` and `output.generic`.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    CLIENT[Browser Client] --> NEG[negotiate Function]
+    NEG --> INFO[SignalRConnectionInfo Input]
+    INFO --> SR[(Azure SignalR Service)]
+    CLIENT -->|WebSocket| SR
+    PUB[broadcast Function] --> OUT[SignalR Output]
+    OUT --> SR
+    SR -->|push| CLIENT
+```
+
+## Prerequisites
+
+SignalR Service bindings are included in the default extension bundle. Ensure your `host.json` references it:
+
+```json
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}
+```
+
+Configure the connection in app settings. A connection string (stored as `AzureSignalRConnectionString`) or an identity-based connection is supported:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "AzureSignalRConnectionString__serviceUri=https://$SIGNALR_NAME.service.signalr.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$SIGNALR_NAME` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+The SignalR Service instance must be in **Serverless** mode. When using an identity-based connection, grant the function app's managed identity the **SignalR Service Owner** role on the resource.
+
+## The negotiate Endpoint
+
+Before a client connects, it calls a `negotiate` endpoint to obtain the service URL and a short-lived access token. The `SignalRConnectionInfo` input binding produces this payload. Do not cache or share the token between clients.
+
+```javascript
+const { app, input } = require("@azure/functions");
+
+const inputSignalR = input.generic({
+  type: "signalRConnectionInfo",
+  name: "connectionInfo",
+  hubName: "serverless",
+  connectionStringSetting: "AzureSignalRConnectionString",
+});
+
+app.post("negotiate", {
+  authLevel: "function",
+  route: "negotiate",
+  extraInputs: [inputSignalR],
+  handler: (request, context) => {
+    return { body: JSON.stringify(context.extraInputs.get(inputSignalR)) };
+  },
+});
+```
+
+!!! warning "Secure the negotiate endpoint"
+    In production, protect the endpoint with App Service Authentication and add `userId: "{headers.x-ms-client-principal-id}"` to the input binding so each token carries a user identity.
+
+## Output Binding: Broadcast a Message
+
+The SignalR output binding sends a message to all connected clients. The message object specifies a `target` (the client-side handler name) and `arguments`.
+
+```javascript
+const { app, output } = require("@azure/functions");
+
+const signalR = output.generic({
+  type: "signalR",
+  name: "signalRMessages",
+  hubName: "serverless",
+  connectionStringSetting: "AzureSignalRConnectionString",
+});
+
+app.http("broadcast", {
+  methods: ["POST"],
+  authLevel: "function",
+  extraOutputs: [signalR],
+  handler: async (request, context) => {
+    const message = await request.text();
+
+    context.extraOutputs.set(signalR, {
+      target: "newMessage",
+      arguments: [message],
+    });
+
+    return { status: 202 };
+  },
+});
+```
+
+## Sending to a Specific User or Group
+
+Add `userId` or `groupName` to the message object to target a subset of clients instead of broadcasting:
+
+```javascript
+context.extraOutputs.set(signalR, {
+  userId: "user1",
+  target: "newMessage",
+  arguments: [message],
+});
+```
+
+| Field | Purpose |
+|-------|---------|
+| `target` | Name of the client-side method invoked by SignalR |
+| `arguments` | Array of arguments passed to the client method |
+| `userId` | Restrict delivery to a single user identifier |
+| `groupName` | Restrict delivery to members of a named group |
+
+## See Also
+
+- [HTTP Authentication](http-auth.md)
+- [Managed Identity](managed-identity.md)
+
+## Sources
+
+- [Azure Functions SignalR Service bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service)
+- [SignalR Service input binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-input)
+- [SignalR Service output binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-output)

--- a/docs/language-guides/nodejs/recipes/table-storage.md
+++ b/docs/language-guides/nodejs/recipes/table-storage.md
@@ -1,0 +1,121 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-output
+---
+# Table Storage
+
+This recipe covers reading and writing entities in Azure Table Storage from Azure Functions Node.js v4 using the table input and output bindings.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    HTTP[HTTP Request] --> FA[Function App]
+    FA -->|output.table| WRITE[(Table: entity written)]
+    READ[(Table: entity read)] -->|input.table| FA
+```
+
+## Prerequisites
+
+Provide the connection in app settings. A connection string or an identity-based connection is supported. Identity-based connections use a `__tableServiceUri` suffix:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "TableConnection__tableServiceUri=https://$STORAGE_NAME.table.core.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$STORAGE_NAME` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+For an identity-based connection, grant the managed identity **Storage Table Data Reader** (input) and **Storage Table Data Contributor** (output).
+
+!!! note "Output binding creates new entities only"
+    The table output binding only creates new entities. To update or delete an entity, use the `@azure/data-tables` SDK directly with a `TableClient`.
+
+## Output Binding: Write Entities
+
+Every entity requires a `PartitionKey` and a `RowKey`.
+
+```javascript
+const { app, output } = require("@azure/functions");
+
+const tableOutput = output.table({
+  tableName: "messages",
+  connection: "TableConnection"
+});
+
+app.http("createMessages", {
+  methods: ["POST"],
+  authLevel: "function",
+  extraOutputs: [tableOutput],
+  handler: async (request, context) => {
+    const body = await request.json();
+    const rows = (body.items ?? []).map((item, i) => ({
+      PartitionKey: "message",
+      RowKey: `${Date.now()}-${i}`,
+      Text: item.text ?? ""
+    }));
+
+    context.extraOutputs.set(tableOutput, rows);
+    return { status: 201, jsonBody: { written: rows.length } };
+  }
+});
+```
+
+## Input Binding: Read an Entity
+
+Bind by partition key and row key to read a single entity.
+
+```javascript
+const { app, input } = require("@azure/functions");
+
+const tableInput = input.table({
+  tableName: "messages",
+  connection: "TableConnection",
+  partitionKey: "message",
+  rowKey: "{rowKey}"
+});
+
+app.http("getMessage", {
+  methods: ["GET"],
+  route: "messages/{rowKey}",
+  authLevel: "function",
+  extraInputs: [tableInput],
+  handler: (request, context) => {
+    const entity = context.extraInputs.get(tableInput);
+    if (!entity) {
+      return { status: 404, jsonBody: { error: "Not found" } };
+    }
+    return { status: 200, jsonBody: entity };
+  }
+});
+```
+
+## See Also
+
+- [Blob Storage](blob-storage.md)
+- [Queue](queue.md)
+- [Managed Identity](managed-identity.md)
+
+## Sources
+
+- [Azure Table storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table)
+- [Azure Tables output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-output)
+- [Azure Tables input binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-input)

--- a/docs/language-guides/nodejs/recipes/testing.md
+++ b/docs/language-guides/nodejs/recipes/testing.md
@@ -1,0 +1,107 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+---
+# Unit Testing
+
+In the Node.js v4 model a function handler is a plain async function that receives an `HttpRequest` and an `InvocationContext`. You test it by calling the handler directly with a constructed request and a stub context — no Functions host required. This page uses Jest; the same approach works with the built-in `node:test` runner.
+
+## Prerequisites
+
+- A Node.js v4 Function App using `@azure/functions`.
+- A test runner installed (`npm install --save-dev jest`).
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    TEST[Jest test] --> BUILD[Build HttpRequest + stub context]
+    BUILD --> CALL[Call handler directly]
+    CALL --> ASSERT[Assert status + body]
+```
+
+## Testable Handler
+
+Export the handler so tests can import it, and register it separately with `app.http`.
+
+```javascript
+const { app } = require("@azure/functions");
+
+async function greet(request, context) {
+    const name = request.query.get("name") || "world";
+    return { status: 200, body: `hello ${name}` };
+}
+
+app.http("greet", { methods: ["GET"], handler: greet });
+
+module.exports = { greet };
+```
+
+## Test the HTTP Trigger
+
+Construct an `HttpRequest` and a minimal context stub, then assert on the returned response object.
+
+```javascript
+const { HttpRequest } = require("@azure/functions");
+const { greet } = require("../src/functions/greet");
+
+function stubContext() {
+    return { log: () => {}, invocationId: "test" };
+}
+
+test("greets with name", async () => {
+    const request = new HttpRequest({
+        method: "GET",
+        url: "http://localhost/api/greet?name=ada",
+    });
+
+    const response = await greet(request, stubContext());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("hello ada");
+});
+
+test("greets default", async () => {
+    const request = new HttpRequest({ method: "GET", url: "http://localhost/api/greet" });
+    const response = await greet(request, stubContext());
+    expect(response.body).toBe("hello world");
+});
+```
+
+## Mocking Dependencies
+
+Replace shared clients (see [Dependency Injection](dependency-injection.md)) with `jest.mock` or by injecting a fake into a factory.
+
+```javascript
+jest.mock("../src/tableClient", () => ({
+    createEntity: jest.fn().mockResolvedValue(undefined),
+}));
+```
+
+| Element | Explanation |
+|---|---|
+| `new HttpRequest({...})` | Builds the trigger input without a running host. |
+| Context stub | A minimal object providing `log` and any fields the handler reads. |
+| `jest.mock` | Replaces module-level clients with test doubles. |
+
+!!! tip "Integration testing"
+    To exercise routing, `host.json`, and bindings end to end, run `func start` and issue real HTTP requests. The unit tests above stay host-free for speed.
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [HTTP API Patterns](http-api.md)
+
+## Sources
+
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)

--- a/docs/language-guides/powershell/cli-cheatsheet.md
+++ b/docs/language-guides/powershell/cli-cheatsheet.md
@@ -1,0 +1,170 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/cli/azure/functionapp
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# CLI Cheatsheet
+
+Quick reference for the most commonly used commands when developing, deploying, and managing Azure Functions PowerShell apps.
+
+## Azure Functions Core Tools (`func`)
+
+The `func` CLI is used for local development, testing, and deploying function apps.
+
+### Local Development
+
+```bash
+# Initialize a new PowerShell function app project
+func init MyFunctionApp --powershell
+
+# Create a new function (interactive)
+func new
+
+# Create an HTTP-triggered function (non-interactive)
+func new --name HttpExample --template "HTTP trigger" --authlevel anonymous
+
+# Start the local Functions host
+func host start
+
+# Start on a custom port with verbose logging
+func host start --port 7072 --verbose
+```
+
+### Deployment
+
+```bash
+# Deploy to Azure
+func azure functionapp publish $APP_NAME
+
+# Deploy to a staging slot
+func azure functionapp publish $APP_NAME --slot staging
+
+# Fetch app settings from Azure to local
+func azure functionapp fetch-app-settings $APP_NAME
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `func init`, `func new`, `func host start`, `func azure functionapp publish` |
+| Key flags | `--powershell`, `--name`, `--template`, `--authlevel`, `--port`, `--verbose`, `--slot` |
+| Variables | `$APP_NAME` |
+| Expected result | Core Tools scaffolds, runs, or publishes the app; verify the local host prints the function URLs or the publish output lists uploaded functions. |
+
+## Azure CLI: Function App (`az functionapp`)
+
+### Create a PowerShell Function App
+
+```bash
+# Flex Consumption (recommended, Linux, PowerShell 7.4)
+az functionapp create \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --storage-account $STORAGE_NAME \
+  --flexconsumption-location $LOCATION \
+  --runtime powershell \
+  --runtime-version 7.4 \
+  --functions-version 4
+
+# Consumption (legacy)
+az functionapp create \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --storage-account $STORAGE_NAME \
+  --consumption-plan-location $LOCATION \
+  --runtime powershell \
+  --runtime-version 7.4 \
+  --functions-version 4 \
+  --os-type Windows
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp create` |
+| Key flags | `--runtime powershell`, `--runtime-version`, `--functions-version`, `--flexconsumption-location`, `--consumption-plan-location`, `--os-type` |
+| Variables | `$APP_NAME`, `$RG`, `$STORAGE_NAME`, `$LOCATION` |
+| Expected result | Azure CLI returns provisioning details; confirm the app name and successful provisioning state before continuing. |
+
+### App Settings
+
+```bash
+# Set app settings
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "FUNCTIONS_WORKER_RUNTIME=powershell" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
+
+# List all app settings
+az functionapp config appsettings list \
+  --name $APP_NAME \
+  --resource-group $RG
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set`, `az functionapp config appsettings list` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG` |
+| Expected result | Azure CLI applies the configuration change; confirm the returned JSON shows the expected value. |
+
+### Logs
+
+```bash
+# Stream live logs
+az functionapp log tail \
+  --name $APP_NAME \
+  --resource-group $RG
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp log tail` |
+| Key flags | `--name`, `--resource-group` |
+| Variables | `$APP_NAME`, `$RG` |
+| Expected result | Azure CLI streams log output; verify function invocations appear as you exercise triggers. |
+
+## PowerShell Module Management
+
+```powershell
+# Save a module into the app's Modules folder for bundled deployment
+Save-Module -Name Az.Accounts -Path ./Modules
+
+# Modern equivalent using the PSResourceGet cmdlet
+Save-PSResource -Name Az.Accounts -Path ./Modules
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `Save-Module`, `Save-PSResource` |
+| Key flags | `-Name`, `-Path` |
+| Variables | None |
+| Expected result | The module and its dependencies are written to `./Modules`; verify the folder contains the module version directories before publishing. |
+
+## Quick Reference Table
+
+| Task | Command |
+|------|---------|
+| Init project | `func init MyFunctionApp --powershell` |
+| Start locally | `func host start` |
+| Deploy to Azure | `func azure functionapp publish $APP_NAME` |
+| Create Flex app | `az functionapp create --runtime powershell --runtime-version 7.4 ...` |
+| Set app setting | `az functionapp config appsettings set --name $APP_NAME --resource-group $RG --settings "KEY=value"` |
+| Stream logs | `az functionapp log tail --name $APP_NAME --resource-group $RG` |
+| Bundle module | `Save-Module -Name Az.Accounts -Path ./Modules` |
+
+## See Also
+
+- [PowerShell Language Guide](index.md)
+- [PowerShell Programming Model](powershell-programming-model.md)
+- [host.json Reference](host-json.md)
+- [Deployments](../../operations/deployment.md)
+
+## Sources
+
+- [Azure Functions Core Tools reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [az functionapp CLI reference (Microsoft Learn)](https://learn.microsoft.com/en-us/cli/azure/functionapp)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/environment-variables.md
+++ b/docs/language-guides/powershell/environment-variables.md
@@ -1,0 +1,73 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Environment Variables
+
+Application settings are exposed to PowerShell functions as environment variables. Read them with `$env:SETTING_NAME`.
+
+## Reading Settings in PowerShell
+
+```powershell
+# Access an app setting
+$connectionString = $env:MyStorageConnection
+
+# Provide a default when unset
+$batchSize = if ($env:BatchSize) { [int]$env:BatchSize } else { 100 }
+```
+
+Set values locally in `local.settings.json` under `Values`, and in Azure via `az functionapp config appsettings set`.
+
+## Runtime Settings
+
+| Setting | Purpose |
+|---|---|
+| `FUNCTIONS_WORKER_RUNTIME` | Must be `powershell`. |
+| `FUNCTIONS_WORKER_RUNTIME_VERSION` | PowerShell major.minor version (`7.4` or `7.6`). Pin explicitly. |
+| `FUNCTIONS_EXTENSION_VERSION` | Functions host version (`~4`). |
+| `AzureWebJobsStorage` | Storage account connection used by the runtime. |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Application Insights connection string for telemetry. |
+
+## Concurrency Settings
+
+| Setting | Purpose |
+|---|---|
+| `FUNCTIONS_WORKER_PROCESS_COUNT` | Number of language worker processes per instance. |
+| `PSWorkerInProcConcurrencyUpperBound` | Number of runspaces per worker process. Defaults to 1,000 on the 4.x runtime. |
+
+!!! warning "Concurrency and Azure PowerShell"
+    Azure PowerShell holds process-level context. Enabling in-process concurrency with state-changing operations can cause race conditions. Set `PSWorkerInProcConcurrencyUpperBound` to `1` if you observe cross-invocation interference.
+
+## Identity and Secrets
+
+| Setting | Purpose |
+|---|---|
+| `MSI_SECRET` / `IDENTITY_HEADER` | Present when a managed identity is assigned; used by `Connect-AzAccount -Identity`. |
+| `WEBSITE_LOAD_USER_PROFILE` | Loads the user profile on Windows plans (needed by some certificate operations). |
+
+```powershell
+# profile.ps1 — authenticate once per worker using managed identity
+if ($env:MSI_SECRET) {
+    Disable-AzContextAutosave -Scope Process | Out-Null
+    Connect-AzAccount -Identity
+}
+```
+
+!!! tip "Never hard-code secrets"
+    Store secrets in Azure Key Vault and reference them with Key Vault references in app settings, or retrieve them at runtime using a managed identity. See [Managed Identity recipe](recipes/managed-identity.md).
+
+## See Also
+
+- [PowerShell Language Guide](index.md)
+- [PowerShell Runtime](powershell-runtime.md)
+- [host.json Reference](host-json.md)
+- [Managed Identity recipe](recipes/managed-identity.md)
+
+## Sources
+
+- [App settings reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-app-settings)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/host-json.md
+++ b/docs/language-guides/powershell/host-json.md
@@ -1,0 +1,120 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# host.json Reference
+
+`host.json` configures runtime behavior for all functions in a PowerShell function app. This page highlights the settings most relevant to PowerShell workers.
+
+## Minimal PowerShell host.json
+
+```json
+{
+  "version": "2.0",
+  "managedDependency": {
+    "enabled": true
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}
+```
+
+## PowerShell-Specific Settings
+
+### managedDependency
+
+Controls whether modules listed in `requirements.psd1` are automatically downloaded from the PowerShell Gallery.
+
+```json
+{
+  "managedDependency": {
+    "enabled": true
+  }
+}
+```
+
+!!! warning "Not supported on Flex Consumption"
+    Managed dependencies are unavailable on the Flex Consumption plan. Set `enabled` to `false` and bundle modules in a `Modules` folder instead. See [PowerShell Runtime](powershell-runtime.md#dependency-management).
+
+### Concurrency
+
+PowerShell throughput is controlled by app settings rather than `host.json`, but the host-level `functionTimeout` and HTTP concurrency settings still apply:
+
+| Setting | Location | Effect |
+|---|---|---|
+| `functionTimeout` | `host.json` | Maximum execution duration per invocation. |
+| `PSWorkerInProcConcurrencyUpperBound` | App setting | Number of runspaces per worker process. |
+| `FUNCTIONS_WORKER_PROCESS_COUNT` | App setting | Number of worker processes per instance. |
+
+See [Environment Variables](environment-variables.md) for the app settings.
+
+## Common Sections
+
+### functionTimeout
+
+```json
+{
+  "functionTimeout": "00:10:00"
+}
+```
+
+Default and maximum values depend on the hosting plan. See [Platform Limits](platform-limits.md).
+
+### extensionBundle
+
+Extension bundles supply trigger and binding extensions without manual package installation. PowerShell apps use the classic `function.json` binding model and rely on the bundle for all non-HTTP bindings.
+
+```json
+{
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}
+```
+
+### logging
+
+```json
+{
+  "logging": {
+    "logLevel": {
+      "default": "Information",
+      "Host.Aggregator": "Warning"
+    },
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "maxTelemetryItemsPerSecond": 20,
+        "excludedTypes": "Request"
+      }
+    }
+  }
+}
+```
+
+## See Also
+
+- [PowerShell Language Guide](index.md)
+- [PowerShell Runtime](powershell-runtime.md)
+- [Environment Variables](environment-variables.md)
+- [Platform Limits](platform-limits.md)
+
+## Sources
+
+- [host.json reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/index.md
+++ b/docs/language-guides/powershell/index.md
@@ -1,0 +1,125 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+  diagrams:
+    - id: powershell-language-guide
+      type: flowchart
+      source: self-generated
+      justification: Flow view of powershell language guide, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+        - https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+---
+# PowerShell Language Guide
+
+This guide maps Azure Functions platform concepts to the PowerShell programming model. PowerShell functions are a natural fit for automation, Azure resource operations, and glue code that already relies on Azure PowerShell (`Az`) modules.
+
+<!-- diagram-id: powershell-language-guide -->
+```mermaid
+flowchart TD
+    A[Tutorial Overview]
+    A --> B[Consumption Track]
+    A --> C[Flex Consumption Track]
+    A --> D[Premium Track]
+    A --> E[Dedicated Track]
+    A --> F[Recipes]
+    A --> G[Runtime and Reference]
+```
+
+!!! tip "Architecture first"
+    Before diving into PowerShell-specific details, review [Platform](../../platform/index.md) for language-agnostic guidance on hosting, scaling, networking, reliability, and security.
+
+## When PowerShell Is a Good Fit
+
+- **Azure automation** — orchestrating resource operations with the `Az` module, scheduled with a timer trigger.
+- **Operational glue** — reacting to queue, Event Grid, or HTTP events with concise scripts.
+- **Teams already invested in PowerShell** — reusing existing modules and skills.
+
+For high-throughput, low-latency APIs or heavy compute, prefer a compiled or richer runtime (.NET, Java) — see [Language Guides Overview](../index.md).
+
+## Programming Model
+
+PowerShell functions use the **classic scripting model**: each function is a folder containing a `run.ps1` script and a `function.json` binding definition. This differs from the decorator/code-first models in Python (v2) and Node.js (v4).
+
+```text
+PSFunctionApp
+ | - MyHttpFunction
+ | | - run.ps1
+ | | - function.json
+ | - host.json
+ | - requirements.psd1
+ | - profile.ps1
+```
+
+See [PowerShell Programming Model](powershell-programming-model.md) for `param` blocks, `Push-OutputBinding`, and binding patterns.
+
+## Start Here
+
+1. Choose your hosting plan in [Tutorial Overview & Plan Chooser](tutorial/index.md).
+2. Follow one full tutorial track from local run through CI/CD.
+3. Use recipes to add integrations (HTTP, Timer, Queue, Blob, Key Vault, and more).
+4. Keep runtime/reference docs open during production hardening.
+
+## What's Covered
+
+| Area | Document | Scope |
+|------|----------|-------|
+| Tutorial | [Overview & Plan Chooser](tutorial/index.md) | Select Consumption, Flex Consumption, Premium, or Dedicated |
+| Tutorial track | [Consumption (Y1)](tutorial/consumption/01-local-run.md) | 7-step flow for classic serverless |
+| Tutorial track | [Flex Consumption (FC1)](tutorial/flex-consumption/01-local-run.md) | 7-step flow for modern default serverless |
+| Tutorial track | [Premium (EP)](tutorial/premium/01-local-run.md) | 7-step flow for always-warm/VNet scenarios |
+| Tutorial track | [Dedicated (App Service)](tutorial/dedicated/01-local-run.md) | 7-step flow for fixed-capacity hosting |
+| Recipes | [Recipes Index](recipes/index.md) | Practical implementation recipes |
+| Runtime model | [PowerShell Programming Model](powershell-programming-model.md) | `run.ps1`, `function.json`, binding patterns |
+| Runtime internals | [PowerShell Runtime](powershell-runtime.md) | Worker behavior, versions, dependency management |
+| CLI | [CLI Cheatsheet](cli-cheatsheet.md) | `az` and `func` operational commands |
+| Host settings | [host.json Reference](host-json.md) | Concurrency, retry, logging, and managed dependency settings |
+| Configuration | [Environment Variables](environment-variables.md) | Key app and platform environment settings |
+| Limits | [Platform Limits](platform-limits.md) | Timeouts, payloads, scaling, and service constraints |
+| Diagnostics | [Troubleshooting](troubleshooting.md) | Common failures and troubleshooting flow |
+
+## Supported Versions
+
+| Functions runtime | PowerShell version | .NET version | Notes |
+|---|---|---|---|
+| 4.x | PowerShell 7.4 | .NET 8 | Generally available; supported on all plans |
+| 4.x | PowerShell 7.6 (preview) | .NET 10 | Windows-only (Premium, Dedicated, Consumption) |
+
+Flex Consumption supports PowerShell 7.4 on Linux. See [PowerShell Runtime](powershell-runtime.md) for version selection details.
+
+## PowerShell-Specific Considerations
+
+- **Managed dependencies** (`requirements.psd1` auto-download) are **not supported on Flex Consumption** — bundle modules in a `Modules` folder instead.
+- **Concurrency** is single-threaded by default; tune with `PSWorkerInProcConcurrencyUpperBound` or `FUNCTIONS_WORKER_PROCESS_COUNT`.
+- **Cold start** — avoid `Install-Module` at runtime; use `Save-Module`/`Save-PSResource` at build time.
+
+## Cross-Language Context
+
+If your team supports multiple stacks, compare PowerShell with:
+
+- [Python guide](../python/index.md)
+- [Node.js guide](../nodejs/index.md)
+- [.NET guide](../dotnet/index.md)
+- [Java guide](../java/index.md)
+
+## See Also
+
+- [Language Guides Overview](../index.md)
+- [Platform: Architecture](../../platform/architecture/index.md)
+- [Platform: Hosting](../../platform/hosting.md)
+- [Operations: Deployment](../../operations/deployment.md)
+- [Operations: Monitoring](../../operations/monitoring.md)
+
+## Sources
+
+- [Azure Functions PowerShell developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+</content>

--- a/docs/language-guides/powershell/platform-limits.md
+++ b/docs/language-guides/powershell/platform-limits.md
@@ -1,0 +1,71 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/language-support-policy
+---
+# Platform Limits
+
+Key limits and version constraints that affect PowerShell function apps. For the authoritative, always-current numbers, consult the Microsoft Learn sources below.
+
+## PowerShell Version Support
+
+| Functions runtime | PowerShell version | .NET version | Availability |
+|---|---|---|---|
+| 4.x | PowerShell 7.4 | .NET 8 | GA — all plans (Consumption, Flex Consumption, Premium, Dedicated) |
+| 4.x | PowerShell 7.6 (preview) | .NET 10 | Windows-only (Premium, Dedicated, Consumption) |
+
+- Pin an explicit major.minor version. The legacy `~7` value maps to `7.0.x` and is not auto-upgraded.
+- Flex Consumption supports PowerShell 7.4 on Linux only.
+
+## Timeout Limits
+
+| Plan | Default | Maximum |
+|---|---|---|
+| Consumption | 5 min | 10 min |
+| Flex Consumption | 30 min | Unbounded (subject to platform constraints) |
+| Premium | 30 min | Unbounded |
+| Dedicated | 30 min | Unbounded |
+
+Configure with `functionTimeout` in [host.json](host-json.md).
+
+## Scaling Limits
+
+| Plan | Max instances (approx.) | Notes |
+|---|---|---|
+| Consumption | 200 | Event-driven; scales to zero. |
+| Flex Consumption | 1,000 | Per-function scaling; always-ready instances configurable. |
+| Premium | 20–100 | Pre-warmed instances eliminate cold start. |
+| Dedicated | Bound to App Service Plan | Manual or autoscale rules. |
+
+## Concurrency
+
+- PowerShell processes one invocation per runspace at a time.
+- `PSWorkerInProcConcurrencyUpperBound` controls runspaces per process (default 1,000 on 4.x).
+- `FUNCTIONS_WORKER_PROCESS_COUNT` controls worker processes per instance.
+- Azure PowerShell state is process-scoped; validate concurrency-safety before raising these values.
+
+## Dependency Management
+
+| Plan | Managed dependencies (`requirements.psd1`) | Bundled `Modules` folder |
+|---|---|---|
+| Consumption | Supported | Supported |
+| Premium / Dedicated | Supported | Supported |
+| Flex Consumption | **Not supported** | Supported (required) |
+
+## See Also
+
+- [PowerShell Language Guide](index.md)
+- [PowerShell Runtime](powershell-runtime.md)
+- [host.json Reference](host-json.md)
+- [Platform Limits (Reference)](../../reference/platform-limits.md)
+
+## Sources
+
+- [Azure Functions scale and hosting (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Language support policy (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/language-support-policy)

--- a/docs/language-guides/powershell/powershell-programming-model.md
+++ b/docs/language-guides/powershell/powershell-programming-model.md
@@ -1,0 +1,156 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
+  diagrams:
+    - id: powershell-programming-model
+      type: flowchart
+      source: self-generated
+      justification: Flow view of powershell programming model, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+---
+# PowerShell Programming Model
+
+Azure Functions PowerShell uses a **file-based programming model**. Each function is a folder that contains a `run.ps1` script and a `function.json` file that declares the trigger and bindings. Unlike the Python v2 or Node.js v4 code-first models, triggers and bindings are configured in JSON, not in code.
+
+<!-- diagram-id: powershell-programming-model -->
+```mermaid
+flowchart TD
+    A[function.json defines trigger and bindings] --> B[Host reads binding metadata]
+    B --> C[Trigger fires and binds inputs to param block]
+    C --> D[run.ps1 executes]
+    D --> E[Push-OutputBinding writes outputs]
+```
+
+## Project Structure
+
+```text
+PSFunctionApp
+ | - HttpExample
+ | | - run.ps1
+ | | - function.json
+ | - host.json
+ | - local.settings.json
+ | - requirements.psd1
+ | - profile.ps1
+```
+
+- **`host.json`** — app-wide host configuration (shared by all functions).
+- **`requirements.psd1`** — managed dependencies (PowerShell modules).
+- **`profile.ps1`** — runs once per worker on cold start (e.g. `Connect-AzAccount -Identity`).
+- **Each function folder** — one `run.ps1` + one `function.json`.
+
+## function.json: Declaring Triggers and Bindings
+
+The `function.json` lists bindings. Each has a `type`, a `direction` (`in` or `out`), and a `name` that maps to a parameter (input) or `Push-OutputBinding -Name` (output).
+
+```json
+{
+  "bindings": [
+    {
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "Request",
+      "authLevel": "function",
+      "methods": ["get", "post"]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "Response"
+    }
+  ]
+}
+```
+
+## run.ps1: The param Block
+
+Input bindings arrive as named parameters. Because PowerShell binds by name, parameter order does not matter, but matching the `function.json` order is a good practice. The optional `$TriggerMetadata` parameter carries extra trigger information.
+
+```powershell
+param($Request, $TriggerMetadata)
+
+$name = $Request.Query.Name
+if (-not $name) { $name = $Request.Body.Name }
+
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = "Hello $name"
+})
+```
+
+## Reading Input
+
+Trigger and input bindings are read as parameters. For HTTP, the `$Request` is an `HttpRequestContext` with these properties:
+
+| Property | Description |
+|---|---|
+| `Body` | Request body, deserialized (JSON → hashtable, otherwise string). |
+| `Headers` | Case-insensitive dictionary of request headers. |
+| `Method` | HTTP method. |
+| `Params` | Route parameters. |
+| `Query` | Query-string parameters. |
+| `Url` | Full request URL. |
+
+## Writing Output
+
+Use `Push-OutputBinding` to write to any output binding. Its `-Name` maps to the binding `name` in `function.json`.
+
+```powershell
+# HTTP response (singleton — a second call errors unless you pass -Clobber)
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = "done"
+})
+
+# Queue output (collection — call repeatedly to push multiple messages)
+Push-OutputBinding -Name outQueue -Value "message-1"
+Push-OutputBinding -Name outQueue -Value "message-2"
+```
+
+| Element | Explanation |
+|---|---|
+| `Push-OutputBinding -Name` | Target output binding, matching `function.json`. |
+| `-Clobber` | Overwrite a singleton output value instead of appending. |
+| `HttpResponseContext` | Typed HTTP response object (`StatusCode`, `Body`, `Headers`, `ContentType`). |
+
+## Data Types
+
+Binding parameters must be one of: `Hashtable`, `string`, `byte[]`, `int`, `double`, `HttpRequestContext`, `HttpResponseContext`. You can type-cast bindings, for example a blob input as a string:
+
+```powershell
+param([string] $InputBlob)
+```
+
+## Modules via entryPoint
+
+Instead of `run.ps1`, you can point `function.json` at a module function with `scriptFile` + `entryPoint`:
+
+```json
+{
+  "scriptFile": "../lib/PSFunction.psm1",
+  "entryPoint": "Invoke-PSTestFunc",
+  "bindings": []
+}
+```
+
+## See Also
+
+- [PowerShell Language Guide](index.md)
+- [PowerShell Runtime](powershell-runtime.md)
+- [host.json Reference](host-json.md)
+- [Recipes: HTTP API](recipes/http-api.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [HTTP trigger binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook)
+</content>

--- a/docs/language-guides/powershell/powershell-runtime.md
+++ b/docs/language-guides/powershell/powershell-runtime.md
@@ -1,0 +1,120 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/language-support-policy
+  diagrams:
+    - id: powershell-runtime
+      type: flowchart
+      source: self-generated
+      justification: Flow view of the powershell worker runtime, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# PowerShell Runtime
+
+This page covers how the Azure Functions PowerShell worker executes your code: version selection, dependency management, cold start, and concurrency.
+
+<!-- diagram-id: powershell-runtime -->
+```mermaid
+flowchart TD
+    START[Worker cold start] --> PROFILE[Run profile.ps1 once]
+    PROFILE --> DEPS[Load managed or bundled modules]
+    DEPS --> READY[Worker ready]
+    READY --> INVOKE[Invoke run.ps1 per trigger]
+```
+
+## PowerShell Versions
+
+| Functions runtime | PowerShell version | .NET version | Availability |
+|---|---|---|---|
+| 4.x | PowerShell 7.4 | .NET 8 | GA — all plans |
+| 4.x | PowerShell 7.6 (preview) | .NET 10 | Windows-only (Premium, Dedicated, Consumption) |
+
+Print `$PSVersionTable` from any function to see the current version. PowerShell function apps must pin an explicit major.minor version (`7.4` or `7.6`); the legacy `~7` value maps to `7.0.x` and is not auto-upgraded.
+
+### Selecting a Version Locally
+
+Add `FUNCTIONS_WORKER_RUNTIME_VERSION` to `local.settings.json`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "powershell",
+    "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.4"
+  }
+}
+```
+
+## Dependency Management
+
+There are two ways to manage PowerShell modules:
+
+### Managed Dependencies (requirements.psd1)
+
+Azure Functions automatically downloads and updates modules listed in `requirements.psd1`. Enabled by default in new apps.
+
+```powershell
+@{
+    'Az' = '9.*'
+}
+```
+
+Requires `managedDependency.enabled: true` in `host.json` and outbound access to `https://www.powershellgallery.com`.
+
+!!! warning "Not supported on Flex Consumption"
+    Managed dependencies are **not** available on the Flex Consumption plan. Bundle modules in a `Modules` folder instead (see below). This is also the recommended approach for other Linux SKUs.
+
+### Bundled Modules (Modules folder)
+
+Save modules into a `Modules` folder at the app root at build time:
+
+```powershell
+Save-Module -Name Az.Accounts -Path ./Modules
+# or
+Save-PSResource -Name Az.Accounts -Path ./Modules
+```
+
+The worker adds `Modules` to `$env:PSModulePath` for autoloading. This avoids external dependencies and version drift from auto-upgrades.
+
+## Cold Start and profile.ps1
+
+`profile.ps1` runs once per worker instance on cold start (and once per runspace when concurrency is enabled). Use it for one-time setup such as managed identity authentication:
+
+```powershell
+if ($env:MSI_SECRET) {
+    Connect-AzAccount -Identity
+}
+```
+
+!!! tip "Avoid Install-Module at runtime"
+    Running `Install-Module` on each invocation causes performance problems. Use `Save-Module`/`Save-PSResource` before publishing.
+
+## Concurrency
+
+PowerShell functions process one invocation at a time by default. Two levers increase throughput:
+
+| Setting | Effect |
+|---|---|
+| `FUNCTIONS_WORKER_PROCESS_COUNT` | Runs multiple worker processes per instance (higher CPU/memory overhead). |
+| `PSWorkerInProcConcurrencyUpperBound` | Creates multiple runspaces in one process (lower overhead). Defaults to 1,000 on 4.x. |
+
+!!! warning "Race conditions with Azure PowerShell"
+    Azure PowerShell keeps process-level context/state. Enabling in-process concurrency with state-changing operations can cause race conditions. If you suspect one, set `PSWorkerInProcConcurrencyUpperBound` to `1` and use process-level isolation instead.
+
+## See Also
+
+- [PowerShell Language Guide](index.md)
+- [PowerShell Programming Model](powershell-programming-model.md)
+- [host.json Reference](host-json.md)
+- [Platform Limits](platform-limits.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Language support policy (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/language-support-policy)
+</content>

--- a/docs/language-guides/powershell/recipes/blob-storage.md
+++ b/docs/language-guides/powershell/recipes/blob-storage.md
@@ -1,0 +1,86 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Blob Storage
+
+Process files with blob triggers and read/write blobs using bindings in PowerShell.
+
+## Blob Trigger
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "InputBlob",
+      "type": "blobTrigger",
+      "direction": "in",
+      "path": "uploads/{name}",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($InputBlob, $TriggerMetadata)
+
+$name = $TriggerMetadata.name
+Write-Information "Processing blob '$name' ($($InputBlob.Length) bytes)"
+```
+
+The blob binding delivers content as a `byte[]` by default. For text, convert:
+
+```powershell
+$text = [System.Text.Encoding]::UTF8.GetString($InputBlob)
+```
+
+## Output Blob Binding
+
+Add an output binding to write a derived file:
+
+```json
+{
+  "name": "OutputBlob",
+  "type": "blob",
+  "direction": "out",
+  "path": "processed/{name}",
+  "connection": "AzureWebJobsStorage"
+}
+```
+
+```powershell
+Push-OutputBinding -Name OutputBlob -Value $processedContent
+```
+
+## Using the Az.Storage Module
+
+For dynamic paths or listing operations, use the module with a managed identity:
+
+```powershell
+Connect-AzAccount -Identity
+$ctx = New-AzStorageContext -StorageAccountName $env:StorageAccountName -UseConnectedAccount
+Get-AzStorageBlob -Container "uploads" -Context $ctx
+```
+
+!!! warning "Blob trigger scaling"
+    Blob triggers on Consumption can lag under high volume. For latency-sensitive processing, prefer an Event Grid-based blob trigger or a queue.
+
+## See Also
+
+- [Queue Storage](queue.md)
+- [Managed Identity](managed-identity.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Blob storage bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-blob)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/http-api.md
+++ b/docs/language-guides/powershell/recipes/http-api.md
@@ -1,0 +1,86 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# HTTP API Patterns
+
+Build HTTP APIs in PowerShell using the `HttpRequestContext` input and `HttpResponseContext` output binding.
+
+## Route and Method Configuration
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "Request",
+      "methods": ["get", "post"],
+      "route": "orders/{id?}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "Response"
+    }
+  ]
+}
+```
+
+## Parsing the Request
+
+```powershell
+param($Request, $TriggerMetadata)
+
+# Route parameter
+$id = $Request.Params.id
+
+# Query string
+$status = $Request.Query.Status
+
+# JSON body (already deserialized into a Hashtable/PSObject)
+$payload = $Request.Body
+```
+
+## Returning Structured Responses
+
+```powershell
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode  = [System.Net.HttpStatusCode]::OK
+    Headers     = @{ "Content-Type" = "application/json" }
+    Body        = @{ id = $id; status = "processed" } | ConvertTo-Json
+})
+```
+
+## Error Handling
+
+```powershell
+if (-not $id) {
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+        StatusCode = [System.Net.HttpStatusCode]::BadRequest
+        Body       = "Missing order id"
+    })
+    return
+}
+```
+
+!!! tip "Always return early"
+    After pushing an error response, `return` immediately to avoid pushing a second value to the same output binding.
+
+## See Also
+
+- [HTTP Authentication](http-auth.md)
+- [PowerShell Programming Model](../powershell-programming-model.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [HTTP trigger and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/http-auth.md
+++ b/docs/language-guides/powershell/recipes/http-auth.md
@@ -1,0 +1,80 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts
+---
+# HTTP Authentication
+
+Control access to PowerShell HTTP functions with authorization levels, function keys, and token validation.
+
+## Authorization Levels
+
+Set `authLevel` in `function.json`:
+
+| Level | Behavior |
+|-------|----------|
+| `anonymous` | No key required. |
+| `function` | Requires a function or host key (default). |
+| `admin` | Requires the host master key. |
+
+```json
+{
+  "authLevel": "function",
+  "type": "httpTrigger",
+  "direction": "in",
+  "name": "Request",
+  "methods": ["post"]
+}
+```
+
+## Calling with a Function Key
+
+```bash
+curl "https://$APP_NAME.azurewebsites.net/api/secure?code=<function-key>"
+```
+
+Retrieve keys with:
+
+```bash
+az functionapp function keys list \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --function-name secure
+```
+
+## Validating a Bearer Token
+
+For Entra ID-issued tokens, validate the JWT inside the function. Prefer fronting the app with API Management or App Service Easy Auth for production, but a lightweight in-function check looks like:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+$authHeader = $Request.Headers.Authorization
+if (-not $authHeader -or -not $authHeader.StartsWith("Bearer ")) {
+    Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+        StatusCode = [System.Net.HttpStatusCode]::Unauthorized
+        Body       = "Missing bearer token"
+    })
+    return
+}
+
+$token = $authHeader.Substring(7)
+# Validate $token signature/claims against your identity provider here.
+```
+
+!!! warning "Do not hand-roll crypto"
+    For real token validation, use a vetted library or delegate to App Service Authentication / API Management rather than manually verifying signatures.
+
+## See Also
+
+- [HTTP API Patterns](http-api.md)
+- [Managed Identity](managed-identity.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Work with function keys (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/function-keys-how-to)
+- [Azure Functions security concepts (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/security-concepts)

--- a/docs/language-guides/powershell/recipes/index.md
+++ b/docs/language-guides/powershell/recipes/index.md
@@ -1,0 +1,79 @@
+---
+content_sources:
+  diagrams:
+    - id: powershell-recipes
+      type: graph
+      source: self-generated
+      justification: Category view of the PowerShell recipes, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices
+---
+# PowerShell Recipes
+
+The Recipes section provides implementation-focused patterns for common Azure Functions integrations in PowerShell.
+
+Use these documents when you already understand the platform basics and need practical, reusable building blocks. PowerShell functions use the classic `function.json` binding model with `param` inputs and `Push-OutputBinding` outputs.
+
+<!-- diagram-id: powershell-recipes -->
+```mermaid
+graph TD
+    A[PowerShell Recipes] --> B[HTTP]
+    A --> C[Storage & Messaging]
+    A --> D[Security]
+    A --> E[Scheduling]
+```
+
+!!! tip "Pair recipes with platform guidance"
+    For architecture and plan behavior that applies across all languages, see [Platform](../../../platform/index.md).
+
+## Recipe categories
+
+### HTTP
+
+| Recipe | Description |
+|--------|-------------|
+| [HTTP API Patterns](http-api.md) | Route design, request parsing, and structured responses with `HttpResponseContext`. |
+| [HTTP Authentication](http-auth.md) | Function auth levels, function keys, and token validation patterns. |
+
+### Storage & Messaging
+
+| Recipe | Description |
+|--------|-------------|
+| [Blob Storage](blob-storage.md) | Blob trigger and blob binding patterns for file processing. |
+| [Queue Storage](queue.md) | Queue trigger consumer patterns and output bindings. |
+| [Service Bus](service-bus.md) | Enterprise messaging with queue/topic triggers and dead-lettering. |
+
+### Security
+
+| Recipe | Description |
+|--------|-------------|
+| [Key Vault](key-vault.md) | Secret retrieval using Key Vault references and the Az module. |
+| [Managed Identity](managed-identity.md) | Passwordless authentication via `Connect-AzAccount -Identity`. |
+
+### Scheduling
+
+| Recipe | Description |
+|--------|-------------|
+| [Timer Trigger](timer.md) | Scheduled jobs, cron semantics, and idempotent batch execution. |
+
+## How to consume recipes effectively
+
+1. Start from your trigger pattern (HTTP, timer, queue, blob, Service Bus).
+2. Apply security baseline patterns first (Managed Identity and Key Vault).
+3. Validate hosting-plan constraints in [Platform: Hosting](../../../platform/hosting.md).
+4. Add monitoring/alerts using [Operations](../../../operations/index.md) guidance.
+
+## See Also
+
+- [PowerShell Language Guide](../index.md)
+- [PowerShell Tutorial](../tutorial/index.md)
+- [Platform: Triggers and Bindings](../../../platform/triggers-and-bindings.md)
+- [Troubleshooting](../troubleshooting.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions trigger and binding concepts (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions best practices (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices)

--- a/docs/language-guides/powershell/recipes/key-vault.md
+++ b/docs/language-guides/powershell/recipes/key-vault.md
@@ -1,0 +1,73 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Key Vault
+
+Retrieve secrets securely in PowerShell functions using Key Vault references or the Az module.
+
+## Key Vault References (Recommended)
+
+Reference a secret directly from an app setting — no code changes required:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "DbPassword=@Microsoft.KeyVault(SecretUri=https://my-vault.vault.azure.net/secrets/db-password/)"
+```
+
+The function reads it as a normal environment variable:
+
+```powershell
+$password = $env:DbPassword
+```
+
+The function app's managed identity must have the **Key Vault Secrets User** role on the vault.
+
+## Retrieving Secrets at Runtime
+
+For dynamic secret names, use the `Az.KeyVault` module with a managed identity:
+
+```powershell
+# profile.ps1
+if ($env:MSI_SECRET) {
+    Connect-AzAccount -Identity
+}
+```
+
+```powershell
+# run.ps1
+param($Request, $TriggerMetadata)
+
+$secret = Get-AzKeyVaultSecret -VaultName "my-vault" -Name "db-password" -AsPlainText
+```
+
+Bundle `Az.KeyVault` (and `Az.Accounts`) in the `Modules` folder, or declare them in `requirements.psd1` on plans that support managed dependencies.
+
+## Grant Access
+
+```bash
+az role assignment create \
+  --assignee <function-app-identity-object-id> \
+  --role "Key Vault Secrets User" \
+  --scope <key-vault-resource-id>
+```
+
+!!! warning "Never log secrets"
+    Do not pass secret values to `Write-Information`/`Write-Host` — they flow to Application Insights.
+
+## See Also
+
+- [Managed Identity](managed-identity.md)
+- [Environment Variables](../environment-variables.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Key Vault references (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/managed-identity.md
+++ b/docs/language-guides/powershell/recipes/managed-identity.md
@@ -1,0 +1,77 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Managed Identity
+
+Authenticate to Azure services without secrets using a managed identity and `Connect-AzAccount -Identity`.
+
+## Enable the Identity
+
+```bash
+az functionapp identity assign \
+  --name $APP_NAME \
+  --resource-group $RG
+```
+
+This injects `MSI_SECRET` and `IDENTITY_HEADER` into the app environment.
+
+## Authenticate Once per Worker
+
+Put the connection in `profile.ps1` so it runs once on cold start rather than per invocation:
+
+```powershell
+# profile.ps1
+if ($env:MSI_SECRET) {
+    Disable-AzContextAutosave -Scope Process | Out-Null
+    Connect-AzAccount -Identity
+}
+```
+
+## Use the Connection
+
+```powershell
+# run.ps1
+param($Request, $TriggerMetadata)
+
+$ctx = New-AzStorageContext -StorageAccountName $env:StorageAccountName -UseConnectedAccount
+$blobs = Get-AzStorageBlob -Container "data" -Context $ctx
+```
+
+## Identity-Based Trigger Connections
+
+Bindings can use the identity instead of a connection string. Replace the connection string setting with a namespace/endpoint setting:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "AzureWebJobsStorage__accountName=$STORAGE_NAME"
+```
+
+## Grant RBAC
+
+```bash
+az role assignment create \
+  --assignee <function-app-identity-object-id> \
+  --role "Storage Blob Data Contributor" \
+  --scope <storage-account-resource-id>
+```
+
+!!! warning "Concurrency and Az context"
+    Azure PowerShell context is process-scoped. When in-process concurrency is enabled, call `Disable-AzContextAutosave -Scope Process` and validate for race conditions. See [PowerShell Runtime](../powershell-runtime.md#concurrency).
+
+## See Also
+
+- [Key Vault](key-vault.md)
+- [Environment Variables](../environment-variables.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Identity-based connections tutorial (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-identity-based-connections-tutorial)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/queue.md
+++ b/docs/language-guides/powershell/recipes/queue.md
@@ -1,0 +1,81 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Queue Storage
+
+Consume and produce Azure Storage queue messages in PowerShell.
+
+## Queue Trigger
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "QueueItem",
+      "type": "queueTrigger",
+      "direction": "in",
+      "queueName": "work-items",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($QueueItem, $TriggerMetadata)
+
+# JSON messages are deserialized automatically into a Hashtable/PSObject
+Write-Information "Processing item $($QueueItem.id)"
+
+Write-Information "Dequeue count: $($TriggerMetadata.DequeueCount)"
+```
+
+## Output Queue Binding
+
+Emit messages to another queue:
+
+```json
+{
+  "name": "OutputQueue",
+  "type": "queue",
+  "direction": "out",
+  "queueName": "results",
+  "connection": "AzureWebJobsStorage"
+}
+```
+
+```powershell
+Push-OutputBinding -Name OutputQueue -Value (@{ id = $QueueItem.id; status = "done" } | ConvertTo-Json)
+```
+
+## Poison Messages
+
+After the runtime exhausts retries (default 5 dequeues), the message moves to `<queueName>-poison`. Add a trigger on that queue to handle failures:
+
+```powershell
+param($QueueItem, $TriggerMetadata)
+Write-Error "Poison message received: $($QueueItem | ConvertTo-Json)"
+```
+
+!!! tip "Idempotency"
+    A message can be delivered more than once. Make handlers idempotent — key writes on a stable message id.
+
+## See Also
+
+- [Blob Storage](blob-storage.md)
+- [Service Bus](service-bus.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Queue storage bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/service-bus.md
+++ b/docs/language-guides/powershell/recipes/service-bus.md
@@ -1,0 +1,85 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Service Bus
+
+Handle enterprise messaging with Service Bus queue and topic triggers in PowerShell.
+
+## Queue Trigger
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Message",
+      "type": "serviceBusTrigger",
+      "direction": "in",
+      "queueName": "orders",
+      "connection": "ServiceBusConnection"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($Message, $TriggerMetadata)
+
+Write-Information "Received message id $($TriggerMetadata.MessageId)"
+Write-Information "Delivery count: $($TriggerMetadata.DeliveryCount)"
+```
+
+## Topic and Subscription Trigger
+
+```json
+{
+  "name": "Message",
+  "type": "serviceBusTrigger",
+  "direction": "in",
+  "topicName": "events",
+  "subscriptionName": "audit",
+  "connection": "ServiceBusConnection"
+}
+```
+
+## Output Binding
+
+```json
+{
+  "name": "OutputMessage",
+  "type": "serviceBus",
+  "direction": "out",
+  "queueName": "notifications",
+  "connection": "ServiceBusConnection"
+}
+```
+
+```powershell
+Push-OutputBinding -Name OutputMessage -Value (@{ event = "order.created" } | ConvertTo-Json)
+```
+
+## Dead-Lettering
+
+Messages that exceed max delivery count move to the dead-letter subqueue automatically. Monitor and reprocess it separately.
+
+!!! tip "Identity-based connections"
+    Prefer a `ServiceBusConnection__fullyQualifiedNamespace` app setting with a managed identity over a shared access key connection string. See [Managed Identity](managed-identity.md).
+
+## See Also
+
+- [Queue Storage](queue.md)
+- [Managed Identity](managed-identity.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Service Bus bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/timer.md
+++ b/docs/language-guides/powershell/recipes/timer.md
@@ -1,0 +1,76 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-timer
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Timer Trigger
+
+Run PowerShell functions on a schedule using NCronTab expressions.
+
+## Configuration
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */5 * * * *"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($Timer)
+
+if ($Timer.IsPastDue) {
+    Write-Warning "Timer is running late"
+}
+
+Write-Information "Scheduled job started at $(Get-Date -Format o)"
+```
+
+## NCronTab Format
+
+`{second} {minute} {hour} {day} {month} {day-of-week}`
+
+| Expression | Meaning |
+|------------|---------|
+| `0 */5 * * * *` | Every 5 minutes |
+| `0 0 * * * *` | Every hour on the hour |
+| `0 0 9 * * 1-5` | 09:00 on weekdays |
+| `0 30 3 * * *` | 03:30 daily |
+
+## Idempotent Batch Execution
+
+Timer functions may occasionally run twice (e.g., across a scale event). Guard against duplicate work:
+
+```powershell
+param($Timer)
+
+$runId = Get-Date -Format "yyyyMMddHH"
+# Use a lease/marker in storage keyed on $runId to ensure single execution.
+```
+
+!!! tip "Time zones"
+    Timer schedules use UTC by default. Set the `WEBSITE_TIME_ZONE` app setting to change the evaluation time zone.
+
+## See Also
+
+- [Queue Storage](queue.md)
+- [Environment Variables](../environment-variables.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Timer trigger (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-timer)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/troubleshooting.md
+++ b/docs/language-guides/powershell/troubleshooting.md
@@ -1,0 +1,94 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-recover-storage-account
+---
+# Troubleshooting PowerShell Functions
+
+Symptom-based guidance for common PowerShell-specific problems. For platform-wide diagnosis, see the [Troubleshooting hub](../../troubleshooting/index.md).
+
+## Module Not Found at Runtime
+
+**Symptom**: `The term '<cmdlet>' is not recognized` or `Could not load module`.
+
+**Checks**:
+
+- On Flex Consumption, confirm the module is bundled in the `Modules` folder — managed dependencies are not supported there.
+- Confirm `managedDependency.enabled` is `true` in [host.json](host-json.md) when using `requirements.psd1`.
+- Verify outbound access to `https://www.powershellgallery.com` for managed dependencies.
+- Check the module version directory exists under `Modules/<Name>/<Version>/`.
+
+```powershell
+# Verify a module is discoverable inside a function
+Get-Module -ListAvailable -Name Az.Accounts
+```
+
+## Slow Cold Start
+
+**Symptom**: First invocation after idle takes many seconds.
+
+**Checks**:
+
+- Large module sets (e.g., the full `Az` module) inflate load time. Import only the sub-modules you need (`Az.Accounts`, `Az.Storage`).
+- Move one-time setup into `profile.ps1` rather than repeating it per invocation.
+- Consider Premium plan pre-warmed instances or Flex Consumption always-ready instances for latency-sensitive workloads.
+
+```powershell
+# requirements.psd1 — pin narrow modules instead of the full Az
+@{
+    'Az.Accounts' = '2.*'
+    'Az.Storage'  = '5.*'
+}
+```
+
+## Output Binding Not Written
+
+**Symptom**: HTTP response is empty or a queue/blob output is missing.
+
+**Checks**:
+
+- Ensure you call `Push-OutputBinding -Name <bindingName> -Value <value>` with a `Name` that matches the binding `name` in `function.json`.
+- For HTTP, the output binding name is typically `Response` and expects an `HttpResponseContext`.
+
+```powershell
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = "ok"
+})
+```
+
+## Concurrency Race Conditions
+
+**Symptom**: Intermittent wrong results, cross-request data bleed, or Azure context errors under load.
+
+**Checks**:
+
+- Azure PowerShell context is process-scoped. Set `PSWorkerInProcConcurrencyUpperBound` to `1` to isolate invocations.
+- Use `FUNCTIONS_WORKER_PROCESS_COUNT` for parallelism instead of in-process runspaces when using stateful modules.
+- Call `Disable-AzContextAutosave -Scope Process` in `profile.ps1`.
+
+## Managed Identity Authentication Fails
+
+**Symptom**: `Connect-AzAccount -Identity` throws or returns no context.
+
+**Checks**:
+
+- Confirm a system- or user-assigned identity is assigned to the function app.
+- Verify `MSI_SECRET`/`IDENTITY_HEADER` are present (they are injected only when an identity exists).
+- Ensure the identity has the required RBAC role on the target resource.
+
+See the [Managed Identity recipe](recipes/managed-identity.md).
+
+## See Also
+
+- [PowerShell Language Guide](index.md)
+- [PowerShell Runtime](powershell-runtime.md)
+- [Troubleshooting hub](../../troubleshooting/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Recover a deleted storage account (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-recover-storage-account)

--- a/docs/language-guides/powershell/tutorial/consumption/01-local-run.md
+++ b/docs/language-guides/powershell/tutorial/consumption/01-local-run.md
@@ -1,0 +1,126 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 01 - Run Locally (Consumption)
+
+Scaffold and run a PowerShell Azure Functions app locally before deploying to the Consumption (Y1) plan.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| PowerShell | 7.4+ | Local runtime matching the worker |
+| Azure Functions Core Tools | v4 | Start the local host and publish |
+| Azure CLI | 2.61+ | Provision and configure Azure resources |
+| Azurite (optional) | latest | Local Storage emulator for triggers |
+
+!!! info "Consumption (Y1) basics"
+    Consumption (Y1) is serverless with scale-to-zero and per-execution billing. PowerShell runs on version 7.4 on this plan.
+
+## What You'll Build
+
+You will scaffold a PowerShell function app with an anonymous HTTP trigger, run it on the local Functions host, and verify the endpoint responds.
+
+## Steps
+
+### Step 1 - Scaffold the project
+
+```bash
+func init MyPsApp --powershell
+cd MyPsApp
+func new --name HttpExample --template "HTTP trigger" --authlevel anonymous
+```
+
+### Step 2 - Configure local settings
+
+`local.settings.json`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "powershell",
+    "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.4"
+  }
+}
+```
+
+### Step 3 - Review the function
+
+`HttpExample/run.ps1`:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+$name = $Request.Query.Name
+if (-not $name) { $name = $Request.Body.Name }
+
+$body = if ($name) { "Hello, $name." } else { "Pass a name in the query string or body." }
+
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = $body
+})
+```
+
+### Step 4 - Start the host
+
+```bash
+func host start
+```
+
+### Step 5 - Call the endpoint
+
+```bash
+curl "http://localhost:7071/api/HttpExample?name=Azure"
+```
+
+## Verification
+
+```text
+Functions:
+    HttpExample: [GET,POST] http://localhost:7071/api/HttpExample
+```
+
+The curl call returns `Hello, Azure.`
+
+## Next Steps
+
+You now have local parity and can deploy to Consumption (Y1).
+
+> **Next:** [02 - First Deploy](02-first-deploy.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/powershell/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/powershell/tutorial/consumption/02-first-deploy.md
@@ -1,0 +1,104 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 02 - First Deploy (Consumption)
+
+Provision a Consumption (Y1) function app and deploy the PowerShell project you built in step 01.
+
+## Prerequisites
+
+- Completed [01 - Run Locally](01-local-run.md)
+- Signed in with `az login`
+
+## Steps
+
+### Step 1 - Set variables
+
+```bash
+RG=rg-functions-demo
+APP_NAME=func-ps-demo
+STORAGE_NAME=stpsdemo$RANDOM
+LOCATION=koreacentral
+
+```
+
+### Step 2 - Create the resource group and storage
+
+```bash
+az group create --name $RG --location $LOCATION
+
+az storage account create \
+  --name $STORAGE_NAME \
+  --resource-group $RG \
+  --location $LOCATION \
+  --sku Standard_LRS
+```
+
+
+### Step 3 - Create the function app
+
+```bash
+az functionapp create \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --storage-account $STORAGE_NAME \
+  --consumption-plan-location $LOCATION \
+  --runtime powershell \
+  --runtime-version 7.4 \
+  --functions-version 4 \
+  --os-type Windows
+```
+
+### Step 4 - Deploy the code
+
+```bash
+func azure functionapp publish $APP_NAME
+```
+
+## Verification
+
+```bash
+curl "https://$APP_NAME.azurewebsites.net/api/HttpExample?name=Azure"
+```
+
+Returns `Hello, Azure.`
+
+## Next Steps
+
+Your app is live. Next, manage its configuration and secrets.
+
+> **Next:** [03 - Configuration](03-configuration.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/powershell/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/powershell/tutorial/consumption/03-configuration.md
@@ -1,0 +1,80 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 03 - Configuration (Consumption)
+
+Manage app settings, connection strings, and PowerShell module dependencies for your Consumption (Y1) app.
+
+## App Settings
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "GreetingPrefix=Hello" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
+```
+
+Read settings in PowerShell with `$env:GreetingPrefix`.
+
+## Module Dependencies
+
+Use managed dependencies. Declare modules in `requirements.psd1` and enable `managedDependency` in `host.json`:
+
+```powershell
+@{
+    'Az.Accounts' = '2.*'
+}
+```
+
+The runtime downloads them from the PowerShell Gallery on startup.
+
+## Verification
+
+```bash
+az functionapp config appsettings list \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --output table
+```
+
+Confirm `GreetingPrefix` appears with the expected value.
+
+## Next Steps
+
+With configuration in place, wire up observability.
+
+> **Next:** [04 - Logging & Monitoring](04-logging-monitoring.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/powershell/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/powershell/tutorial/consumption/04-logging-monitoring.md
@@ -1,0 +1,96 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 04 - Logging & Monitoring (Consumption)
+
+Configure Application Insights and structured logging for your Consumption (Y1) PowerShell app.
+
+## Enable Application Insights
+
+```bash
+az monitor app-insights component create \
+  --app func-ps-demo-ai \
+  --location $LOCATION \
+  --resource-group $RG
+
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
+```
+
+## Logging in PowerShell
+
+Use the standard streams — they flow to Application Insights automatically:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+Write-Information "Processing request for $($Request.Query.Name)"
+Write-Warning "Name was empty; using default"
+Write-Error "Downstream call failed"
+```
+
+| Cmdlet | Severity |
+|--------|----------|
+| `Write-Information` / `Write-Host` | Information |
+| `Write-Warning` | Warning |
+| `Write-Error` | Error |
+
+## Stream Live Logs
+
+```bash
+az functionapp log tail --name $APP_NAME --resource-group $RG
+```
+
+## Verification
+
+Invoke the function, then query Application Insights:
+
+```kusto
+traces
+| where timestamp > ago(15m)
+| order by timestamp desc
+```
+
+You should see your `Write-Information` messages.
+
+## Next Steps
+
+Codify the whole environment as Infrastructure as Code.
+
+> **Next:** [05 - Infrastructure as Code](05-infrastructure-as-code.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/powershell/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/powershell/tutorial/consumption/05-infrastructure-as-code.md
@@ -1,0 +1,93 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 05 - Infrastructure as Code (Consumption)
+
+Define your Consumption (Y1) PowerShell app in Bicep for reproducible deployments.
+
+## Bicep Template
+
+```bicep
+param appName string
+param location string = resourceGroup().location
+param storageName string
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+}
+
+resource app 'Microsoft.Web/sites@2023-12-01' = {
+  name: appName
+  location: location
+  kind: 'functionapp'
+  properties: {
+    siteConfig: {
+      appSettings: [
+        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'powershell' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME_VERSION', value: '7.4' }
+      ]
+    }
+  }
+}
+```
+
+## Deploy
+
+```bash
+az deployment group create \
+  --resource-group $RG \
+  --template-file infra/main.bicep \
+  --parameters appName=$APP_NAME storageName=$STORAGE_NAME
+```
+
+## Verification
+
+```bash
+az deployment group show --resource-group $RG --name main --query properties.provisioningState
+```
+
+Returns `Succeeded`.
+
+## Next Steps
+
+Automate the build and deploy with CI/CD.
+
+> **Next:** [06 - CI/CD](06-ci-cd.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/powershell/tutorial/consumption/06-ci-cd.md
+++ b/docs/language-guides/powershell/tutorial/consumption/06-ci-cd.md
@@ -1,0 +1,82 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 06 - CI/CD (Consumption)
+
+Automate build and deployment of your Consumption (Y1) PowerShell app with GitHub Actions.
+
+## Workflow
+
+```yaml
+name: deploy-powershell-functions
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bundle PowerShell modules
+        shell: pwsh
+        run: |
+          Save-Module -Name Az.Accounts -Path ./Modules
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Azure Functions
+        uses: Azure/functions-action@v1
+        with:
+          app-name: func-ps-demo
+          package: .
+```
+
+## Verification
+
+Push to `main` and confirm the workflow completes green in the Actions tab, then curl the deployed endpoint.
+
+## Next Steps
+
+Extend beyond HTTP with additional trigger types.
+
+> **Next:** [07 - Extending with Triggers](07-extending-triggers.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/powershell/tutorial/consumption/07-extending-triggers.md
+++ b/docs/language-guides/powershell/tutorial/consumption/07-extending-triggers.md
@@ -1,0 +1,120 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 07 - Extending with Triggers (Consumption)
+
+Add Timer, Queue, and Blob triggers to your Consumption (Y1) PowerShell app. PowerShell uses the classic `function.json` binding model.
+
+## Timer Trigger
+
+`TimerExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */5 * * * *"
+    }
+  ]
+}
+```
+
+`TimerExample/run.ps1`:
+
+```powershell
+param($Timer)
+Write-Information "Timer fired at $(Get-Date -Format o)"
+```
+
+## Queue Trigger
+
+`QueueExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "QueueItem",
+      "type": "queueTrigger",
+      "direction": "in",
+      "queueName": "work-items",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+```powershell
+param($QueueItem, $TriggerMetadata)
+Write-Information "Dequeued: $QueueItem"
+```
+
+## Blob Trigger
+
+`BlobExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "InputBlob",
+      "type": "blobTrigger",
+      "direction": "in",
+      "path": "uploads/{name}",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+```powershell
+param($InputBlob, $TriggerMetadata)
+Write-Information "Blob $($TriggerMetadata.name) is $($InputBlob.Length) bytes"
+```
+
+## Verification
+
+Deploy, then drop a message on the `work-items` queue or upload a blob to `uploads/`. Confirm the invocation appears in `az functionapp log tail`.
+
+## Next Steps
+
+Explore the [Recipes Index](../../recipes/index.md) for reusable binding patterns.
+
+> **Next:** [Recipes Index](../../recipes/index.md) — reusable PowerShell trigger and binding patterns.
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+
+!!! warning "Legacy hosting path"
+    Consumption plan (Y1) content is provided for existing workloads. For most new serverless applications, prefer [Flex Consumption](../flex-consumption/01-local-run.md).

--- a/docs/language-guides/powershell/tutorial/dedicated/01-local-run.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/01-local-run.md
@@ -1,0 +1,123 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 01 - Run Locally (Dedicated)
+
+Scaffold and run a PowerShell Azure Functions app locally before deploying to the Dedicated (App Service Plan) plan.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| PowerShell | 7.4+ | Local runtime matching the worker |
+| Azure Functions Core Tools | v4 | Start the local host and publish |
+| Azure CLI | 2.61+ | Provision and configure Azure resources |
+| Azurite (optional) | latest | Local Storage emulator for triggers |
+
+!!! info "Dedicated (App Service Plan) basics"
+    Dedicated (App Service Plan) is fixed-capacity App Service hosting with predictable pricing. PowerShell runs on version 7.4 on this plan.
+
+## What You'll Build
+
+You will scaffold a PowerShell function app with an anonymous HTTP trigger, run it on the local Functions host, and verify the endpoint responds.
+
+## Steps
+
+### Step 1 - Scaffold the project
+
+```bash
+func init MyPsApp --powershell
+cd MyPsApp
+func new --name HttpExample --template "HTTP trigger" --authlevel anonymous
+```
+
+### Step 2 - Configure local settings
+
+`local.settings.json`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "powershell",
+    "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.4"
+  }
+}
+```
+
+### Step 3 - Review the function
+
+`HttpExample/run.ps1`:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+$name = $Request.Query.Name
+if (-not $name) { $name = $Request.Body.Name }
+
+$body = if ($name) { "Hello, $name." } else { "Pass a name in the query string or body." }
+
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = $body
+})
+```
+
+### Step 4 - Start the host
+
+```bash
+func host start
+```
+
+### Step 5 - Call the endpoint
+
+```bash
+curl "http://localhost:7071/api/HttpExample?name=Azure"
+```
+
+## Verification
+
+```text
+Functions:
+    HttpExample: [GET,POST] http://localhost:7071/api/HttpExample
+```
+
+The curl call returns `Hello, Azure.`
+
+## Next Steps
+
+You now have local parity and can deploy to Dedicated (App Service Plan).
+
+> **Next:** [02 - First Deploy](02-first-deploy.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Dedicated (App Service) plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/02-first-deploy.md
@@ -1,0 +1,110 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 02 - First Deploy (Dedicated)
+
+Provision a Dedicated (App Service Plan) function app and deploy the PowerShell project you built in step 01.
+
+## Prerequisites
+
+- Completed [01 - Run Locally](01-local-run.md)
+- Signed in with `az login`
+
+## Steps
+
+### Step 1 - Set variables
+
+```bash
+RG=rg-functions-demo
+APP_NAME=func-ps-demo
+STORAGE_NAME=stpsdemo$RANDOM
+LOCATION=koreacentral
+PLAN_NAME=plan-ps-demo
+```
+
+### Step 2 - Create the resource group and storage
+
+```bash
+az group create --name $RG --location $LOCATION
+
+az storage account create \
+  --name $STORAGE_NAME \
+  --resource-group $RG \
+  --location $LOCATION \
+  --sku Standard_LRS
+```
+
+### Step 2b - Create the hosting plan
+
+```bash
+az appservice plan create \
+  --name $PLAN_NAME \
+  --resource-group $RG \
+  --location $LOCATION \
+  --sku B1 \
+  --is-linux
+```
+
+### Step 3 - Create the function app
+
+```bash
+az functionapp create \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --storage-account $STORAGE_NAME \
+  --plan $PLAN_NAME \
+  --runtime powershell \
+  --runtime-version 7.4 \
+  --functions-version 4
+```
+
+### Step 4 - Deploy the code
+
+```bash
+func azure functionapp publish $APP_NAME
+```
+
+## Verification
+
+```bash
+curl "https://$APP_NAME.azurewebsites.net/api/HttpExample?name=Azure"
+```
+
+Returns `Hello, Azure.`
+
+## Next Steps
+
+Your app is live. Next, manage its configuration and secrets.
+
+> **Next:** [03 - Configuration](03-configuration.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Dedicated (App Service) plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/03-configuration.md
@@ -1,0 +1,77 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 03 - Configuration (Dedicated)
+
+Manage app settings, connection strings, and PowerShell module dependencies for your Dedicated (App Service Plan) app.
+
+## App Settings
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "GreetingPrefix=Hello" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
+```
+
+Read settings in PowerShell with `$env:GreetingPrefix`.
+
+## Module Dependencies
+
+Use managed dependencies. Declare modules in `requirements.psd1` and enable `managedDependency` in `host.json`:
+
+```powershell
+@{
+    'Az.Accounts' = '2.*'
+}
+```
+
+The runtime downloads them from the PowerShell Gallery on startup.
+
+## Verification
+
+```bash
+az functionapp config appsettings list \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --output table
+```
+
+Confirm `GreetingPrefix` appears with the expected value.
+
+## Next Steps
+
+With configuration in place, wire up observability.
+
+> **Next:** [04 - Logging & Monitoring](04-logging-monitoring.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Dedicated (App Service) plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/04-logging-monitoring.md
@@ -1,0 +1,93 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 04 - Logging & Monitoring (Dedicated)
+
+Configure Application Insights and structured logging for your Dedicated (App Service Plan) PowerShell app.
+
+## Enable Application Insights
+
+```bash
+az monitor app-insights component create \
+  --app func-ps-demo-ai \
+  --location $LOCATION \
+  --resource-group $RG
+
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
+```
+
+## Logging in PowerShell
+
+Use the standard streams — they flow to Application Insights automatically:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+Write-Information "Processing request for $($Request.Query.Name)"
+Write-Warning "Name was empty; using default"
+Write-Error "Downstream call failed"
+```
+
+| Cmdlet | Severity |
+|--------|----------|
+| `Write-Information` / `Write-Host` | Information |
+| `Write-Warning` | Warning |
+| `Write-Error` | Error |
+
+## Stream Live Logs
+
+```bash
+az functionapp log tail --name $APP_NAME --resource-group $RG
+```
+
+## Verification
+
+Invoke the function, then query Application Insights:
+
+```kusto
+traces
+| where timestamp > ago(15m)
+| order by timestamp desc
+```
+
+You should see your `Write-Information` messages.
+
+## Next Steps
+
+Codify the whole environment as Infrastructure as Code.
+
+> **Next:** [05 - Infrastructure as Code](05-infrastructure-as-code.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Dedicated (App Service) plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/05-infrastructure-as-code.md
@@ -1,0 +1,90 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 05 - Infrastructure as Code (Dedicated)
+
+Define your Dedicated (App Service Plan) PowerShell app in Bicep for reproducible deployments.
+
+## Bicep Template
+
+```bicep
+param appName string
+param location string = resourceGroup().location
+param storageName string
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+}
+
+resource app 'Microsoft.Web/sites@2023-12-01' = {
+  name: appName
+  location: location
+  kind: 'functionapp,linux'
+  properties: {
+    siteConfig: {
+      appSettings: [
+        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'powershell' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME_VERSION', value: '7.4' }
+      ]
+    }
+  }
+}
+```
+
+## Deploy
+
+```bash
+az deployment group create \
+  --resource-group $RG \
+  --template-file infra/main.bicep \
+  --parameters appName=$APP_NAME storageName=$STORAGE_NAME
+```
+
+## Verification
+
+```bash
+az deployment group show --resource-group $RG --name main --query properties.provisioningState
+```
+
+Returns `Succeeded`.
+
+## Next Steps
+
+Automate the build and deploy with CI/CD.
+
+> **Next:** [06 - CI/CD](06-ci-cd.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Dedicated (App Service) plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/dedicated/06-ci-cd.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/06-ci-cd.md
@@ -1,0 +1,79 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 06 - CI/CD (Dedicated)
+
+Automate build and deployment of your Dedicated (App Service Plan) PowerShell app with GitHub Actions.
+
+## Workflow
+
+```yaml
+name: deploy-powershell-functions
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bundle PowerShell modules
+        shell: pwsh
+        run: |
+          Save-Module -Name Az.Accounts -Path ./Modules
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Azure Functions
+        uses: Azure/functions-action@v1
+        with:
+          app-name: func-ps-demo
+          package: .
+```
+
+## Verification
+
+Push to `main` and confirm the workflow completes green in the Actions tab, then curl the deployed endpoint.
+
+## Next Steps
+
+Extend beyond HTTP with additional trigger types.
+
+> **Next:** [07 - Extending with Triggers](07-extending-triggers.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Dedicated (App Service) plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/dedicated/07-extending-triggers.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/07-extending-triggers.md
@@ -1,0 +1,117 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 07 - Extending with Triggers (Dedicated)
+
+Add Timer, Queue, and Blob triggers to your Dedicated (App Service Plan) PowerShell app. PowerShell uses the classic `function.json` binding model.
+
+## Timer Trigger
+
+`TimerExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */5 * * * *"
+    }
+  ]
+}
+```
+
+`TimerExample/run.ps1`:
+
+```powershell
+param($Timer)
+Write-Information "Timer fired at $(Get-Date -Format o)"
+```
+
+## Queue Trigger
+
+`QueueExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "QueueItem",
+      "type": "queueTrigger",
+      "direction": "in",
+      "queueName": "work-items",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+```powershell
+param($QueueItem, $TriggerMetadata)
+Write-Information "Dequeued: $QueueItem"
+```
+
+## Blob Trigger
+
+`BlobExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "InputBlob",
+      "type": "blobTrigger",
+      "direction": "in",
+      "path": "uploads/{name}",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+```powershell
+param($InputBlob, $TriggerMetadata)
+Write-Information "Blob $($TriggerMetadata.name) is $($InputBlob.Length) bytes"
+```
+
+## Verification
+
+Deploy, then drop a message on the `work-items` queue or upload a blob to `uploads/`. Confirm the invocation appears in `az functionapp log tail`.
+
+## Next Steps
+
+Explore the [Recipes Index](../../recipes/index.md) for reusable binding patterns.
+
+> **Next:** [Recipes Index](../../recipes/index.md) — reusable PowerShell trigger and binding patterns.
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Dedicated (App Service) plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/flex-consumption/01-local-run.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/01-local-run.md
@@ -1,0 +1,123 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 01 - Run Locally (Flex Consumption)
+
+Scaffold and run a PowerShell Azure Functions app locally before deploying to the Flex Consumption (FC1) plan.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| PowerShell | 7.4+ | Local runtime matching the worker |
+| Azure Functions Core Tools | v4 | Start the local host and publish |
+| Azure CLI | 2.61+ | Provision and configure Azure resources |
+| Azurite (optional) | latest | Local Storage emulator for triggers |
+
+!!! info "Flex Consumption (FC1) basics"
+    Flex Consumption (FC1) is scale-to-zero with VNet integration and configurable instance memory. PowerShell runs on version 7.4 on this plan.
+
+## What You'll Build
+
+You will scaffold a PowerShell function app with an anonymous HTTP trigger, run it on the local Functions host, and verify the endpoint responds.
+
+## Steps
+
+### Step 1 - Scaffold the project
+
+```bash
+func init MyPsApp --powershell
+cd MyPsApp
+func new --name HttpExample --template "HTTP trigger" --authlevel anonymous
+```
+
+### Step 2 - Configure local settings
+
+`local.settings.json`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "powershell",
+    "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.4"
+  }
+}
+```
+
+### Step 3 - Review the function
+
+`HttpExample/run.ps1`:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+$name = $Request.Query.Name
+if (-not $name) { $name = $Request.Body.Name }
+
+$body = if ($name) { "Hello, $name." } else { "Pass a name in the query string or body." }
+
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = $body
+})
+```
+
+### Step 4 - Start the host
+
+```bash
+func host start
+```
+
+### Step 5 - Call the endpoint
+
+```bash
+curl "http://localhost:7071/api/HttpExample?name=Azure"
+```
+
+## Verification
+
+```text
+Functions:
+    HttpExample: [GET,POST] http://localhost:7071/api/HttpExample
+```
+
+The curl call returns `Hello, Azure.`
+
+## Next Steps
+
+You now have local parity and can deploy to Flex Consumption (FC1).
+
+> **Next:** [02 - First Deploy](02-first-deploy.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/02-first-deploy.md
@@ -1,0 +1,100 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 02 - First Deploy (Flex Consumption)
+
+Provision a Flex Consumption (FC1) function app and deploy the PowerShell project you built in step 01.
+
+## Prerequisites
+
+- Completed [01 - Run Locally](01-local-run.md)
+- Signed in with `az login`
+
+## Steps
+
+### Step 1 - Set variables
+
+```bash
+RG=rg-functions-demo
+APP_NAME=func-ps-demo
+STORAGE_NAME=stpsdemo$RANDOM
+LOCATION=koreacentral
+
+```
+
+### Step 2 - Create the resource group and storage
+
+```bash
+az group create --name $RG --location $LOCATION
+
+az storage account create \
+  --name $STORAGE_NAME \
+  --resource-group $RG \
+  --location $LOCATION \
+  --sku Standard_LRS
+```
+
+
+### Step 3 - Create the function app
+
+```bash
+az functionapp create \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --storage-account $STORAGE_NAME \
+  --flexconsumption-location $LOCATION \
+  --runtime powershell \
+  --runtime-version 7.4 \
+  --functions-version 4
+```
+
+### Step 4 - Deploy the code
+
+```bash
+func azure functionapp publish $APP_NAME
+```
+
+## Verification
+
+```bash
+curl "https://$APP_NAME.azurewebsites.net/api/HttpExample?name=Azure"
+```
+
+Returns `Hello, Azure.`
+
+## Next Steps
+
+Your app is live. Next, manage its configuration and secrets.
+
+> **Next:** [03 - Configuration](03-configuration.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/03-configuration.md
@@ -1,0 +1,75 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 03 - Configuration (Flex Consumption)
+
+Manage app settings, connection strings, and PowerShell module dependencies for your Flex Consumption (FC1) app.
+
+## App Settings
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "GreetingPrefix=Hello" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
+```
+
+Read settings in PowerShell with `$env:GreetingPrefix`.
+
+## Module Dependencies
+
+Managed dependencies are **not** supported on Flex Consumption. Bundle modules into a `Modules` folder before publishing:
+
+```bash
+pwsh -c "Save-Module -Name Az.Accounts -Path ./Modules"
+```
+
+The `Modules` folder is added to `$env:PSModulePath` for autoloading.
+
+## Verification
+
+```bash
+az functionapp config appsettings list \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --output table
+```
+
+Confirm `GreetingPrefix` appears with the expected value.
+
+## Next Steps
+
+With configuration in place, wire up observability.
+
+> **Next:** [04 - Logging & Monitoring](04-logging-monitoring.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/04-logging-monitoring.md
@@ -1,0 +1,93 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 04 - Logging & Monitoring (Flex Consumption)
+
+Configure Application Insights and structured logging for your Flex Consumption (FC1) PowerShell app.
+
+## Enable Application Insights
+
+```bash
+az monitor app-insights component create \
+  --app func-ps-demo-ai \
+  --location $LOCATION \
+  --resource-group $RG
+
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
+```
+
+## Logging in PowerShell
+
+Use the standard streams — they flow to Application Insights automatically:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+Write-Information "Processing request for $($Request.Query.Name)"
+Write-Warning "Name was empty; using default"
+Write-Error "Downstream call failed"
+```
+
+| Cmdlet | Severity |
+|--------|----------|
+| `Write-Information` / `Write-Host` | Information |
+| `Write-Warning` | Warning |
+| `Write-Error` | Error |
+
+## Stream Live Logs
+
+```bash
+az functionapp log tail --name $APP_NAME --resource-group $RG
+```
+
+## Verification
+
+Invoke the function, then query Application Insights:
+
+```kusto
+traces
+| where timestamp > ago(15m)
+| order by timestamp desc
+```
+
+You should see your `Write-Information` messages.
+
+## Next Steps
+
+Codify the whole environment as Infrastructure as Code.
+
+> **Next:** [05 - Infrastructure as Code](05-infrastructure-as-code.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -1,0 +1,90 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 05 - Infrastructure as Code (Flex Consumption)
+
+Define your Flex Consumption (FC1) PowerShell app in Bicep for reproducible deployments.
+
+## Bicep Template
+
+```bicep
+param appName string
+param location string = resourceGroup().location
+param storageName string
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+}
+
+resource app 'Microsoft.Web/sites@2023-12-01' = {
+  name: appName
+  location: location
+  kind: 'functionapp,linux'
+  properties: {
+    siteConfig: {
+      appSettings: [
+        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'powershell' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME_VERSION', value: '7.4' }
+      ]
+    }
+  }
+}
+```
+
+## Deploy
+
+```bash
+az deployment group create \
+  --resource-group $RG \
+  --template-file infra/main.bicep \
+  --parameters appName=$APP_NAME storageName=$STORAGE_NAME
+```
+
+## Verification
+
+```bash
+az deployment group show --resource-group $RG --name main --query properties.provisioningState
+```
+
+Returns `Succeeded`.
+
+## Next Steps
+
+Automate the build and deploy with CI/CD.
+
+> **Next:** [06 - CI/CD](06-ci-cd.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/flex-consumption/06-ci-cd.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/06-ci-cd.md
@@ -1,0 +1,79 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 06 - CI/CD (Flex Consumption)
+
+Automate build and deployment of your Flex Consumption (FC1) PowerShell app with GitHub Actions.
+
+## Workflow
+
+```yaml
+name: deploy-powershell-functions
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bundle PowerShell modules
+        shell: pwsh
+        run: |
+          Save-Module -Name Az.Accounts -Path ./Modules
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Azure Functions
+        uses: Azure/functions-action@v1
+        with:
+          app-name: func-ps-demo
+          package: .
+```
+
+## Verification
+
+Push to `main` and confirm the workflow completes green in the Actions tab, then curl the deployed endpoint.
+
+## Next Steps
+
+Extend beyond HTTP with additional trigger types.
+
+> **Next:** [07 - Extending with Triggers](07-extending-triggers.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/flex-consumption/07-extending-triggers.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/07-extending-triggers.md
@@ -1,0 +1,117 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 07 - Extending with Triggers (Flex Consumption)
+
+Add Timer, Queue, and Blob triggers to your Flex Consumption (FC1) PowerShell app. PowerShell uses the classic `function.json` binding model.
+
+## Timer Trigger
+
+`TimerExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */5 * * * *"
+    }
+  ]
+}
+```
+
+`TimerExample/run.ps1`:
+
+```powershell
+param($Timer)
+Write-Information "Timer fired at $(Get-Date -Format o)"
+```
+
+## Queue Trigger
+
+`QueueExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "QueueItem",
+      "type": "queueTrigger",
+      "direction": "in",
+      "queueName": "work-items",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+```powershell
+param($QueueItem, $TriggerMetadata)
+Write-Information "Dequeued: $QueueItem"
+```
+
+## Blob Trigger
+
+`BlobExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "InputBlob",
+      "type": "blobTrigger",
+      "direction": "in",
+      "path": "uploads/{name}",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+```powershell
+param($InputBlob, $TriggerMetadata)
+Write-Information "Blob $($TriggerMetadata.name) is $($InputBlob.Length) bytes"
+```
+
+## Verification
+
+Deploy, then drop a message on the `work-items` queue or upload a blob to `uploads/`. Confirm the invocation appears in `az functionapp log tail`.
+
+## Next Steps
+
+Explore the [Recipes Index](../../recipes/index.md) for reusable binding patterns.
+
+> **Next:** [Recipes Index](../../recipes/index.md) — reusable PowerShell trigger and binding patterns.
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/index.md
+++ b/docs/language-guides/powershell/tutorial/index.md
@@ -1,0 +1,159 @@
+---
+content_sources:
+  diagrams:
+    - id: which-plan-should-i-start-with
+      type: flowchart
+      source: self-generated
+      justification: Flow view of the PowerShell hosting plan decision, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+        - https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - id: powershell-plan-tracks
+      type: flowchart
+      source: self-generated
+      justification: Flow view of the shared seven-step journey across all PowerShell tutorial tracks, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Tutorial — Choose Your Hosting Plan
+
+This tutorial section provides **four independent, step-by-step tracks** — one for each Azure Functions hosting plan. Every track covers the same seven topics so you can follow the complete journey from local development to production on whichever plan fits your PowerShell workload.
+
+## Which Plan Should I Start With?
+
+<!-- diagram-id: which-plan-should-i-start-with -->
+```mermaid
+flowchart TD
+    Start["I need to run PowerShell on Azure Functions"] --> Q1{"Need VNet / private networking?"}
+
+    Q1 -->|No| Q2{"Predictable monthly cost?"}
+    Q1 -->|Yes| Q3{"Scale to zero when idle?"}
+
+    Q2 -->|"Pay only when running"| CONS["Consumption (Y1)"]
+    Q2 -->|"Fixed monthly budget"| DEDI["Dedicated (App Service)"]
+
+    Q3 -->|Yes| FLEX["Flex Consumption (FC1)"]
+    Q3 -->|"No — always warm"| Q4{"Need deployment slots?"}
+
+    Q4 -->|Yes| PREM["Premium (EP)"]
+    Q4 -->|No| FLEX
+
+    style CONS fill:#0078d4,color:#fff
+    style FLEX fill:#107c10,color:#fff
+    style PREM fill:#ff8c00,color:#fff
+    style DEDI fill:#5c2d91,color:#fff
+```
+
+> **Not sure yet?** Start with **Flex Consumption** — it offers scale-to-zero with VNet integration and is Microsoft's recommended default for new projects. PowerShell 7.4 runs on Flex Consumption (Linux).
+
+## Plan Comparison at a Glance
+
+| Feature | Consumption (Y1) | Flex Consumption (FC1) | Premium (EP) | Dedicated (ASP) |
+|---------|:-----------------:|:----------------------:|:------------:|:----------------:|
+| **Scale to zero** | ✅ | ✅ | ❌ (min 1 instance) | ❌ |
+| **VNet integration** | ❌ | ✅ | ✅ | ✅ (Standard+) |
+| **Deployment slots** | ✅ (Windows only) | ❌ | ✅ | ✅ (Standard+) |
+| **Default timeout** | 5 min | 30 min | 30 min | 30 min |
+| **PowerShell version** | 7.4 | 7.4 | 7.4 (7.6 preview, Windows) | 7.4 (7.6 preview, Windows) |
+| **Managed dependencies** | ✅ | ❌ (bundle `Modules`) | ✅ | ✅ |
+| **OS** | Windows / Linux | Linux only | Windows / Linux | Windows / Linux |
+
+!!! warning "Managed dependencies on Flex Consumption"
+    The `requirements.psd1` managed dependency feature is **not** supported on Flex Consumption. Bundle modules in a `Modules` folder instead. See [PowerShell Runtime](../powershell-runtime.md#dependency-management).
+
+## Tutorial Tracks
+
+Each track contains the same seven steps. Pick your plan and follow from start to finish.
+
+<!-- diagram-id: powershell-plan-tracks -->
+```mermaid
+flowchart TD
+    A[01 Run Locally] --> B[02 First Deploy]
+    B --> C[03 Configuration]
+    C --> D[04 Logging & Monitoring]
+    D --> E[05 Infrastructure as Code]
+    E --> F[06 CI/CD]
+    F --> G[07 Extending with Triggers]
+```
+
+### ☁️ [Consumption (Y1)](consumption/01-local-run.md)
+
+Classic serverless — pay only when your functions execute. Best for lightweight, event-driven workloads that don't need VNet access.
+
+| Step | Topic |
+|------|-------|
+| 01 | [Run Locally](consumption/01-local-run.md) |
+| 02 | [First Deploy](consumption/02-first-deploy.md) |
+| 03 | [Configuration](consumption/03-configuration.md) |
+| 04 | [Logging & Monitoring](consumption/04-logging-monitoring.md) |
+| 05 | [Infrastructure as Code](consumption/05-infrastructure-as-code.md) |
+| 06 | [CI/CD](consumption/06-ci-cd.md) |
+| 07 | [Extending with Triggers](consumption/07-extending-triggers.md) |
+
+### ⚡ [Flex Consumption (FC1)](flex-consumption/01-local-run.md)
+
+Next-generation serverless — scale-to-zero with VNet integration. Microsoft's recommended default for new projects. PowerShell 7.4 on Linux.
+
+| Step | Topic |
+|------|-------|
+| 01 | [Run Locally](flex-consumption/01-local-run.md) |
+| 02 | [First Deploy](flex-consumption/02-first-deploy.md) |
+| 03 | [Configuration](flex-consumption/03-configuration.md) |
+| 04 | [Logging & Monitoring](flex-consumption/04-logging-monitoring.md) |
+| 05 | [Infrastructure as Code](flex-consumption/05-infrastructure-as-code.md) |
+| 06 | [CI/CD](flex-consumption/06-ci-cd.md) |
+| 07 | [Extending with Triggers](flex-consumption/07-extending-triggers.md) |
+
+### 🚀 [Premium (EP)](premium/01-local-run.md)
+
+Always-warm instances with VNet support and deployment slots. Best for latency-sensitive workloads or long-running functions.
+
+| Step | Topic |
+|------|-------|
+| 01 | [Run Locally](premium/01-local-run.md) |
+| 02 | [First Deploy](premium/02-first-deploy.md) |
+| 03 | [Configuration](premium/03-configuration.md) |
+| 04 | [Logging & Monitoring](premium/04-logging-monitoring.md) |
+| 05 | [Infrastructure as Code](premium/05-infrastructure-as-code.md) |
+| 06 | [CI/CD](premium/06-ci-cd.md) |
+| 07 | [Extending with Triggers](premium/07-extending-triggers.md) |
+
+### 🖥️ [Dedicated (App Service Plan)](dedicated/01-local-run.md)
+
+Traditional App Service hosting with predictable pricing. Best when you already have an App Service Plan with spare capacity.
+
+| Step | Topic |
+|------|-------|
+| 01 | [Run Locally](dedicated/01-local-run.md) |
+| 02 | [First Deploy](dedicated/02-first-deploy.md) |
+| 03 | [Configuration](dedicated/03-configuration.md) |
+| 04 | [Logging & Monitoring](dedicated/04-logging-monitoring.md) |
+| 05 | [Infrastructure as Code](dedicated/05-infrastructure-as-code.md) |
+| 06 | [CI/CD](dedicated/06-ci-cd.md) |
+| 07 | [Extending with Triggers](dedicated/07-extending-triggers.md) |
+
+## What Each Step Covers
+
+| Step | Topic | You Will Learn |
+|------|-------|----------------|
+| 01 | **Run Locally** | Scaffold a PowerShell app, run with Core Tools, test endpoints |
+| 02 | **First Deploy** | Provision Azure resources and deploy your first function app |
+| 03 | **Configuration** | Manage app settings, connection strings, and module dependencies |
+| 04 | **Logging & Monitoring** | Configure Application Insights and structured logging |
+| 05 | **Infrastructure as Code** | Define all resources in Bicep, deploy reproducibly |
+| 06 | **CI/CD** | Automate build and deploy with GitHub Actions |
+| 07 | **Extending with Triggers** | Add Timer, Queue, and Blob triggers beyond HTTP |
+
+## See Also
+
+- [PowerShell Language Guide](../index.md)
+- [Scaling and Plans](../../../platform/scaling.md)
+- [Networking](../../../platform/networking.md)
+
+## Sources
+
+- [Azure Functions hosting options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/tutorial/premium/01-local-run.md
+++ b/docs/language-guides/powershell/tutorial/premium/01-local-run.md
@@ -1,0 +1,123 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 01 - Run Locally (Premium)
+
+Scaffold and run a PowerShell Azure Functions app locally before deploying to the Premium (EP1) plan.
+
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| PowerShell | 7.4+ | Local runtime matching the worker |
+| Azure Functions Core Tools | v4 | Start the local host and publish |
+| Azure CLI | 2.61+ | Provision and configure Azure resources |
+| Azurite (optional) | latest | Local Storage emulator for triggers |
+
+!!! info "Premium (EP1) basics"
+    Premium (EP1) is pre-warmed instances that eliminate cold start, with VNet and slots. PowerShell runs on version 7.4 on this plan.
+
+## What You'll Build
+
+You will scaffold a PowerShell function app with an anonymous HTTP trigger, run it on the local Functions host, and verify the endpoint responds.
+
+## Steps
+
+### Step 1 - Scaffold the project
+
+```bash
+func init MyPsApp --powershell
+cd MyPsApp
+func new --name HttpExample --template "HTTP trigger" --authlevel anonymous
+```
+
+### Step 2 - Configure local settings
+
+`local.settings.json`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "powershell",
+    "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.4"
+  }
+}
+```
+
+### Step 3 - Review the function
+
+`HttpExample/run.ps1`:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+$name = $Request.Query.Name
+if (-not $name) { $name = $Request.Body.Name }
+
+$body = if ($name) { "Hello, $name." } else { "Pass a name in the query string or body." }
+
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = $body
+})
+```
+
+### Step 4 - Start the host
+
+```bash
+func host start
+```
+
+### Step 5 - Call the endpoint
+
+```bash
+curl "http://localhost:7071/api/HttpExample?name=Azure"
+```
+
+## Verification
+
+```text
+Functions:
+    HttpExample: [GET,POST] http://localhost:7071/api/HttpExample
+```
+
+The curl call returns `Hello, Azure.`
+
+## Next Steps
+
+You now have local parity and can deploy to Premium (EP1).
+
+> **Next:** [02 - First Deploy](02-first-deploy.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/powershell/tutorial/premium/02-first-deploy.md
@@ -1,0 +1,110 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 02 - First Deploy (Premium)
+
+Provision a Premium (EP1) function app and deploy the PowerShell project you built in step 01.
+
+## Prerequisites
+
+- Completed [01 - Run Locally](01-local-run.md)
+- Signed in with `az login`
+
+## Steps
+
+### Step 1 - Set variables
+
+```bash
+RG=rg-functions-demo
+APP_NAME=func-ps-demo
+STORAGE_NAME=stpsdemo$RANDOM
+LOCATION=koreacentral
+PLAN_NAME=plan-ps-demo
+```
+
+### Step 2 - Create the resource group and storage
+
+```bash
+az group create --name $RG --location $LOCATION
+
+az storage account create \
+  --name $STORAGE_NAME \
+  --resource-group $RG \
+  --location $LOCATION \
+  --sku Standard_LRS
+```
+
+### Step 2b - Create the hosting plan
+
+```bash
+az functionapp plan create \
+  --name $PLAN_NAME \
+  --resource-group $RG \
+  --location $LOCATION \
+  --sku EP1 \
+  --is-linux
+```
+
+### Step 3 - Create the function app
+
+```bash
+az functionapp create \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --storage-account $STORAGE_NAME \
+  --plan $PLAN_NAME \
+  --runtime powershell \
+  --runtime-version 7.4 \
+  --functions-version 4
+```
+
+### Step 4 - Deploy the code
+
+```bash
+func azure functionapp publish $APP_NAME
+```
+
+## Verification
+
+```bash
+curl "https://$APP_NAME.azurewebsites.net/api/HttpExample?name=Azure"
+```
+
+Returns `Hello, Azure.`
+
+## Next Steps
+
+Your app is live. Next, manage its configuration and secrets.
+
+> **Next:** [03 - Configuration](03-configuration.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/powershell/tutorial/premium/03-configuration.md
@@ -1,0 +1,77 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 03 - Configuration (Premium)
+
+Manage app settings, connection strings, and PowerShell module dependencies for your Premium (EP1) app.
+
+## App Settings
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "GreetingPrefix=Hello" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
+```
+
+Read settings in PowerShell with `$env:GreetingPrefix`.
+
+## Module Dependencies
+
+Use managed dependencies. Declare modules in `requirements.psd1` and enable `managedDependency` in `host.json`:
+
+```powershell
+@{
+    'Az.Accounts' = '2.*'
+}
+```
+
+The runtime downloads them from the PowerShell Gallery on startup.
+
+## Verification
+
+```bash
+az functionapp config appsettings list \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --output table
+```
+
+Confirm `GreetingPrefix` appears with the expected value.
+
+## Next Steps
+
+With configuration in place, wire up observability.
+
+> **Next:** [04 - Logging & Monitoring](04-logging-monitoring.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/powershell/tutorial/premium/04-logging-monitoring.md
@@ -1,0 +1,93 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 04 - Logging & Monitoring (Premium)
+
+Configure Application Insights and structured logging for your Premium (EP1) PowerShell app.
+
+## Enable Application Insights
+
+```bash
+az monitor app-insights component create \
+  --app func-ps-demo-ai \
+  --location $LOCATION \
+  --resource-group $RG
+
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
+```
+
+## Logging in PowerShell
+
+Use the standard streams — they flow to Application Insights automatically:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+Write-Information "Processing request for $($Request.Query.Name)"
+Write-Warning "Name was empty; using default"
+Write-Error "Downstream call failed"
+```
+
+| Cmdlet | Severity |
+|--------|----------|
+| `Write-Information` / `Write-Host` | Information |
+| `Write-Warning` | Warning |
+| `Write-Error` | Error |
+
+## Stream Live Logs
+
+```bash
+az functionapp log tail --name $APP_NAME --resource-group $RG
+```
+
+## Verification
+
+Invoke the function, then query Application Insights:
+
+```kusto
+traces
+| where timestamp > ago(15m)
+| order by timestamp desc
+```
+
+You should see your `Write-Information` messages.
+
+## Next Steps
+
+Codify the whole environment as Infrastructure as Code.
+
+> **Next:** [05 - Infrastructure as Code](05-infrastructure-as-code.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/powershell/tutorial/premium/05-infrastructure-as-code.md
@@ -1,0 +1,90 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 05 - Infrastructure as Code (Premium)
+
+Define your Premium (EP1) PowerShell app in Bicep for reproducible deployments.
+
+## Bicep Template
+
+```bicep
+param appName string
+param location string = resourceGroup().location
+param storageName string
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageName
+  location: location
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+}
+
+resource app 'Microsoft.Web/sites@2023-12-01' = {
+  name: appName
+  location: location
+  kind: 'functionapp,linux'
+  properties: {
+    siteConfig: {
+      appSettings: [
+        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'powershell' }
+        { name: 'FUNCTIONS_WORKER_RUNTIME_VERSION', value: '7.4' }
+      ]
+    }
+  }
+}
+```
+
+## Deploy
+
+```bash
+az deployment group create \
+  --resource-group $RG \
+  --template-file infra/main.bicep \
+  --parameters appName=$APP_NAME storageName=$STORAGE_NAME
+```
+
+## Verification
+
+```bash
+az deployment group show --resource-group $RG --name main --query properties.provisioningState
+```
+
+Returns `Succeeded`.
+
+## Next Steps
+
+Automate the build and deploy with CI/CD.
+
+> **Next:** [06 - CI/CD](06-ci-cd.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/premium/06-ci-cd.md
+++ b/docs/language-guides/powershell/tutorial/premium/06-ci-cd.md
@@ -1,0 +1,79 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 06 - CI/CD (Premium)
+
+Automate build and deployment of your Premium (EP1) PowerShell app with GitHub Actions.
+
+## Workflow
+
+```yaml
+name: deploy-powershell-functions
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bundle PowerShell modules
+        shell: pwsh
+        run: |
+          Save-Module -Name Az.Accounts -Path ./Modules
+
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy to Azure Functions
+        uses: Azure/functions-action@v1
+        with:
+          app-name: func-ps-demo
+          package: .
+```
+
+## Verification
+
+Push to `main` and confirm the workflow completes green in the Actions tab, then curl the deployed endpoint.
+
+## Next Steps
+
+Extend beyond HTTP with additional trigger types.
+
+> **Next:** [07 - Extending with Triggers](07-extending-triggers.md)
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/powershell/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/powershell/tutorial/premium/07-extending-triggers.md
@@ -1,0 +1,117 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    cli_version:
+    core_tools_version:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 07 - Extending with Triggers (Premium)
+
+Add Timer, Queue, and Blob triggers to your Premium (EP1) PowerShell app. PowerShell uses the classic `function.json` binding model.
+
+## Timer Trigger
+
+`TimerExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */5 * * * *"
+    }
+  ]
+}
+```
+
+`TimerExample/run.ps1`:
+
+```powershell
+param($Timer)
+Write-Information "Timer fired at $(Get-Date -Format o)"
+```
+
+## Queue Trigger
+
+`QueueExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "QueueItem",
+      "type": "queueTrigger",
+      "direction": "in",
+      "queueName": "work-items",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+```powershell
+param($QueueItem, $TriggerMetadata)
+Write-Information "Dequeued: $QueueItem"
+```
+
+## Blob Trigger
+
+`BlobExample/function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "InputBlob",
+      "type": "blobTrigger",
+      "direction": "in",
+      "path": "uploads/{name}",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+```powershell
+param($InputBlob, $TriggerMetadata)
+Write-Information "Blob $($TriggerMetadata.name) is $($InputBlob.Length) bytes"
+```
+
+## Verification
+
+Deploy, then drop a message on the `work-items` queue or upload a blob to `uploads/`. Confirm the invocation appears in `az functionapp log tail`.
+
+## Next Steps
+
+Explore the [Recipes Index](../../recipes/index.md) for reusable binding patterns.
+
+> **Next:** [Recipes Index](../../recipes/index.md) — reusable PowerShell trigger and binding patterns.
+
+
+## See Also
+
+- [Tutorial Overview & Plan Chooser](../index.md)
+- [PowerShell Language Guide](../../index.md)
+- [Platform: Hosting Plans](../../../../platform/hosting.md)
+- [Operations: Deployment](../../../../operations/deployment.md)
+- [Recipes Index](../../recipes/index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Azure Functions Premium plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-premium-plan)
+- [Run Functions locally with Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)

--- a/docs/language-guides/python/recipes/dependency-injection.md
+++ b/docs/language-guides/python/recipes/dependency-injection.md
@@ -1,0 +1,112 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+        - https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections
+---
+# Dependency Injection
+
+The Python v2 programming model does not provide a dependency injection (DI) container. Functions are plain Python callables decorated with triggers, so there is no constructor to inject into. The idiomatic pattern is to create heavyweight clients once at module scope and reuse them across invocations. Because a single worker process serves many invocations, module-level globals give you the same connection-reuse benefit that a singleton-scoped DI registration would provide in other runtimes.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    LOAD[Module import] --> INIT[Create client at module scope]
+    INIT --> POOL[Client holds connection pool]
+    TRIG[Trigger invocation] --> FUNC[Function callable]
+    FUNC --> POOL
+    POOL --> REUSE[Connections reused across invocations]
+```
+
+## Why Module-Level Clients
+
+The worker imports your `function_app.py` once and then calls your functions repeatedly. Creating an Azure SDK client inside the function body reconstructs the connection pool and re-authenticates on every request, which increases latency and can exhaust outbound connections under load. Creating the client at module scope initializes it once per worker.
+
+```python
+import azure.functions as func
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient
+import os
+
+# Created once when the worker imports this module.
+_credential = DefaultAzureCredential()
+_blob_service = BlobServiceClient(
+    account_url=os.environ["STORAGE__blobServiceUri"],
+    credential=_credential,
+)
+
+app = func.FunctionApp()
+
+
+@app.route(route="upload", auth_level=func.AuthLevel.FUNCTION)
+def upload(req: func.HttpRequest) -> func.HttpResponse:
+    container = _blob_service.get_container_client("uploads")
+    container.upload_blob(name=req.headers["x-id"], data=req.get_body())
+    return func.HttpResponse(status_code=202)
+```
+
+## Lazy Initialization
+
+If the client is expensive and not every function needs it, initialize it lazily on first use. Guard construction so concurrent async invocations do not each build a client.
+
+```python
+_lock = threading.Lock()
+_client = None
+
+
+def get_client() -> BlobServiceClient:
+    global _client
+    if _client is None:
+        with _lock:
+            if _client is None:
+                _client = BlobServiceClient(
+                    account_url=os.environ["STORAGE__blobServiceUri"],
+                    credential=DefaultAzureCredential(),
+                )
+    return _client
+```
+
+## Passing Dependencies to Business Logic
+
+Keep business logic in plain functions or classes that accept their dependencies as arguments. This keeps the logic testable — a unit test constructs the class with a fake client — while the trigger function performs the wiring.
+
+```python
+class OrderService:
+    def __init__(self, blob_service: BlobServiceClient) -> None:
+        self._blob = blob_service
+
+    def submit(self, order_id: str, payload: bytes) -> None:
+        self._blob.get_container_client("orders").upload_blob(order_id, payload)
+
+
+_orders = OrderService(_blob_service)
+
+
+@app.route(route="orders/{id}", auth_level=func.AuthLevel.FUNCTION)
+def submit_order(req: func.HttpRequest) -> func.HttpResponse:
+    _orders.submit(req.route_params["id"], req.get_body())
+    return func.HttpResponse(status_code=202)
+```
+
+!!! tip "Reuse clients, not per-request state"
+    Module-level clients are shared by every concurrent invocation on the worker. Store only thread-safe, stateless clients at module scope; keep per-request data inside the function body.
+
+## See Also
+
+- [Managed Identity](managed-identity.md)
+- [Blob Storage Integration](blob-storage.md)
+
+## Sources
+
+- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Manage connections in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/manage-connections)

--- a/docs/language-guides/python/recipes/durable-advanced.md
+++ b/docs/language-guides/python/recipes/durable-advanced.md
@@ -1,0 +1,128 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of sub-orchestration composition, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations
+        - https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations
+---
+# Durable Functions: Advanced Patterns
+
+This recipe covers advanced Durable Functions patterns for Python beyond the basic chaining and fan-out/fan-in flows: sub-orchestrations, eternal orchestrations, activity retries, and safe versioning. For the fundamentals, see [Durable Orchestration](durable-orchestration.md).
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PARENT[Parent orchestrator] -->|call_sub_orchestrator| SUB1[Sub-orchestrator A]
+    PARENT -->|call_sub_orchestrator| SUB2[Sub-orchestrator B]
+    SUB1 --> ACT1[Activities]
+    SUB2 --> ACT2[Activities]
+    SUB1 --> PARENT
+    SUB2 --> PARENT
+```
+
+## Sub-Orchestrations
+
+Break a large workflow into reusable orchestrators. A parent calls a sub-orchestrator with `call_sub_orchestrator`, and can fan out over several the same way it fans out over activities.
+
+```python
+@bp.orchestration_trigger(context_name="context")
+def parent_orchestrator(context: df.DurableOrchestrationContext):
+    regions = context.get_input()["regions"]
+
+    # Fan out over sub-orchestrations, one per region.
+    tasks = [
+        context.call_sub_orchestrator("process_region", region)
+        for region in regions
+    ]
+    results = yield context.task_all(tasks)
+    return {"regions_processed": len(results), "results": results}
+
+
+@bp.orchestration_trigger(context_name="context")
+def process_region(context: df.DurableOrchestrationContext):
+    region = context.get_input()
+    validated = yield context.call_activity("validate_region", region)
+    loaded = yield context.call_activity("load_region", validated)
+    return loaded
+```
+
+## Eternal Orchestrations
+
+For a workflow that runs indefinitely (aggregators, periodic jobs), do **not** use an unbounded loop — the history would grow forever. Call `continue_as_new` to restart the orchestration with fresh state and a clean history.
+
+```python
+from datetime import timedelta
+
+@bp.orchestration_trigger(context_name="context")
+def periodic_cleanup(context: df.DurableOrchestrationContext):
+    state = context.get_input() or {"runs": 0}
+
+    yield context.call_activity("run_cleanup", state)
+    state["runs"] += 1
+
+    # Durable sleep, then restart with new state and empty history.
+    next_run = context.current_utc_datetime + timedelta(hours=1)
+    yield context.create_timer(next_run)
+    context.continue_as_new(state)
+```
+
+## Activity Retries
+
+Wrap flaky activities with a retry policy instead of hand-coding retry loops. The orchestration replays cleanly because retries are recorded in history.
+
+```python
+retry_options = df.RetryOptions(
+    first_retry_interval_in_milliseconds=5000,
+    max_number_of_attempts=3,
+)
+
+@bp.orchestration_trigger(context_name="context")
+def resilient_orchestrator(context: df.DurableOrchestrationContext):
+    order = context.get_input()
+    result = yield context.call_activity_with_retry(
+        "charge_customer", retry_options, order
+    )
+    return result
+```
+
+| Element | Explanation |
+|---|---|
+| `call_sub_orchestrator` | Invokes another orchestrator as a child; compose and fan out like activities. |
+| `continue_as_new` | Restarts the orchestration with new input and a trimmed history for eternal loops. |
+| `RetryOptions` | Declarative retry policy applied via `call_activity_with_retry`. |
+
+## Versioning
+
+Orchestrations replay from history, so changing an orchestrator's code while instances are in flight can break replay (non-determinism). Safe strategies:
+
+- **Deploy side by side**: give the changed orchestrator a new name and route new instances to it, letting existing instances drain on the old version.
+- **Do not reorder or remove** existing activity calls in a deployed orchestrator.
+- **Terminate and restart** in-flight instances if a breaking change is unavoidable.
+
+!!! warning "Determinism still applies"
+    Advanced patterns do not relax the determinism rule. Never call `datetime.now()`, generate random values, or do direct I/O inside an orchestrator — use activities and `context.current_utc_datetime`.
+
+## See Also
+
+- [Durable Orchestration](durable-orchestration.md)
+- [Durable Entities](durable-entities.md)
+- [Platform: Durable Functions](../../../platform/durable-functions.md)
+
+## Sources
+
+- [Sub-orchestrations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-sub-orchestrations)
+- [Eternal orchestrations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-eternal-orchestrations)
+- [Versioning (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning)

--- a/docs/language-guides/python/recipes/event-hub.md
+++ b/docs/language-guides/python/recipes/event-hub.md
@@ -1,0 +1,180 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger
+---
+# Event Hubs
+
+This recipe covers integrating Azure Event Hubs with Azure Functions Python v2 — consuming a high-throughput event stream with the Event Hubs trigger (single event and batch), reading event metadata, and publishing events with the output binding. Event Hubs is the standard choice for telemetry ingestion, clickstream, and log-aggregation workloads.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PROD[Event Producers] --> EH[(Event Hub Partitions)]
+    EH --> TRIG[Event Hubs Trigger]
+    TRIG --> FA[Function App]
+    FA --> DOWN[Downstream Store]
+    FA --> OUT[Event Hubs Output]
+```
+
+## Prerequisites
+
+Event Hubs bindings are included in the default extension bundle. Ensure your `host.json` references it:
+
+```json
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}
+```
+
+Provide the connection in app settings. A connection-string setting or an identity-based connection is supported. Identity-based connections use a setting prefix with `__fullyQualifiedNamespace`:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "EventHubConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$NAMESPACE` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+When using an identity-based connection, grant the function app's managed identity the **Azure Event Hubs Data Receiver** (and **Data Sender** for output) role on the namespace.
+
+## Event Hubs Trigger: Process a Single Event
+
+The trigger fires as events arrive on the hub. Each function instance owns a set of partitions and checkpoints progress automatically.
+
+```python
+import azure.functions as func
+import logging
+import json
+
+bp = func.Blueprint()
+
+@bp.event_hub_message_trigger(
+    arg_name="event",
+    event_hub_name="telemetry",
+    connection="EventHubConnection",
+    consumer_group="$Default",
+)
+def process_event(event: func.EventHubEvent) -> None:
+    """Process a single event from the hub."""
+    body = event.get_body().decode("utf-8")
+    data = json.loads(body)
+
+    logging.info("Event received: partition_key=%s sequence=%s offset=%s",
+                 event.partition_key, event.sequence_number, event.offset)
+    logging.info("Enqueued at: %s", event.enqueued_time)
+    logging.info("Payload: %s", data)
+```
+
+## Event Hubs Trigger: Batch Processing (Recommended for Throughput)
+
+Setting `cardinality="many"` delivers a batch of events per invocation, which dramatically improves throughput for high-volume streams. Design the handler to be idempotent because delivery is at-least-once.
+
+```python
+from typing import List
+
+@bp.event_hub_message_trigger(
+    arg_name="events",
+    event_hub_name="telemetry",
+    connection="EventHubConnection",
+    consumer_group="$Default",
+    cardinality="many",
+)
+def process_batch(events: List[func.EventHubEvent]) -> None:
+    """Process a batch of events in a single invocation."""
+    logging.info("Batch size: %d", len(events))
+    for event in events:
+        data = json.loads(event.get_body().decode("utf-8"))
+        # Process each event; keep this idempotent.
+        logging.info("Processing sequence=%s", event.sequence_number)
+```
+
+## Output Binding: Publish Events
+
+Use the output binding to publish one or many events downstream.
+
+```python
+@bp.route(route="publish", methods=["POST"])
+@bp.event_hub_output(
+    arg_name="out_events",
+    event_hub_name="downstream",
+    connection="EventHubConnection",
+)
+def publish(req: func.HttpRequest, out_events: func.Out[str]) -> func.HttpResponse:
+    """Publish an event to a downstream hub."""
+    try:
+        body = req.get_json()
+    except ValueError:
+        return func.HttpResponse(
+            json.dumps({"error": "Invalid JSON body"}),
+            mimetype="application/json",
+            status_code=400,
+        )
+
+    out_events.set(json.dumps(body))
+    return func.HttpResponse(
+        json.dumps({"status": "published"}),
+        mimetype="application/json",
+        status_code=202,
+    )
+```
+
+## Host Configuration and Checkpointing
+
+Tune batch size and checkpoint frequency in `host.json`:
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "eventHubs": {
+      "maxEventBatchSize": 100,
+      "batchCheckpointFrequency": 1,
+      "prefetchCount": 300
+    }
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `maxEventBatchSize` | 100 | Maximum number of events delivered per batch invocation |
+| `batchCheckpointFrequency` | 1 | Number of batches processed before a checkpoint is written |
+| `prefetchCount` | 300 | Number of events the underlying client prefetches |
+
+!!! note "Checkpointing"
+    The Event Hubs extension checkpoints progress to the storage account referenced by `AzureWebJobsStorage`. A higher `batchCheckpointFrequency` reduces storage writes but increases the volume of events reprocessed after a restart.
+
+## See Also
+
+- [Queue Storage](queue.md)
+- [Managed Identity Recipe](managed-identity.md)
+
+## Sources
+
+- [Azure Event Hubs bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs)
+- [Azure Event Hubs trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-trigger)
+- [Azure Event Hubs output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs-output)
+</content>

--- a/docs/language-guides/python/recipes/index.md
+++ b/docs/language-guides/python/recipes/index.md
@@ -44,6 +44,7 @@ graph TD
 |--------|-------------|
 | [HTTP API Patterns](http-api.md) | Route design, request/response patterns, and API-friendly function composition. |
 | [HTTP Authentication](http-auth.md) | Function auth levels, app-level auth, and token validation integration patterns. |
+| [OpenAPI and Swagger](openapi.md) | Documenting HTTP APIs via API Management import or a hand-authored spec plus Swagger UI. |
 
 ### Storage
 
@@ -52,6 +53,7 @@ graph TD
 | [Cosmos DB](cosmosdb.md) | Input/output patterns for Cosmos DB-backed APIs and event processing workloads. |
 | [Blob Storage](blob-storage.md) | Blob trigger and blob binding patterns, including production-oriented processing flow. |
 | [Queue Storage](queue.md) | Queue trigger consumer patterns, retries, and output binding usage. |
+| [Table Storage](table-storage.md) | Table (NoSQL key-value) input/output binding patterns for entity storage and lookups. |
 
 ### Security
 
@@ -68,7 +70,15 @@ graph TD
 | [Timer Trigger](timer.md) | Scheduled jobs, cron semantics, and idempotent batch execution patterns. |
 | [Durable Functions](durable-orchestration.md) | Orchestration, fan-out/fan-in, and stateful workflow coordination. |
 | [Durable Entities](durable-entities.md) | Stateful entity (actor-style) model for aggregation and per-key state coordination. |
+| [Durable Advanced](durable-advanced.md) | Sub-orchestrations, eternal orchestrations, activity retries, and versioning. |
 | [Event Grid](event-grid.md) | Event-driven designs and event routing patterns for reactive systems. |
+| [Event Hubs](event-hub.md) | High-throughput event stream consumption with batch trigger, metadata, and output binding. |
+| [Service Bus](service-bus.md) | Enterprise messaging with queue/topic triggers, dead-lettering, sessions, and output binding. |
+| [SignalR Service](signalr.md) | Real-time messaging to connected clients via the negotiate endpoint and output binding. |
+| [Dependency Injection](dependency-injection.md) | Sharing clients across invocations via module-level singletons (no built-in DI container). |
+| [Retry Policies](retry.md) | Runtime retry policies (fixed delay, exponential backoff) for Timer, Event Hubs, and Cosmos DB triggers. |
+| [Middleware](middleware.md) | Cross-cutting behavior via wrapper decorators (no built-in middleware pipeline). |
+| [Unit Testing](testing.md) | Host-free unit testing of handlers with pytest and mocked bindings. |
 
 ## How to consume recipes effectively
 

--- a/docs/language-guides/python/recipes/middleware.md
+++ b/docs/language-guides/python/recipes/middleware.md
@@ -1,0 +1,87 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+---
+# Middleware
+
+The Python v2 programming model has **no built-in middleware pipeline**. Unlike the .NET isolated worker or the Node.js v4 hook system, there is no runtime-provided way to wrap every function invocation. The idiomatic alternative is a plain Python decorator that you apply above the function's trigger decorator, giving you the same cross-cutting behavior — logging, timing, error handling — with standard language features.
+
+## Prerequisites
+
+- A Python v2 Function App using `azure.functions` with `app = func.FunctionApp()`.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    REQ[Trigger fires] --> DEC[Wrapper decorator: pre-logic]
+    DEC --> FUNC[Function body]
+    FUNC --> POST[Wrapper decorator: post-logic]
+    POST --> RESP[Response returned]
+```
+
+## Wrap With a Decorator
+
+Define a decorator that wraps the handler. Apply it **below** the trigger decorator so the runtime still sees the correct binding signature.
+
+```python
+import functools
+import logging
+import time
+import azure.functions as func
+
+app = func.FunctionApp()
+
+def instrument(handler):
+    @functools.wraps(handler)
+    def wrapper(req: func.HttpRequest) -> func.HttpResponse:
+        start = time.perf_counter()
+        logging.info("Starting %s", handler.__name__)
+        try:
+            response = handler(req)
+            return response
+        except Exception:
+            logging.exception("Unhandled error in %s", handler.__name__)
+            raise
+        finally:
+            elapsed = (time.perf_counter() - start) * 1000
+            logging.info("Finished %s in %.1fms", handler.__name__, elapsed)
+    return wrapper
+
+@app.route(route="orders")
+@instrument
+def create_order(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse("created", status_code=201)
+```
+
+## Sharing One Decorator Across Functions
+
+Because the decorator is an ordinary function, apply the same `@instrument` to every function that needs the behavior. For blueprint-based apps, define the decorator in a shared module and import it wherever functions are declared.
+
+| Element | Explanation |
+|---|---|
+| `functools.wraps` | Preserves the wrapped function's name and metadata for logging and introspection. |
+| Decorator order | The trigger decorator (`@app.route`) must be **above** the custom wrapper so bindings resolve correctly. |
+| `try/except/finally` | Gives pre-logic, error handling, and guaranteed post-logic in one place. |
+
+!!! note "No runtime pipeline"
+    Decorators run inside the worker as plain Python — they cannot intercept binding resolution or platform-level retries. For retry behavior, see [Retry Policies](retry.md).
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [Retry Policies](retry.md)
+
+## Sources
+
+- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)

--- a/docs/language-guides/python/recipes/openapi.md
+++ b/docs/language-guides/python/recipes/openapi.md
@@ -1,0 +1,92 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition
+---
+# OpenAPI and Swagger
+
+Unlike the .NET isolated worker, the Python v2 model has no first-class, Microsoft-supported OpenAPI extension that generates a spec from decorators. The idiomatic approaches are: (1) let Azure API Management generate the OpenAPI definition when you import your HTTP endpoints, and (2) hand-author an `openapi.json` document and serve it — plus optionally a Swagger UI — from an HTTP function.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    FUNC[HTTP trigger functions] --> APIM[API Management import]
+    APIM --> GEN[Generated OpenAPI definition]
+    SPEC[Hand-authored openapi.json] --> SERVE[HTTP function serves /openapi.json]
+    SERVE --> UI[Swagger UI page]
+```
+
+## Option 1: Generate via API Management
+
+Azure API Management can import your HTTP-triggered function endpoints and produce an OpenAPI definition. This works for function apps in any supported language, including Python. In the portal, open your function app, select **API Management**, create or link an instance, then **Link API** to import the endpoints and **Download OpenAPI definition**.
+
+This is the lowest-effort path when you already front your functions with API Management.
+
+## Option 2: Serve a Hand-Authored Spec
+
+Keep an `openapi.json` (or YAML) file in your project and serve it from an HTTP function. This gives you a versioned, source-controlled contract without a code-generation dependency.
+
+```python
+import json
+import pathlib
+import azure.functions as func
+
+app = func.FunctionApp()
+
+_SPEC = json.loads(
+    (pathlib.Path(__file__).parent / "openapi.json").read_text(encoding="utf-8")
+)
+
+
+@app.route(route="openapi.json", auth_level=func.AuthLevel.ANONYMOUS)
+def openapi(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        json.dumps(_SPEC),
+        mimetype="application/json",
+    )
+```
+
+## Serve Swagger UI
+
+Point the Swagger UI at the spec endpoint above. Serve a minimal HTML page from another HTTP function that loads Swagger UI from a CDN.
+
+```python
+_SWAGGER_HTML = """<!DOCTYPE html>
+<html>
+  <head><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css"></head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script>
+      window.onload = () => SwaggerUIBundle({ url: "/api/openapi.json", dom_id: "#swagger-ui" });
+    </script>
+  </body>
+</html>"""
+
+
+@app.route(route="docs", auth_level=func.AuthLevel.ANONYMOUS)
+def docs(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(_SWAGGER_HTML, mimetype="text/html")
+```
+
+!!! note "Keep the spec in sync"
+    Because the spec is hand-authored, it can drift from your actual routes. Add a contract test that loads `openapi.json` and asserts every documented path has a matching function route.
+
+## See Also
+
+- [HTTP API Patterns](http-api.md)
+- [HTTP Authentication](http-auth.md)
+
+## Sources
+
+- [Expose serverless APIs from HTTP endpoints using Azure API Management (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-openapi-definition)

--- a/docs/language-guides/python/recipes/retry.md
+++ b/docs/language-guides/python/recipes/retry.md
@@ -1,0 +1,100 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+---
+# Retry Policies
+
+Azure Functions runtime-enforced retry policies rerun a failed execution until it succeeds or the maximum retry count is reached. In the Python v2 model you attach a policy with the `@app.retry` decorator. Retry policies are only supported for a specific set of trigger types; other triggers rely on their own built-in retry behavior.
+
+## Supported Triggers
+
+Runtime retry policies apply only to these triggers:
+
+| Trigger | Retry source |
+|---|---|
+| Timer | Retry policies |
+| Event Hubs | Retry policies |
+| Azure Cosmos DB | Retry policies |
+| Kafka | Retry policies |
+
+Queue Storage, Blob Storage, and Service Bus triggers do **not** use retry policies — they retry through their own binding extensions (poison-queue handling, `maxDeliveryCount`, dead-lettering). HTTP triggers have no automatic retry; the caller must retry.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    EXEC[Function execution] --> ERR{Uncaught exception?}
+    ERR -->|No| DONE[Success: checkpoint/commit]
+    ERR -->|Yes| COUNT{retry_count < max?}
+    COUNT -->|Yes| WAIT[Wait per strategy] --> EXEC
+    COUNT -->|No| FAIL[Give up: execution fails]
+```
+
+## Fixed Delay
+
+A fixed amount of time elapses between each retry.
+
+```python
+import azure.functions as func
+
+app = func.FunctionApp()
+
+
+@app.timer_trigger(schedule="0 */5 * * * *", arg_name="mytimer",
+                   run_on_startup=False, use_monitor=False)
+@app.retry(strategy="fixed_delay", max_retry_count="3",
+           delay_interval="00:00:10")
+def scheduled_job(mytimer: func.TimerRequest, context: func.Context) -> None:
+    if context.retry_context.retry_count == context.retry_context.max_retry_count:
+        # Final attempt failed — log and stop retrying.
+        return
+    raise Exception("This is a retryable exception")
+```
+
+## Exponential Backoff
+
+The first retry waits the minimum interval; each subsequent retry adds time exponentially (with small randomization) up to the maximum interval.
+
+```python
+@app.timer_trigger(schedule="0 */5 * * * *", arg_name="mytimer",
+                   run_on_startup=False, use_monitor=False)
+@app.retry(strategy="exponential_backoff", max_retry_count="5",
+           minimum_interval="00:00:10", maximum_interval="00:15:00")
+def scheduled_job(mytimer: func.TimerRequest, context: func.Context) -> None:
+    raise Exception("This is a retryable exception")
+```
+
+## Policy Properties
+
+| Property | Description |
+|---|---|
+| `strategy` | Required. `fixed_delay` or `exponential_backoff`. |
+| `max_retry_count` | Required. Max retries per execution. `-1` retries indefinitely. |
+| `delay_interval` | Fixed-delay interval, format `HH:mm:ss`. |
+| `minimum_interval` | Exponential-backoff minimum delay, format `HH:mm:ss`. |
+| `maximum_interval` | Exponential-backoff maximum delay, format `HH:mm:ss`. |
+
+!!! warning "Max retry count is best-effort"
+    The retry count is stored in instance memory. If the instance fails between retries, the count is lost — Event Hubs resumes on a new instance with the count reset, while Timer does not resume. Design your functions to be idempotent.
+
+!!! note "Event Hubs checkpoint behavior"
+    Event Hubs checkpoints are not written until the retry policy finishes, so progress on that partition is paused until the current batch completes.
+
+## See Also
+
+- [Event Hubs](event-hub.md)
+- [Timer Trigger](timer.md)
+
+## Sources
+
+- [Azure Functions error handling and retry guidance (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages)

--- a/docs/language-guides/python/recipes/service-bus.md
+++ b/docs/language-guides/python/recipes/service-bus.md
@@ -1,0 +1,160 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger
+---
+# Service Bus
+
+This recipe covers integrating Azure Service Bus with Azure Functions Python v2 — consuming queue and topic/subscription messages with the trigger, handling sessions and dead-lettering, and publishing messages with the output binding. Service Bus is the standard choice for enterprise messaging that needs ordering, sessions, transactions, or duplicate detection.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    PROD[Producers] --> SBQ[(Service Bus Queue/Topic)]
+    SBQ --> TRIG[Service Bus Trigger]
+    TRIG --> FA[Function App]
+    FA --> DLQ[(Dead-Letter Queue)]
+    FA --> OUT[Service Bus Output]
+```
+
+## Prerequisites
+
+Service Bus bindings are included in the default extension bundle. Provide the connection in app settings. A connection-string setting or an identity-based connection is supported. Identity-based connections use a setting prefix with `__fullyQualifiedNamespace`:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "ServiceBusConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$NAMESPACE` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+When using an identity-based connection, grant the function app's managed identity the **Azure Service Bus Data Receiver** (and **Data Sender** for output) role on the namespace.
+
+## Queue Trigger
+
+The trigger fires as messages arrive. Message settlement (complete, abandon, dead-letter) is handled automatically based on whether the function succeeds or raises.
+
+```python
+import azure.functions as func
+import logging
+import json
+
+bp = func.Blueprint()
+
+@bp.service_bus_queue_trigger(
+    arg_name="msg",
+    queue_name="orders",
+    connection="ServiceBusConnection",
+)
+def process_order(msg: func.ServiceBusMessage) -> None:
+    """Process a single Service Bus queue message."""
+    body = msg.get_body().decode("utf-8")
+    data = json.loads(body)
+
+    logging.info("Message ID: %s, delivery count: %s",
+                 msg.message_id, msg.delivery_count)
+    logging.info("Payload: %s", data)
+    # Raising an exception abandons the message; after maxDeliveryCount
+    # it is moved to the dead-letter queue automatically.
+```
+
+## Topic/Subscription Trigger
+
+```python
+@bp.service_bus_topic_trigger(
+    arg_name="msg",
+    topic_name="events",
+    subscription_name="billing",
+    connection="ServiceBusConnection",
+)
+def process_event(msg: func.ServiceBusMessage) -> None:
+    """Process a message from a topic subscription."""
+    logging.info("Subscription message: %s", msg.get_body().decode("utf-8"))
+```
+
+## Output Binding: Publish Messages
+
+```python
+@bp.route(route="enqueue", methods=["POST"])
+@bp.service_bus_queue_output(
+    arg_name="out_msg",
+    queue_name="orders",
+    connection="ServiceBusConnection",
+)
+def enqueue(req: func.HttpRequest, out_msg: func.Out[str]) -> func.HttpResponse:
+    """Publish a message to a Service Bus queue."""
+    try:
+        body = req.get_json()
+    except ValueError:
+        return func.HttpResponse(
+            json.dumps({"error": "Invalid JSON body"}),
+            mimetype="application/json",
+            status_code=400,
+        )
+
+    out_msg.set(json.dumps(body))
+    return func.HttpResponse(
+        json.dumps({"status": "enqueued"}),
+        mimetype="application/json",
+        status_code=202,
+    )
+```
+
+## Host Configuration
+
+Tune concurrency and prefetch in `host.json`:
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "serviceBus": {
+      "maxConcurrentCalls": 16,
+      "prefetchCount": 0,
+      "maxAutoLockRenewalDuration": "00:05:00",
+      "sessionHandlerOptions": {
+        "maxConcurrentSessions": 8
+      }
+    }
+  }
+}
+```
+
+| Setting | Description |
+|---------|-------------|
+| `maxConcurrentCalls` | Maximum concurrent message handlers per instance (non-session) |
+| `prefetchCount` | Number of messages the client prefetches to reduce latency |
+| `maxAutoLockRenewalDuration` | How long the runtime keeps renewing the message lock during processing |
+| `maxConcurrentSessions` | Maximum concurrent sessions processed per instance |
+
+!!! note "Sessions and ordering"
+    Enable `isSessionsEnabled=True` on the trigger to process session-enabled queues/subscriptions, which guarantees ordered, single-consumer processing per session ID.
+
+## See Also
+
+- [Queue Storage](queue.md)
+- [Event Hubs](event-hub.md)
+
+## Sources
+
+- [Azure Service Bus bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus)
+- [Azure Service Bus trigger for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-trigger)
+- [Azure Service Bus output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-service-bus-output)

--- a/docs/language-guides/python/recipes/signalr.md
+++ b/docs/language-guides/python/recipes/signalr.md
@@ -1,0 +1,145 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-input
+---
+# SignalR Service
+
+This recipe covers adding real-time messaging to Azure Functions Python v2 with Azure SignalR Service in serverless mode. It uses the `SignalRConnectionInfo` input binding to implement the required `negotiate` endpoint and the SignalR output binding to broadcast messages to connected clients. In the Python v2 model, SignalR bindings are expressed as generic bindings.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    CLIENT[Browser Client] --> NEG[negotiate Function]
+    NEG --> INFO[SignalRConnectionInfo Input]
+    INFO --> SR[(Azure SignalR Service)]
+    CLIENT -->|WebSocket| SR
+    PUB[broadcast Function] --> OUT[SignalR Output]
+    OUT --> SR
+    SR -->|push| CLIENT
+```
+
+## Prerequisites
+
+SignalR Service bindings are included in the default extension bundle. Ensure your `host.json` references it:
+
+```json
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}
+```
+
+Configure the connection in app settings. A connection string (stored as `AzureSignalRConnectionString`) or an identity-based connection is supported:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "AzureSignalRConnectionString__serviceUri=https://$SIGNALR_NAME.service.signalr.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$SIGNALR_NAME` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+The SignalR Service instance must be in **Serverless** mode. When using an identity-based connection, grant the function app's managed identity the **SignalR Service Owner** role on the resource.
+
+## The negotiate Endpoint
+
+Before a client connects, it calls a `negotiate` endpoint to obtain the service URL and a short-lived access token. The `SignalRConnectionInfo` input binding produces this payload. Do not cache or share the token between clients.
+
+```python
+import azure.functions as func
+import json
+
+bp = func.Blueprint()
+
+@bp.route(route="negotiate", auth_level=func.AuthLevel.ANONYMOUS)
+@bp.generic_input_binding(
+    arg_name="connectionInfo",
+    type="signalRConnectionInfo",
+    hubName="serverless",
+    connectionStringSetting="AzureSignalRConnectionString",
+)
+def negotiate(req: func.HttpRequest, connectionInfo) -> func.HttpResponse:
+    """Return the SignalR service endpoint and access token to the client."""
+    return func.HttpResponse(
+        connectionInfo,
+        mimetype="application/json",
+    )
+```
+
+!!! warning "Secure the negotiate endpoint"
+    The example uses `AuthLevel.ANONYMOUS` for clarity. In production, protect the endpoint with App Service Authentication and bind the authenticated user via `userId="{headers.x-ms-client-principal-id}"` so each token carries a user identity.
+
+## Output Binding: Broadcast a Message
+
+The SignalR output binding sends a message to all connected clients. The message object specifies a `target` (the client-side handler name) and `arguments`.
+
+```python
+@bp.route(route="messages", methods=["POST"])
+@bp.generic_output_binding(
+    arg_name="signalRMessages",
+    type="signalR",
+    hubName="serverless",
+    connectionStringSetting="AzureSignalRConnectionString",
+)
+def broadcast(req: func.HttpRequest, signalRMessages: func.Out[str]) -> func.HttpResponse:
+    """Broadcast a message to every connected client."""
+    body = req.get_body().decode("utf-8")
+
+    signalRMessages.set(json.dumps({
+        "target": "newMessage",
+        "arguments": [body],
+    }))
+
+    return func.HttpResponse(status_code=202)
+```
+
+## Sending to a Specific User or Group
+
+Add `userId` or `groupName` to the message object to target a subset of clients instead of broadcasting:
+
+```python
+signalRMessages.set(json.dumps({
+    "userId": "user1",
+    "target": "newMessage",
+    "arguments": [body],
+}))
+```
+
+| Field | Purpose |
+|-------|---------|
+| `target` | Name of the client-side method invoked by SignalR |
+| `arguments` | List of arguments passed to the client method |
+| `userId` | Restrict delivery to a single user identifier |
+| `groupName` | Restrict delivery to members of a named group |
+
+## See Also
+
+- [HTTP Authentication](http-auth.md)
+- [Managed Identity Recipe](managed-identity.md)
+
+## Sources
+
+- [Azure Functions SignalR Service bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service)
+- [SignalR Service input binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-input)
+- [SignalR Service output binding (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service-output)

--- a/docs/language-guides/python/recipes/table-storage.md
+++ b/docs/language-guides/python/recipes/table-storage.md
@@ -1,0 +1,122 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-output
+---
+# Table Storage
+
+This recipe covers reading and writing entities in Azure Table Storage from Azure Functions Python v2 using the table input and output bindings. Table Storage is a low-cost, schemaless key/value store keyed by partition and row.
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    HTTP[HTTP Request] --> FA[Function App]
+    FA -->|table_output| WRITE[(Table: entity written)]
+    READ[(Table: entity read)] -->|table_input| FA
+```
+
+## Prerequisites
+
+Table bindings ship in the default extension bundle. Provide the connection in app settings. A connection string or an identity-based connection is supported. Identity-based connections use a `__tableServiceUri` suffix:
+
+```bash
+az functionapp config appsettings set \
+  --name $APP_NAME \
+  --resource-group $RG \
+  --settings "TableConnection__tableServiceUri=https://$STORAGE_NAME.table.core.windows.net"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command(s) | `az functionapp config appsettings set` |
+| Key flags | `--name`, `--resource-group`, `--settings` |
+| Variables | `$APP_NAME`, `$RG`, `$STORAGE_NAME` |
+| Expected result | Azure CLI returns the updated app settings as JSON; confirm the setting is present before continuing. |
+
+For an identity-based connection, grant the managed identity **Storage Table Data Reader** (input) and **Storage Table Data Contributor** (output) on the storage account.
+
+!!! note "Output binding creates new entities only"
+    The table output binding only creates new entities. To update or delete an existing entity, use the `azure-data-tables` SDK directly with a `TableClient`.
+
+## Output Binding: Write an Entity
+
+Every entity requires a `PartitionKey` and a `RowKey`.
+
+```python
+import azure.functions as func
+import uuid
+import json
+
+bp = func.Blueprint()
+
+@bp.route(route="messages", methods=["POST"])
+@bp.table_output(
+    arg_name="entity",
+    connection="TableConnection",
+    table_name="messages",
+)
+def create_message(req: func.HttpRequest, entity: func.Out[str]) -> func.HttpResponse:
+    """Persist a new message entity to Table Storage."""
+    body = req.get_json()
+    row_key = str(uuid.uuid4())
+
+    data = {
+        "PartitionKey": "message",
+        "RowKey": row_key,
+        "Text": body.get("text", ""),
+    }
+    entity.set(json.dumps(data))
+
+    return func.HttpResponse(
+        json.dumps({"rowKey": row_key}),
+        mimetype="application/json",
+        status_code=201,
+    )
+```
+
+## Input Binding: Read an Entity
+
+Bind by partition key and row key to read a single entity. The runtime injects the entity as a JSON string.
+
+```python
+@bp.route(route="messages/{partitionKey}/{rowKey}", methods=["GET"])
+@bp.table_input(
+    arg_name="entity",
+    connection="TableConnection",
+    table_name="messages",
+    partition_key="{partitionKey}",
+    row_key="{rowKey}",
+)
+def get_message(req: func.HttpRequest, entity: str) -> func.HttpResponse:
+    """Read a single entity by partition and row key."""
+    return func.HttpResponse(
+        entity,
+        mimetype="application/json",
+        status_code=200,
+    )
+```
+
+To read multiple entities, omit `row_key` and optionally supply a `filter` and `take` on the input binding.
+
+## See Also
+
+- [Blob Storage](blob-storage.md)
+- [Queue Storage](queue.md)
+- [Managed Identity Recipe](managed-identity.md)
+
+## Sources
+
+- [Azure Table storage bindings for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table)
+- [Azure Tables output binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-output)
+- [Azure Tables input binding for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table-input)

--- a/docs/language-guides/python/recipes/testing.md
+++ b/docs/language-guides/python/recipes/testing.md
@@ -1,0 +1,104 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+  diagrams:
+    - id: architecture
+      type: flowchart
+      source: self-generated
+      justification: Flow view of architecture, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+---
+# Unit Testing
+
+Azure Functions handlers in the Python v2 model are ordinary Python callables, so you test them with `pytest` by constructing the trigger objects (for example `func.HttpRequest`) and asserting on the returned `func.HttpResponse`. No Functions host is required for unit tests.
+
+## Prerequisites
+
+- A Python v2 Function App using `azure.functions` with `app = func.FunctionApp()`.
+- `pytest` installed in your virtual environment (`pip install pytest`).
+
+## Architecture
+
+<!-- diagram-id: architecture -->
+```mermaid
+flowchart TD
+    TEST[pytest test] --> BUILD[Build func.HttpRequest]
+    BUILD --> CALL[Call handler directly]
+    CALL --> ASSERT[Assert status + body]
+```
+
+## Testable Handler
+
+Keep business logic in the handler (or a plain function it calls) so tests can invoke it without the runtime.
+
+```python
+import azure.functions as func
+
+app = func.FunctionApp()
+
+@app.route(route="greet")
+def greet(req: func.HttpRequest) -> func.HttpResponse:
+    name = req.params.get("name") or "world"
+    return func.HttpResponse(f"hello {name}", status_code=200)
+```
+
+## Test the HTTP Trigger
+
+Construct a `func.HttpRequest`, call the handler, and assert on the response.
+
+```python
+import azure.functions as func
+from function_app import greet
+
+def test_greet_with_name():
+    req = func.HttpRequest(
+        method="GET",
+        url="/api/greet",
+        params={"name": "ada"},
+        body=None,
+    )
+
+    response = greet(req)
+
+    assert response.status_code == 200
+    assert response.get_body() == b"hello ada"
+
+def test_greet_default():
+    req = func.HttpRequest(method="GET", url="/api/greet", params={}, body=None)
+    response = greet(req)
+    assert response.get_body() == b"hello world"
+```
+
+## Mocking Bindings and Dependencies
+
+For output bindings or external clients, inject a fake or patch the dependency with `unittest.mock`.
+
+```python
+from unittest.mock import patch
+
+@patch("function_app.table_client")
+def test_writes_entity(mock_client):
+    # call the handler, then assert on the mock
+    mock_client.create_entity.assert_called_once()
+```
+
+| Element | Explanation |
+|---|---|
+| `func.HttpRequest(...)` | Constructs the trigger input without a running host. |
+| `response.get_body()` | Returns the response body as `bytes` for assertions. |
+| `unittest.mock.patch` | Replaces module-level clients (see [Dependency Injection](dependency-injection.md)) with test doubles. |
+
+!!! tip "Integration testing"
+    To exercise the full host (bindings, `host.json`, routing), run `func start` locally and issue HTTP requests, or use the Azure Functions test tooling in CI. Unit tests above stay host-free for speed.
+
+## See Also
+
+- [Dependency Injection](dependency-injection.md)
+- [HTTP API Patterns](http-api.md)
+
+## Sources
+
+- [Azure Functions Python developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -52,9 +52,12 @@ flowchart TD
 - [Deployment](deployment.md)
 - [Configuration](configuration.md)
 - [Monitoring](monitoring.md)
+- [OpenTelemetry Export](opentelemetry.md)
 - [Alerts](alerts.md)
 - [Cold Start](cold-start.md)
 - [Retries and Poison Handling](retries-and-poison-handling.md)
+- [Security](security.md)
+- [Cost Optimization](cost-optimization.md)
 - [Recovery](recovery.md)
 
 ## Review Matrix

--- a/docs/operations/opentelemetry.md
+++ b/docs/operations/opentelemetry.md
@@ -1,0 +1,130 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring
+  diagrams:
+    - id: opentelemetry-export-flow
+      type: flowchart
+      source: self-generated
+      justification: Flow view of OpenTelemetry export paths, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto
+content_validation:
+  status: verified
+  last_reviewed: 2026-07-17
+  reviewer: agent
+  core_claims:
+    - claim: "OpenTelemetry output is enabled at the function app level by adding telemetryMode set to OpenTelemetry in host.json."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto
+      verified: true
+    - claim: "When both an Application Insights connection string and an OTLP exporter are configured, OpenTelemetry data is sent to both endpoints."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto
+      verified: true
+    - claim: "OpenTelemetry is not supported for C# in-process apps."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto
+      verified: true
+    - claim: "When the host is configured to use OpenTelemetry, the Azure portal does not support log streaming."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto
+      verified: true
+---
+# OpenTelemetry Export
+
+Azure Functions can export logs and traces in OpenTelemetry (OTLP) format instead of relying solely on the Application Insights SDK. This lets you send the same host and worker telemetry to Application Insights, to any OTLP-compliant backend (Datadog, New Relic, Grafana), or to both. This page covers enabling and operating OpenTelemetry export in production.
+
+!!! tip "Related Guide"
+    For the day-2 monitoring workflow with Application Insights, see [Monitoring](monitoring.md).
+
+## Prerequisites
+
+- A function app on a supported runtime (OpenTelemetry is **not** supported for C# in-process apps).
+- Access to update `host.json` and application settings.
+- A destination: an Application Insights resource, an OTLP endpoint, or both.
+
+## When to Use
+
+- You need to send Functions telemetry to a non-Azure observability backend.
+- You want standards-based, correlated traces and logs across the host and worker processes.
+- You are standardizing telemetry across a multi-service estate on OpenTelemetry semantics.
+
+Stay with the default Application Insights SDK path if you only need Azure Monitor and portal features such as live log streaming.
+
+## Export Paths
+
+<!-- diagram-id: opentelemetry-export-flow -->
+```mermaid
+flowchart TD
+    HOST[Functions host telemetry] --> MODE{telemetryMode = OpenTelemetry?}
+    WORKER[Worker process telemetry] --> MODE
+    MODE -->|App Insights conn string| AI[Application Insights]
+    MODE -->|OTLP endpoint set| OTLP[OTLP-compliant backend]
+    MODE -->|Both set| BOTH[Both endpoints]
+```
+
+## Procedure
+
+### Step 1: Enable OpenTelemetry in the Host
+
+Add `telemetryMode` to the root of `host.json`. This makes the host export OpenTelemetry regardless of language stack.
+
+```json
+{
+    "version": "2.0",
+    "telemetryMode": "OpenTelemetry"
+}
+```
+
+### Step 2: Configure the Destination via App Settings
+
+The app's environment variables determine where data is sent.
+
+| App setting | Purpose |
+|---|---|
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Sends OpenTelemetry data to an Application Insights workspace. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | The OTLP endpoint URL from your observability provider. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Authentication headers (for example API keys) for the OTLP endpoint. |
+
+When both an Application Insights connection string and an OTLP exporter are configured, data is sent to **both** endpoints. To export only to OTLP, remove `APPLICATIONINSIGHTS_CONNECTION_STRING`.
+
+```bash
+az functionapp config appsettings set --resource-group $RG --name $APP_NAME --settings OTEL_EXPORTER_OTLP_ENDPOINT="https://otlp.example-provider.com" OTEL_EXPORTER_OTLP_HEADERS="api-key=<redacted>"
+```
+
+| CLI element | Explanation |
+|---|---|
+| Command | `az functionapp config appsettings set` |
+| Key flags | `--resource-group`, `--name`, `--settings` |
+| Variables | `$RG`, `$APP_NAME`, provider endpoint and headers |
+| Expected result | Settings applied; confirm they appear in the app configuration before validating export. |
+
+### Step 3: Instrument the Worker Process
+
+Enabling OpenTelemetry in both the host and the app code gives better trace/log correlation. Worker-side setup is language-specific — install the OpenTelemetry packages and register the exporter in your app's entry point (`Program.cs`, `function_app.py`, `src/index.js`, or Maven dependencies). See the language-specific instructions in the Microsoft Learn source below.
+
+## Verification
+
+- Confirm telemetry arrives at the configured backend (Application Insights or OTLP destination).
+- In Application Insights, verify traces and logs correlate across the host and worker (shared operation IDs).
+- Query for `instrumentation.provider == 'opentelemetry'` to confirm OpenTelemetry-sourced records.
+
+## Rollback / Troubleshooting
+
+- **Revert**: remove `telemetryMode` from `host.json` (or set it back to the default) to return to the Application Insights SDK path.
+- **No log streaming**: when the host uses OpenTelemetry, the Azure portal does not support live log streaming — this is expected.
+- **`logging.applicationInsights` ignored**: when `telemetryMode` is `OpenTelemetry`, the `logging.applicationInsights` section of `host.json` no longer applies.
+- **Duplicate telemetry**: avoid adding a console exporter or the Azure Monitor distro in the worker when the host already emits equivalent telemetry.
+- **Missing request telemetry**: with parent-based sampling, requests whose incoming `traceparent` is not sampled will not generate request telemetry.
+- **Recent invocations view**: the portal's *Recent function invocation* traces appear only when telemetry is sent to Azure Monitor.
+
+## See Also
+
+- [Monitoring](monitoring.md)
+- [Alerts](alerts.md)
+- [Configuration](configuration.md)
+
+## Sources
+
+- [Use OpenTelemetry with Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/opentelemetry-howto)
+- [Monitor Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-monitoring)

--- a/docs/platform/custom-handlers.md
+++ b/docs/platform/custom-handlers.md
@@ -1,0 +1,155 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers
+  diagrams:
+    - id: custom-handler-flow
+      type: flowchart
+      source: self-generated
+      justification: Flow view of the custom handler request/response protocol, synthesized from Microsoft Learn documentation cited on this page.
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers
+content_validation:
+  status: verified
+  last_reviewed: 2026-07-17
+  reviewer: agent
+  core_claims:
+    - claim: "Custom handlers are lightweight web servers that receive events from the Azure Functions host process."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers
+      verified: true
+    - claim: "A custom handler app sets FUNCTIONS_WORKER_RUNTIME to Custom and configures a customHandler section with defaultExecutablePath in host.json."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers
+      verified: true
+    - claim: "The Functions host sends a request payload with Data and Metadata members and expects a response payload with Outputs, Logs, and ReturnValue keys."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers
+      verified: true
+    - claim: "The custom handler web server must start within 60 seconds."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers
+      verified: true
+---
+# Custom Handlers
+
+Azure Functions normally executes your code through language-specific workers. When you need a language or runtime that Functions does not support out of the box — such as Rust, Deno, or a self-hosted server — **custom handlers** let you run it. A custom handler is a lightweight web server that receives events from the Functions host process over HTTP.
+
+## When to Use
+
+- Implement a function app in a language not offered by default (for example, Rust).
+- Run a runtime not featured by default (for example, Deno).
+- Host a server built with standard SDKs behind Functions triggers and bindings.
+
+!!! note "Prefer first-class support when available"
+    Custom handlers exist to enable unsupported languages/runtimes. If a first-class worker exists for your language, use it — custom handlers add a web-server hop and can increase cold-start time.
+
+## How It Works
+
+The Functions host translates every trigger into an HTTP request to your web server and maps the response back to output bindings.
+
+<!-- diagram-id: custom-handler-flow -->
+```mermaid
+flowchart TD
+    EVENT[Trigger event] --> HOST[Functions host]
+    HOST --> REQ[HTTP POST request payload to web server]
+    REQ --> WS[Custom handler web server]
+    WS --> RESP[HTTP response payload]
+    RESP --> HOST2[Functions host]
+    HOST2 --> OUT[Output bindings processed]
+```
+
+1. An event triggers a request to the Functions host.
+2. The host issues a request payload to your web server, containing trigger and input-binding data plus metadata.
+3. The web server executes the function and returns a response payload.
+4. The host passes the response to the function's output bindings.
+
+## Application Structure
+
+A custom handler app needs:
+
+- A `host.json` file at the app root.
+- A `local.settings.json` file at the app root.
+- A `function.json` file per function, inside a folder named to match the function.
+- A command, script, or executable that runs a web server.
+
+```bash
+| /MyQueueFunction
+|   function.json
+|
+| host.json
+| local.settings.json
+| handler.exe
+```
+
+## Configuration
+
+### host.json
+
+The `customHandler` section points the host at your web server via `defaultExecutablePath`. Standard triggers and bindings become available by referencing extension bundles.
+
+```json
+{
+  "version": "2.0",
+  "customHandler": {
+    "description": {
+      "defaultExecutablePath": "handler.exe"
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}
+```
+
+`arguments` (with `%SETTING%` environment-variable expansion) and `workingDirectory` can further control how the executable runs.
+
+### local.settings.json
+
+Set the worker runtime to `Custom`.
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "Custom"
+  }
+}
+```
+
+## Request and Response Payloads
+
+The host sends a JSON request with `Data` (keys matching input/trigger names) and `Metadata` (event-source metadata). Your handler replies with a key/value response.
+
+| Response key | Type | Purpose |
+|---|---|---|
+| `Outputs` | object | Output-binding values, keyed by the binding names in `function.json`. |
+| `Logs` | array | Messages surfaced in invocation logs (Application Insights in Azure). |
+| `ReturnValue` | string | Response when an output is configured as `$return`. |
+
+Your web server listens on the port supplied by the `FUNCTIONS_CUSTOMHANDLER_PORT` environment variable — this is the internal port the host uses to call the handler, not the public function URL.
+
+## HTTP-Only Functions
+
+For HTTP-triggered functions with no other bindings, set `enableProxyingHttpRequest` to `true` in `host.json` so your handler works directly with the raw HTTP request and response (with response streaming) instead of the `Data`/`Outputs` payload envelope.
+
+## Deployment
+
+- Deploy with Core Tools: `func azure functionapp publish $APP_NAME`.
+- When creating the function app in Azure for custom handlers, select **.NET Core** as the stack.
+- Ensure all files needed to run the handler are included, and that platform-specific binaries match the target OS.
+- If the handler needs OS/runtime dependencies, use a [custom container](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container).
+
+## Restrictions
+
+- The custom handler web server must start within **60 seconds**.
+- Functions is not a general reverse proxy — some HTTP headers and routes may be restricted.
+- Support covers host-to-handler startup and communication, not the internals of your chosen language or framework.
+
+## See Also
+
+- [Triggers and Bindings](triggers-and-bindings.md)
+- [Hosting](hosting.md)
+- [Operations: Deployment](../operations/deployment.md)
+
+## Sources
+
+- [Azure Functions custom handlers (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-custom-handlers)

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -45,12 +45,16 @@ flowchart TD
 - [Architecture](architecture/index.md) — host/worker runtime model, deployment unit, and resource relationships.
 - [Hosting](hosting.md) — Consumption, Flex Consumption, Premium, and Dedicated plan behavior.
 - [Triggers and bindings](triggers-and-bindings.md) — eventing patterns and integration contracts.
+- [Durable Functions](durable-functions.md) — stateful orchestrations, entities, and workflow patterns on the Durable extension.
 - [Scaling](scaling.md) — how scale decisions differ by trigger type and hosting plan.
 - [Networking](networking.md) — VNet integration, private endpoints, and hybrid connectivity.
 - [Networking Scenarios](networking-scenarios/index.md) — practical deployment patterns for public, private egress, private ingress, and fixed outbound IP.
 - [Storage Connectivity](storage-connectivity.md) — storage roles, public/service/private endpoint postures, and the storage network settings matrix.
 - [Reliability](reliability.md) — retries, poison message handling, and high-availability choices.
 - [Security](security.md) — auth models, managed identity, and network isolation.
+- [Functions vs App Service](functions-vs-app-service.md) — when to choose Functions over App Service and how the models compare.
+- [Deployment Scenarios](deployment-scenarios.md) — end-to-end deployment topologies by hosting plan and network posture.
+- [Custom Handlers](custom-handlers.md) — running unsupported languages and runtimes through a lightweight web server.
 
 ## Start with the design sequence
 

--- a/docs/platform/index.md
+++ b/docs/platform/index.md
@@ -48,6 +48,7 @@ flowchart TD
 - [Scaling](scaling.md) — how scale decisions differ by trigger type and hosting plan.
 - [Networking](networking.md) — VNet integration, private endpoints, and hybrid connectivity.
 - [Networking Scenarios](networking-scenarios/index.md) — practical deployment patterns for public, private egress, private ingress, and fixed outbound IP.
+- [Storage Connectivity](storage-connectivity.md) — storage roles, public/service/private endpoint postures, and the storage network settings matrix.
 - [Reliability](reliability.md) — retries, poison message handling, and high-availability choices.
 - [Security](security.md) — auth models, managed identity, and network isolation.
 

--- a/docs/platform/networking-scenarios/index.md
+++ b/docs/platform/networking-scenarios/index.md
@@ -74,6 +74,7 @@ Choose your network scenario based on requirements, then select a compatible hos
 |----------|-------------|:--:|:---:|:--:|:------:|:-------:|
 | [**1. Public Only**](public-only.md) | Internet ingress, public egress | :material-check: | :material-check: | :material-check: | :material-check: | :material-check: |
 | [**2. Private Egress**](private-egress.md) | Internet ingress, VNet egress to private backends | :material-close: | :material-check: | :material-check: | :material-minus:[^1] | :material-check: |
+| [**2b. Storage Service Endpoint**](storage-service-endpoint.md) | Subnet-scoped storage access, public DNS retained | :material-close: | :material-check: | :material-check: | :material-minus:[^1] | :material-check: |
 | [**3. Private Ingress**](private-ingress.md) | Private endpoint ingress, VNet egress | :material-close: | :material-check: | :material-check: | :material-minus:[^1] | :material-check: |
 | [**4. Fixed Outbound IP**](fixed-outbound-nat.md) | NAT Gateway for stable egress IP | :material-close: | :material-check: | :material-check: | :material-minus:[^1] | :material-check: |
 
@@ -128,6 +129,7 @@ Each scenario guide provides:
 ## See Also
 
 - [Platform: Networking](../networking.md) — Detailed networking concepts
+- [Platform: Storage Connectivity](../storage-connectivity.md) — Storage roles and network settings matrix
 - [Platform: Deployment Scenarios](../deployment-scenarios.md) — Plan-centric deployment comparison
 - [Best Practices: Networking](../../best-practices/networking.md) — Production networking patterns
 - [Troubleshooting: DNS VNet Resolution](../../troubleshooting/lab-guides/dns-vnet-resolution.md) — Common DNS issues

--- a/docs/platform/networking-scenarios/private-egress.md
+++ b/docs/platform/networking-scenarios/private-egress.md
@@ -255,19 +255,35 @@ done
 
 ### Step 7: Lock Down Storage (Optional)
 
-After private endpoints are configured, disable public access:
+After private endpoints are configured, restrict the storage account's public reachability. Two settings are involved and they are **not** the same thing:
+
+| Setting | What it does | Resulting posture |
+|---------|--------------|-------------------|
+| `publicNetworkAccess = Enabled` + `defaultAction = Deny` | Keeps the public endpoint, but the storage **firewall** denies by default. Selected-network VNet rules and IP rules can still pass. | Firewall-restricted (Selected networks) |
+| `publicNetworkAccess = Disabled` | Disables the public endpoint entirely. Only private endpoints can reach the account. | Private-only |
+
+For a fully private posture, apply **both**: set the firewall default action to `Deny` (so no IP/VNet rule accidentally re-opens access) and disable public network access.
 
 ```bash
+# Firewall default -> Deny (public endpoint still Enabled at this point)
 az storage account update \
   --name "$STORAGE_NAME" \
   --resource-group "$RG" \
   --default-action Deny \
   --allow-blob-public-access false
+
+# Private-only: disable the public endpoint entirely
+az storage account update \
+  --name "$STORAGE_NAME" \
+  --resource-group "$RG" \
+  --public-network-access Disabled
 ```
 
 | Command/Parameter | Purpose |
 |-------------------|---------|
-| `--default-action Deny` | Blocks all public network access |
+| `--default-action Deny` | Sets the storage **firewall** default to Deny. Public endpoint stays Enabled; Selected-network VNet rules and IP rules still apply. Does **not** by itself disable the public endpoint. |
+| `--allow-blob-public-access false` | Disables anonymous public blob/container access (a separate control from network firewall) |
+| `--public-network-access Disabled` | Disables the storage account's public endpoint entirely (private-only). This is the setting that truly "blocks all public network access". |
 
 !!! warning "Order Matters"
     Disable public access **after** private endpoints and DNS zones are configured. Otherwise, your function app will lose storage connectivity.

--- a/docs/platform/networking-scenarios/public-only.md
+++ b/docs/platform/networking-scenarios/public-only.md
@@ -30,7 +30,7 @@ content_validation:
 
 # Scenario 1: Public Only
 
-The simplest deployment pattern with no VNet integration. All traffic flows over the public internet.
+The simplest deployment pattern with no VNet integration. The Function App and its dependencies are accessed through their **public endpoints**. Public endpoint usage does not necessarily mean traffic leaves the Microsoft backbone or traverses the general public internet — Azure-to-Azure traffic between resources in supported regions can stay on the Microsoft network. What defines this scenario is the *absence of VNet integration and private endpoints*, not the physical path every packet takes.
 
 ## Portal Walkthrough
 
@@ -223,7 +223,7 @@ Expected response:
 ## Security Considerations
 
 !!! warning "Public Exposure"
-    Without VNet integration, your function app and its dependencies are accessible over the public internet. Consider:
+    Without VNet integration, your function app and its dependencies are reachable through their public endpoints, and inbound requests can originate from the public internet. Public endpoint exposure is the risk here regardless of whether a given hop stays on the Microsoft backbone. Consider:
     
     - **Function-level authorization keys** for HTTP triggers
     - **IP access restrictions** to limit source networks

--- a/docs/platform/networking-scenarios/storage-service-endpoint.md
+++ b/docs/platform/networking-scenarios/storage-service-endpoint.md
@@ -1,0 +1,181 @@
+---
+content_sources:
+  diagrams:
+    - id: storage-service-endpoint-architecture
+      type: flowchart
+      source: self-generated
+      justification: "Service-endpoint access pattern synthesized from Microsoft Learn storage networking and Functions networking documentation"
+      based_on:
+        - https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security
+        - https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview
+        - https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+content_validation:
+  status: verified
+  last_reviewed: 2026-07-16
+  reviewer: agent
+  core_claims:
+    - claim: "A virtual network service endpoint for Microsoft.Storage extends the subnet identity to the storage account and is authorized with a storage network (VNet) rule under Selected networks."
+      source: https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security
+      verified: true
+    - claim: "Service endpoints keep traffic on the Azure backbone but the storage account is still reached through its public endpoint, so its DNS name continues to resolve to a public IP address."
+      source: https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview
+      verified: true
+    - claim: "Private endpoints, unlike service endpoints, assign a private IP from the VNet to the storage account and require Private DNS to resolve the storage FQDN to that private IP."
+      source: https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints
+      verified: true
+    - claim: "Azure Functions VNet integration routes the app's outbound calls through the integration subnet, which is what allows subnet-scoped storage network rules to apply to the Function App."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+      verified: true
+---
+
+# Storage Service Endpoint
+
+This scenario secures Azure Storage access with a **virtual network service endpoint** instead of a private endpoint. It is the middle ground between fully public storage and a private-endpoint deployment: the storage account stays on its **public endpoint** (DNS resolves to a public IP), but the account only accepts traffic from an authorized **subnet**.
+
+This is a common and often-overlooked posture for Azure Functions, because the Function App reaches storage through its **VNet integration** subnet, and that same subnet is what the storage network rule authorizes.
+
+## Prerequisites
+
+- A Function App on a plan that supports VNet integration: Flex Consumption (FC1), Premium (EP), or Dedicated (S1+). Consumption (Y1) does **not** support VNet integration and cannot use this scenario.
+- An existing virtual network with an integration subnet.
+- A base deployment completed via your language tutorial's `02-first-deploy.md`.
+
+## How Service Endpoints Differ From Private Endpoints
+
+The key distinction is **where the storage account lives on the network** and **what DNS returns**.
+
+| Aspect | Service Endpoint | Private Endpoint |
+|--------|------------------|------------------|
+| Storage endpoint | Public endpoint (retained) | Private endpoint (new NIC in the VNet) |
+| DNS result for `*.blob.core.windows.net` | **Public IP** (unchanged) | **Private IP** (requires Private DNS zone) |
+| Authorization model | Subnet **VNet rule** on Selected networks | Network isolation at the NIC + Private DNS |
+| Private DNS zone required | No | Yes (`privatelink.*.core.windows.net`) |
+| Route All required | No | No (but often paired with it) |
+| Cross-region support | Same-region subnets (and specific paired scenarios) | Works across regions and peered VNets |
+| Traffic path | Azure backbone, optimized route from the subnet | Azure backbone via private NIC |
+
+!!! info "DNS is the giveaway"
+    With a service endpoint, `nslookup <account>.blob.core.windows.net` still returns a **public IP**. That is expected and correct — the *subnet identity*, not DNS, is what grants access. If you expect a private IP here, you actually want a [private endpoint](private-egress.md).
+
+## Architecture
+
+<!-- diagram-id: storage-service-endpoint-architecture -->
+```mermaid
+flowchart TD
+    FA[Function App] -->|VNet integration| SUBNET[Integration Subnet<br/>Microsoft.Storage service endpoint]
+    SUBNET -->|Optimized backbone route| PUB[Storage Public Endpoint]
+    PUB --> RULE{Storage firewall<br/>Selected networks}
+    RULE -->|VNet rule matches subnet| ST[(Storage Account)]
+    RULE -->|Other sources| DENY[Denied by defaultAction]
+
+    style FA fill:#0078d4,color:#fff
+    style ST fill:#FFF3E0
+    style DENY fill:#FCE4EC
+```
+
+The Function App's outbound storage calls leave through the integration subnet. Because the subnet carries the `Microsoft.Storage` service endpoint and the storage account authorizes that subnet with a VNet rule, the request is allowed. All other sources hit the firewall's `defaultAction` (Deny) and are rejected — even though the endpoint is technically public.
+
+## Supported Plans
+
+| Plan | Supported | Notes |
+|------|:---------:|-------|
+| Consumption (Y1) | :material-close: | No VNet integration |
+| Flex Consumption (FC1) | :material-check: | VNet integration required |
+| Premium (EP) | :material-check: | VNet integration required |
+| Dedicated (S1+) | :material-check: | VNet integration required |
+
+## Procedure
+
+### Step 1: Enable VNet Integration on the Function App
+
+The Function App must route outbound traffic through the subnet before storage subnet rules can match it. Follow the VNet integration steps in [Private Egress](private-egress.md) (Enable VNet Integration), or use the plan-appropriate command.
+
+### Step 2: Add the Microsoft.Storage Service Endpoint to the Integration Subnet
+
+```bash
+az network vnet subnet update \
+  --resource-group "$RG" \
+  --vnet-name "$VNET_NAME" \
+  --name "$INTEGRATION_SUBNET" \
+  --service-endpoints "Microsoft.Storage"
+```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `--service-endpoints "Microsoft.Storage"` | Extends the subnet's identity to Azure Storage over the backbone |
+
+### Step 3: Restrict the Storage Account to Selected Networks and Add the VNet Rule
+
+```bash
+# Default the firewall to Deny, keeping the public endpoint Enabled
+az storage account update \
+  --name "$STORAGE_NAME" \
+  --resource-group "$RG" \
+  --default-action Deny
+
+# Authorize the integration subnet
+az storage account network-rule add \
+  --account-name "$STORAGE_NAME" \
+  --resource-group "$RG" \
+  --vnet-name "$VNET_NAME" \
+  --subnet "$INTEGRATION_SUBNET"
+```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `--default-action Deny` | Sets the storage firewall default to Deny. The public endpoint stays **Enabled**; only authorized rules pass. |
+| `az storage account network-rule add ... --subnet` | Adds the subnet VNet rule so the integration subnet is allowed |
+
+!!! warning "publicNetworkAccess stays Enabled"
+    This scenario relies on `publicNetworkAccess = Enabled` with `defaultAction = Deny`. Do **not** set `--public-network-access Disabled` here — that disables the public endpoint entirely and breaks service-endpoint access (only private endpoints would work at that point). See [Storage Connectivity](../storage-connectivity.md) for the full setting matrix.
+
+### Step 4: Apply the Same Rule to Every Storage the App Uses
+
+Azure Functions may depend on more than one storage account. A service-endpoint rule must exist for **each** account and role the app touches:
+
+- `AzureWebJobsStorage` (host storage)
+- Any separate trigger/binding storage account (for example a Blob or Queue trigger on a different account)
+- Deployment storage, if separate
+
+If only `AzureWebJobsStorage` is authorized but a Blob-trigger account is not, the host can start while the trigger silently fails. See [Storage Connectivity — Storage roles](../storage-connectivity.md).
+
+## Verification
+
+Confirm DNS still returns a **public** IP (expected for service endpoints):
+
+```bash
+nslookup "$STORAGE_NAME.blob.core.windows.net"
+```
+
+Expected: a public IP address (not a `10.x`/private range). Access is granted by the subnet rule, not by DNS.
+
+Confirm connectivity from the app (for example via a health endpoint that touches storage, or by checking that triggers fire and the host is healthy). A `403 AuthorizationFailure` / `This request is not authorized` in storage logs indicates the subnet rule is missing or the request did not egress through the integration subnet.
+
+## Rollback / Troubleshooting
+
+- **403 from storage after enabling Deny**: The subnet VNet rule is missing, or VNet integration is not actually routing storage traffic through the subnet. Re-check Step 1 and Step 3.
+- **Works for host but triggers fail**: A secondary storage account (trigger/deployment) lacks the VNet rule — see Step 4.
+- **You expected a private IP**: Service endpoints never change DNS. If you need private IPs and Private DNS, use [Private Egress](private-egress.md) instead.
+
+To roll back, set the storage firewall default back to `Allow`:
+
+```bash
+az storage account update \
+  --name "$STORAGE_NAME" \
+  --resource-group "$RG" \
+  --default-action Allow
+```
+
+## See Also
+
+- [Networking Scenarios Overview](index.md)
+- [Scenario 2: Private Egress](private-egress.md) — Private endpoint alternative
+- [Storage Connectivity](../storage-connectivity.md) — Central reference and full setting matrix
+- [Troubleshooting: Storage Access Failure](../../troubleshooting/lab-guides/storage-access-failure.md)
+
+## Sources
+
+- [Configure Azure Storage firewalls and virtual networks (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security)
+- [Virtual Network service endpoints (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-service-endpoints-overview)
+- [Use private endpoints for Azure Storage (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints)
+- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)

--- a/docs/platform/storage-connectivity.md
+++ b/docs/platform/storage-connectivity.md
@@ -7,6 +7,10 @@ content_sources:
       url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
     - type: mslearn-adapted
       url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
 content_validation:
   status: verified
   last_reviewed: 2026-07-16
@@ -15,7 +19,7 @@ content_validation:
     - claim: "Azure Functions requires an associated storage account (AzureWebJobsStorage) used for host operations such as trigger management, leases, timers, and default key storage; losing access can make the host unhealthy."
       source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
       verified: true
-    - claim: "Premium and Consumption plans use an Azure Files content share (WEBSITE_CONTENTAZUREFILECONNECTIONSTRING / WEBSITE_CONTENTSHARE), and WEBSITE_CONTENTOVERVNET routes that content share over the virtual network."
+    - claim: "Consumption and Premium plans use an Azure Files content share (WEBSITE_CONTENTAZUREFILECONNECTIONSTRING / WEBSITE_CONTENTSHARE); WEBSITE_CONTENTOVERVNET routes that content share over the virtual network and applies only to Premium, which supports VNet integration (Consumption does not)."
       source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
       verified: true
     - claim: "Setting a storage firewall defaultAction to Deny keeps the public endpoint enabled while blocking unlisted sources, which is a different control from disabling public network access entirely."

--- a/docs/platform/storage-connectivity.md
+++ b/docs/platform/storage-connectivity.md
@@ -1,0 +1,169 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
+content_validation:
+  status: verified
+  last_reviewed: 2026-07-16
+  reviewer: agent
+  core_claims:
+    - claim: "Azure Functions requires an associated storage account (AzureWebJobsStorage) used for host operations such as trigger management, leases, timers, and default key storage; losing access can make the host unhealthy."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
+      verified: true
+    - claim: "Premium and Consumption plans use an Azure Files content share (WEBSITE_CONTENTAZUREFILECONNECTIONSTRING / WEBSITE_CONTENTSHARE), and WEBSITE_CONTENTOVERVNET routes that content share over the virtual network."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options
+      verified: true
+    - claim: "Setting a storage firewall defaultAction to Deny keeps the public endpoint enabled while blocking unlisted sources, which is a different control from disabling public network access entirely."
+      source: https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security
+      verified: true
+    - claim: "A private endpoint requires Private DNS so the storage FQDN resolves to a private IP; if the private DNS zone is missing, the FQDN resolves to a public IP and connectivity behavior can mask the misconfiguration."
+      source: https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints
+      verified: true
+    - claim: "Flex Consumption can use managed identity for AzureWebJobsStorage via AzureWebJobsStorage__accountName and AzureWebJobsStorage__credential=managedidentity."
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+      verified: true
+---
+
+# Storage Connectivity
+
+Azure Functions has a deeper storage dependency than a typical web app: the runtime itself relies on storage for host operations. This page is the central reference for **how the Function App reaches storage**, independent of **how it authenticates** to it. It covers every network posture — public endpoint, service endpoint, and private endpoint — and maps them against the different storage **roles** a Function App uses.
+
+Use the scenario pages for step-by-step procedures:
+
+- [Public Only](networking-scenarios/public-only.md)
+- [Storage Service Endpoint](networking-scenarios/storage-service-endpoint.md)
+- [Private Egress (Private Endpoint)](networking-scenarios/private-egress.md)
+
+## 1. Storage Roles in Azure Functions
+
+Unlike a plain web app, "the storage account" for Functions is really several distinct roles. Each has its own network path and must be verified independently.
+
+| Storage role | Example / setting | What breaks if the network path fails |
+|--------------|-------------------|----------------------------------------|
+| **Host Storage** | `AzureWebJobsStorage` | Host startup, trigger management, leases, timers, queue state — the **host itself** can go unhealthy, not just one function |
+| **Content Share** | `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `WEBSITE_CONTENTSHARE`, `WEBSITE_CONTENTOVERVNET` | App content (the deployed files) becomes unreachable — requires the Storage **file** endpoint and TCP **445** |
+| **Trigger / Binding Storage** | Blob/Queue trigger `Connection` (may be a separate account) | The specific trigger stops firing while the host stays healthy — easy to misdiagnose |
+| **Deployment Storage** | Flex Consumption deployment container / `WEBSITE_RUN_FROM_PACKAGE` URL | Deployments fail or the package cannot be mounted at runtime |
+| **Application Data Storage** | Accounts accessed directly from function code / SDK | Business logic fails; host and triggers may look fine |
+
+!!! danger "Host Storage is not just another dependency"
+    If `AzureWebJobsStorage` connectivity is blocked, the Functions host can fail to start or become **Unhealthy** — this is qualitatively different from a single downstream call failing. See the [Storage Access Failure lab](../troubleshooting/lab-guides/storage-access-failure.md).
+
+## 2. Authentication vs Network — Two Independent Axes
+
+Storage access has **two** independent controls. Confusing them is the most common source of misconfiguration.
+
+- **Authentication** — *who* is allowed: shared key (connection string) vs **managed identity + RBAC**.
+- **Network** — *from where* access is allowed: public endpoint, service endpoint (subnet rule), or private endpoint.
+
+A request must satisfy **both**. Managed identity with correct RBAC still fails if the network firewall denies the source. A permissive network still fails if the identity lacks the right data-plane role. Always diagnose them separately.
+
+## 3. Public Endpoint
+
+The storage account is reachable over its public endpoint. This is the default and requires no VNet integration.
+
+- DNS resolves to a **public IP**.
+- `publicNetworkAccess = Enabled`, `defaultAction = Allow`.
+- Suitable for dev/test; for production, layer on IP rules or move to service/private endpoints.
+
+See [Public Only](networking-scenarios/public-only.md).
+
+## 4. Service Endpoint
+
+The storage account keeps its **public endpoint**, but only accepts traffic from an authorized **subnet** (`Microsoft.Storage` service endpoint + VNet rule on Selected networks).
+
+- DNS still resolves to a **public IP** (this is expected).
+- `publicNetworkAccess = Enabled`, `defaultAction = Deny`, plus a VNet rule for the integration subnet.
+- No Private DNS zone; Route All not required.
+
+See [Storage Service Endpoint](networking-scenarios/storage-service-endpoint.md).
+
+## 5. Private Endpoint
+
+A private endpoint places a NIC with a **private IP** into the VNet for the storage account.
+
+- Requires Private DNS zones (`privatelink.blob|queue|table|file.core.windows.net`) so the storage FQDN resolves to the **private IP**.
+- For a fully private posture, set `publicNetworkAccess = Disabled`.
+- Functions typically need private endpoints for **blob, queue, table, and file** depending on plan and features.
+
+See [Private Egress](networking-scenarios/private-egress.md).
+
+## 6. Hosting Plan Differences
+
+| Plan | Host Storage auth | Content share | Notable settings |
+|------|-------------------|---------------|------------------|
+| Consumption (Y1) | Connection string (shared key) | Azure Files content share required | Cannot use VNet integration |
+| Flex Consumption (FC1) | **Managed identity** supported | No classic content share; uses deployment container | `AzureWebJobsStorage__accountName`, `AzureWebJobsStorage__credential=managedidentity` |
+| Premium (EP) | Managed identity supported for host storage | Azure Files content share to consider | `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `WEBSITE_CONTENTSHARE`, `WEBSITE_CONTENTOVERVNET=1` |
+| Dedicated (ASP) | Connection string or identity | Reduce Azure Files dependency | `WEBSITE_RUN_FROM_PACKAGE=1` pattern |
+
+!!! warning "Enterprise policy: allowSharedKeyAccess=false"
+    Subscriptions that enforce `allowSharedKeyAccess: false` block plans that require an Azure Files content share with shared key (Y1, EP content share). Prefer FC1 (identity-based blob storage) or ASP with `WEBSITE_RUN_FROM_PACKAGE=1`.
+
+## 7. Storage Network Settings Combination Matrix
+
+This is the central table. It separates the **storage setting**, the **Function App network config**, what **DNS returns**, the **actual endpoint** used, and the **expected result**.
+
+| Storage setting | Function App config | DNS result | Actual endpoint | Expected result |
+|-----------------|---------------------|------------|-----------------|-----------------|
+| All networks | No VNet integration | Public IP | Public endpoint | Works |
+| All networks | VNet integration | Public IP | Public endpoint | Works — VNet integration alone does **not** make storage private |
+| All networks | VNet integration + Route All | Public IP | Public endpoint | Traffic can traverse the VNet, but the storage endpoint is still public |
+| Selected networks + IP rule | Allow function outbound IP | Public IP | Public endpoint | Plan/region dependent — outbound IP must be stable and allowlisted |
+| Selected networks + Service Endpoint | Integration subnet allowed | Public IP | Public endpoint + service endpoint | Works — subnet identity grants access |
+| Private Endpoint + All networks | Private DNS correct | Private IP | Private endpoint | Function uses private path; other clients can still reach the public endpoint |
+| Private Endpoint + All networks | Private DNS **missing** | Public IP | Public endpoint | Connection may still succeed publicly, **masking** the DNS misconfiguration |
+| Public network access Disabled | Private endpoint + Private DNS | Private IP | Private endpoint | Correct private-only configuration |
+| Public network access Disabled | No private endpoint | Public IP | Unreachable | Host startup or trigger failure |
+
+!!! tip "The dangerous row"
+    *Private Endpoint + All networks + missing Private DNS* is the silent failure: because the public endpoint is still open, the app keeps working while resolving to a public IP. The private path is not actually in use, and the day you set `publicNetworkAccess = Disabled` it breaks. Always verify DNS returns a private IP.
+
+## 8. Host Startup Impact
+
+Because `AzureWebJobsStorage` participates in host startup, a storage network change that blocks it does not degrade gracefully — the host may fail to initialize. When tightening storage networking:
+
+1. Configure private/service endpoints and DNS **first**.
+2. Verify the app still resolves and reaches storage.
+3. Only then set `defaultAction = Deny` or `publicNetworkAccess = Disabled`.
+
+Reversing this order is a leading cause of self-inflicted outages. See [Private Egress — Order Matters](networking-scenarios/private-egress.md).
+
+## 9. DNS and Connectivity Verification
+
+```bash
+# Storage FQDNs should resolve to PRIVATE IPs when private endpoints + Private DNS are configured
+for SVC in blob queue table file; do
+  echo "== $SVC =="
+  nslookup "$STORAGE_NAME.$SVC.core.windows.net"
+done
+```
+
+Interpretation:
+
+- **Private IP (10.x / VNet range)** → private endpoint + Private DNS working.
+- **Public IP** → either public/service-endpoint scenario (expected there), or a **missing Private DNS zone** in a private-endpoint scenario (misconfiguration).
+
+For content share (Azure Files) also verify the **file** endpoint resolves and that TCP **445** egress is permitted.
+
+## See Also
+
+- [Networking Scenarios Overview](networking-scenarios/index.md)
+- [Public Only](networking-scenarios/public-only.md)
+- [Storage Service Endpoint](networking-scenarios/storage-service-endpoint.md)
+- [Private Egress](networking-scenarios/private-egress.md)
+- [Platform: Networking](networking.md)
+- [Troubleshooting: Storage Access Failure](../troubleshooting/lab-guides/storage-access-failure.md)
+
+## Sources
+
+- [Azure Functions storage considerations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations)
+- [Azure Functions networking options (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-networking-options)
+- [Configure Azure Storage firewalls and virtual networks (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security)
+- [Use private endpoints for Azure Storage (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints)
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)

--- a/docs/platform/storage-connectivity.md
+++ b/docs/platform/storage-connectivity.md
@@ -99,8 +99,8 @@ See [Private Egress](networking-scenarios/private-egress.md).
 |------|-------------------|---------------|------------------|
 | Consumption (Y1) | Connection string (shared key) | Azure Files content share required | Cannot use VNet integration |
 | Flex Consumption (FC1) | **Managed identity** supported | No classic content share; uses deployment container | `AzureWebJobsStorage__accountName`, `AzureWebJobsStorage__credential=managedidentity` |
-| Premium (EP) | Managed identity supported for host storage | Azure Files content share to consider | `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `WEBSITE_CONTENTSHARE`, `WEBSITE_CONTENTOVERVNET=1` |
-| Dedicated (ASP) | Connection string or identity | Reduce Azure Files dependency | `WEBSITE_RUN_FROM_PACKAGE=1` pattern |
+| Premium (EP) | Managed identity supported for host storage | Azure Files content share **required** | `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `WEBSITE_CONTENTSHARE`, `WEBSITE_CONTENTOVERVNET=1` |
+| Dedicated (ASP) | Connection string or identity | Required by default (can avoid with `WEBSITE_RUN_FROM_PACKAGE=1`) | `WEBSITE_RUN_FROM_PACKAGE=1` pattern |
 
 !!! warning "Enterprise policy: allowSharedKeyAccess=false"
     Subscriptions that enforce `allowSharedKeyAccess: false` block plans that require an Azure Files content share with shared key (Y1, EP content share). Prefer FC1 (identity-based blob storage) or ASP with `WEBSITE_RUN_FROM_PACKAGE=1`.
@@ -114,7 +114,7 @@ This is the central table. It separates the **storage setting**, the **Function 
 | All networks | No VNet integration | Public IP | Public endpoint | Works |
 | All networks | VNet integration | Public IP | Public endpoint | Works — VNet integration alone does **not** make storage private |
 | All networks | VNet integration + Route All | Public IP | Public endpoint | Traffic can traverse the VNet, but the storage endpoint is still public |
-| Selected networks + IP rule | Allow function outbound IP | Public IP | Public endpoint | Plan/region dependent — outbound IP must be stable and allowlisted |
+| Selected networks + IP rule | Allow function outbound IP | Public IP | Public endpoint | Plan/region dependent — outbound IP must be stable and allowlisted. **Consumption (Y1) outbound IPs are shared and can change; Flex Consumption IPs are not stable without a NAT Gateway**, making IP-rule access unreliable |
 | Selected networks + Service Endpoint | Integration subnet allowed | Public IP | Public endpoint + service endpoint | Works — subnet identity grants access |
 | Private Endpoint + All networks | Private DNS correct | Private IP | Private endpoint | Function uses private path; other clients can still reach the public endpoint |
 | Private Endpoint + All networks | Private DNS **missing** | Public IP | Public endpoint | Connection may still succeed publicly, **masking** the DNS misconfiguration |

--- a/docs/reference/content-validation-status.md
+++ b/docs/reference/content-validation-status.md
@@ -11,12 +11,12 @@ This page tracks `content_validation` metadata for **in-scope factual-claim docu
 
 ## Summary
 
-*Generated: 2026-07-05*
+*Generated: 2026-07-17*
 
 | Content Type | Total | Verified | Pending | Unverified | No Metadata |
 |---|---:|---:|---:|---:|---:|
-| Mermaid Diagrams | 513 | 513 | 0 | 0 | 0 |
-| In-Scope Factual-Claim Documents | 58 | 58 | 0 | 0 | 0 |
+| Mermaid Diagrams | 556 | 556 | 0 | 0 | 0 |
+| In-Scope Factual-Claim Documents | 62 | 62 | 0 | 0 | 0 |
 
 !!! success "All In-Scope Documents Verified"
     Every in-scope factual-claim document has verified Microsoft Learn sources for its core claims.
@@ -24,7 +24,7 @@ This page tracks `content_validation` metadata for **in-scope factual-claim docu
 <!-- diagram-id: content-validation-status-pie -->
 ```mermaid
 pie title In-Scope Document Validation Status
-    "Verified" : 58
+    "Verified" : 62
 ```
 
 ## By Section
@@ -33,6 +33,7 @@ pie title In-Scope Document Validation Status
 
 | Document | Has Sources | Status | Claims | Last Reviewed |
 |---|---|---|---|---|
+| [Custom Handlers](../platform/custom-handlers.md) | ✅ | ✅ Verified | 4/4 | 2026-07-17 |
 | [Deployment Scenarios](../platform/deployment-scenarios.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Durable Functions](../platform/durable-functions.md) | ✅ | ✅ Verified | 5/5 | 2026-07-05 |
 | [Fixed Outbound Nat](../platform/networking-scenarios/fixed-outbound-nat.md) | ✅ | ✅ Verified | 3/3 | 2026-04-12 |
@@ -47,6 +48,8 @@ pie title In-Scope Document Validation Status
 | [Reliability](../platform/reliability.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Scaling](../platform/scaling.md) | ✅ | ✅ Verified | 3/3 | 2026-04-12 |
 | [Security](../platform/security.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
+| [Storage Connectivity](../platform/storage-connectivity.md) | ✅ | ✅ Verified | 5/5 | 2026-07-16 |
+| [Storage Service Endpoint](../platform/networking-scenarios/storage-service-endpoint.md) | ✅ | ✅ Verified | 4/4 | 2026-07-16 |
 | [Triggers And Bindings](../platform/triggers-and-bindings.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 
 ### Best Practices
@@ -73,6 +76,7 @@ pie title In-Scope Document Validation Status
 | [Cost Optimization](../operations/cost-optimization.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Deployment](../operations/deployment.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Monitoring](../operations/monitoring.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
+| [Opentelemetry](../operations/opentelemetry.md) | ✅ | ✅ Verified | 4/4 | 2026-07-17 |
 | [Recovery](../operations/recovery.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Retries And Poison Handling](../operations/retries-and-poison-handling.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Security](../operations/security.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,114 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations
+---
+# Glossary
+
+Definitions of core Azure Functions terms used throughout this guide. Terms are grouped by domain; within each group they are ordered alphabetically.
+
+## Runtime and Hosting
+
+| Term | Definition |
+|------|------------|
+| **Function** | A single, independently triggered unit of code deployed within a function app. |
+| **Function app** | The deployment and management unit that hosts one or more functions sharing the same configuration, runtime, and hosting plan. |
+| **Functions host** | The runtime process that loads the function app, manages the language worker, and dispatches trigger events to functions. |
+| **Language worker** | A separate process (Python, Node.js, Java, or .NET isolated) that runs your function code and communicates with the Functions host over gRPC. |
+| **In-process model** | Legacy .NET model where function code runs inside the Functions host process. Superseded by the isolated worker model. |
+| **Isolated worker model** | The current .NET model where function code runs in a separate worker process, decoupled from the host runtime version. |
+| **Consumption plan (Y1)** | Serverless, event-driven hosting that scales to zero and bills per execution. Legacy default for new workloads. |
+| **Flex Consumption plan (FC1)** | Serverless plan with fast/large scale-out, VNet integration, and per-instance concurrency control. Recommended default for most new workloads. |
+| **Premium plan (EP)** | Plan with always-ready (pre-warmed) instances, VNet integration, and no cold start for warm instances. |
+| **Dedicated plan (App Service plan)** | Fixed-capacity hosting on an App Service plan, suitable for reusing an existing App Service estate. |
+
+## Triggers and Bindings
+
+| Term | Definition |
+|------|------------|
+| **Trigger** | The event that causes a function to run (for example an HTTP request, a queue message, or a timer schedule). Each function has exactly one trigger. |
+| **Binding** | A declarative connection to data or a service. Input bindings supply data to a function; output bindings send data from a function. |
+| **Binding extension** | A NuGet/npm/pip package that provides a specific trigger or binding type (for example the Service Bus or Event Hubs extension). |
+| **Extension bundle** | A versioned set of binding extensions declared in `host.json` so non-.NET apps do not manage individual extension packages. |
+| **Poison message** | A message that repeatedly fails processing and is moved to a poison/dead-letter location after the maximum dequeue/delivery count is reached. |
+
+## Scaling
+
+| Term | Definition |
+|------|------------|
+| **Scale controller** | The Azure component that monitors trigger activity and decides when to add or remove function app instances. |
+| **Target-based scaling** | A scaling model that computes desired instance count from queue/stream backlog and per-instance target, allowing faster scale-out than incremental scaling. |
+| **Always-ready instance** | A pre-provisioned Premium/Flex instance kept warm to eliminate cold start for a baseline of concurrent executions. |
+| **Per-instance concurrency** | The number of concurrent invocations a single instance handles before the platform scales out (configurable on Flex Consumption). |
+| **Cold start** | The added latency when a request is served by a newly allocated instance that must initialize the host, worker, and dependencies. |
+| **Scale to zero** | The behavior of serverless plans that remove all instances when there is no work, eliminating idle cost. |
+
+## Storage
+
+| Term | Definition |
+|------|------------|
+| **AzureWebJobsStorage** | The storage account connection setting the Functions runtime uses for internal state such as triggers, leases, and logs. |
+| **Content share** | The Azure Files share that stores the deployed application content for Consumption and Premium plans. |
+| **Deployment package** | The zipped application artifact. On Flex Consumption it is stored in a blob container and mounted at runtime. |
+| **Lease** | A storage-based lock used to coordinate singleton behavior and trigger ownership across instances. |
+
+## Networking
+
+| Term | Definition |
+|------|------------|
+| **VNet integration** | A feature that lets a function app make outbound calls into an Azure virtual network. |
+| **Private endpoint** | A network interface that exposes an Azure service (including a function app or its storage) with a private IP inside a VNet. |
+| **Service endpoint** | A VNet feature that secures an Azure service to specific subnets over the Azure backbone without a private IP. |
+| **Fixed outbound IP** | A predictable egress IP for a function app, typically achieved with VNet integration and a NAT gateway. |
+| **Private DNS zone** | A DNS zone that resolves a service's hostname to its private endpoint IP inside a VNet. |
+
+## Security
+
+| Term | Definition |
+|------|------------|
+| **Managed identity** | An Azure-managed Microsoft Entra identity assigned to a function app for passwordless authentication to other Azure services. |
+| **System-assigned identity** | A managed identity whose lifecycle is tied to a single function app. |
+| **User-assigned identity** | A standalone managed identity that can be shared across multiple resources. |
+| **Function access key** | A shared secret that authorizes calls to an HTTP-triggered function or the app's admin endpoints. |
+| **Authorization level** | The access requirement for an HTTP trigger: `anonymous`, `function`, or `admin`. |
+
+## Deployment and Operations
+
+| Term | Definition |
+|------|------------|
+| **Deployment slot** | A separate, addressable instance of a function app used for staging and zero-downtime swaps. |
+| **Zip deploy / run-from-package** | Deployment mechanisms that publish the app as a package, with run-from-package mounting it read-only. |
+| **Kudu / SCM** | The advanced deployment and diagnostics site for App Service and Functions apps (not available on Flex Consumption). |
+| **Application setting** | A key/value configuration entry exposed to the app as an environment variable. |
+
+## Observability
+
+| Term | Definition |
+|------|------------|
+| **Application Insights** | The Azure Monitor telemetry service that collects requests, dependencies, traces, exceptions, and metrics from a function app. |
+| **Live Metrics** | A near-real-time stream of request, dependency, and performance metrics in Application Insights. |
+| **Distributed tracing** | Correlation of a single logical operation across functions, bindings, and downstream dependencies using trace context. |
+| **Sampling** | A telemetry-volume control that records a representative subset of events to manage cost. |
+
+## See Also
+
+- [Platform Limits](platform-limits.md)
+- [host.json Reference](host-json.md)
+- [Environment Variables](environment-variables.md)
+- [Platform: Triggers and Bindings](../platform/triggers-and-bindings.md)
+
+## Sources
+
+- [Azure Functions overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-overview)
+- [Azure Functions triggers and bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings)
+- [Azure Functions event-driven scaling (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale)
+- [Azure Functions storage considerations (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/storage-considerations)
+</content>
+</invoke>

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -44,6 +44,7 @@ graph TD
 | [Environment Variables](environment-variables.md) | System and application environment variables |
 | [Platform Limits](platform-limits.md) | Timeouts, payload sizes, concurrency limits per hosting plan |
 | [Troubleshooting](troubleshooting.md) | Common issues and debugging for Python function apps |
+| [Glossary](glossary.md) | Definitions of core Azure Functions terms used across this guide |
 
 ## Quick Links
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,7 @@ nav:
     - Hosting: platform/hosting.md
     - Triggers and Bindings: platform/triggers-and-bindings.md
     - Durable Functions: platform/durable-functions.md
+    - Custom Handlers: platform/custom-handlers.md
     - Scaling: platform/scaling.md
     - Networking: platform/networking.md
     - Reliability: platform/reliability.md
@@ -176,15 +177,25 @@ nav:
         - language-guides/python/recipes/index.md
         - language-guides/python/recipes/http-api.md
         - language-guides/python/recipes/http-auth.md
+        - language-guides/python/recipes/openapi.md
         - language-guides/python/recipes/cosmosdb.md
         - language-guides/python/recipes/blob-storage.md
         - language-guides/python/recipes/queue.md
+        - language-guides/python/recipes/table-storage.md
         - language-guides/python/recipes/key-vault.md
         - language-guides/python/recipes/managed-identity.md
         - language-guides/python/recipes/timer.md
         - language-guides/python/recipes/durable-orchestration.md
         - language-guides/python/recipes/durable-entities.md
+        - language-guides/python/recipes/durable-advanced.md
         - language-guides/python/recipes/event-grid.md
+        - language-guides/python/recipes/event-hub.md
+        - language-guides/python/recipes/service-bus.md
+        - language-guides/python/recipes/signalr.md
+        - language-guides/python/recipes/dependency-injection.md
+        - language-guides/python/recipes/retry.md
+        - language-guides/python/recipes/middleware.md
+        - language-guides/python/recipes/testing.md
         - language-guides/python/recipes/custom-domain-certificates.md
       - Python Reference:
         - language-guides/python/cli-cheatsheet.md
@@ -236,14 +247,25 @@ nav:
         - language-guides/nodejs/recipes/index.md
         - language-guides/nodejs/recipes/http-api.md
         - language-guides/nodejs/recipes/http-auth.md
+        - language-guides/nodejs/recipes/openapi.md
         - language-guides/nodejs/recipes/cosmosdb.md
         - language-guides/nodejs/recipes/blob-storage.md
         - language-guides/nodejs/recipes/queue.md
+        - language-guides/nodejs/recipes/table-storage.md
         - language-guides/nodejs/recipes/key-vault.md
         - language-guides/nodejs/recipes/managed-identity.md
         - language-guides/nodejs/recipes/timer.md
         - language-guides/nodejs/recipes/durable-orchestration.md
+        - language-guides/nodejs/recipes/durable-entities.md
+        - language-guides/nodejs/recipes/durable-advanced.md
         - language-guides/nodejs/recipes/event-grid.md
+        - language-guides/nodejs/recipes/event-hub.md
+        - language-guides/nodejs/recipes/service-bus.md
+        - language-guides/nodejs/recipes/signalr.md
+        - language-guides/nodejs/recipes/dependency-injection.md
+        - language-guides/nodejs/recipes/retry.md
+        - language-guides/nodejs/recipes/middleware.md
+        - language-guides/nodejs/recipes/testing.md
         - language-guides/nodejs/recipes/custom-domain-certificates.md
       - Node.js Reference:
         - language-guides/nodejs/cli-cheatsheet.md
@@ -295,14 +317,26 @@ nav:
         - language-guides/dotnet/recipes/index.md
         - language-guides/dotnet/recipes/http-api.md
         - language-guides/dotnet/recipes/http-auth.md
+        - language-guides/dotnet/recipes/openapi.md
         - language-guides/dotnet/recipes/cosmosdb.md
         - language-guides/dotnet/recipes/blob-storage.md
         - language-guides/dotnet/recipes/queue.md
+        - language-guides/dotnet/recipes/table-storage.md
         - language-guides/dotnet/recipes/key-vault.md
         - language-guides/dotnet/recipes/managed-identity.md
         - language-guides/dotnet/recipes/timer.md
         - language-guides/dotnet/recipes/durable-orchestration.md
+        - language-guides/dotnet/recipes/durable-entities.md
+        - language-guides/dotnet/recipes/durable-advanced.md
         - language-guides/dotnet/recipes/event-grid.md
+        - language-guides/dotnet/recipes/event-hub.md
+        - language-guides/dotnet/recipes/service-bus.md
+        - language-guides/dotnet/recipes/signalr.md
+        - language-guides/dotnet/recipes/dependency-injection.md
+        - language-guides/dotnet/recipes/retry.md
+        - language-guides/dotnet/recipes/middleware.md
+        - language-guides/dotnet/recipes/testing.md
+        - language-guides/dotnet/recipes/migrate-to-isolated.md
         - language-guides/dotnet/recipes/custom-domain-certificates.md
       - .NET Reference:
         - language-guides/dotnet/cli-cheatsheet.md
@@ -354,14 +388,25 @@ nav:
         - language-guides/java/recipes/index.md
         - language-guides/java/recipes/http-api.md
         - language-guides/java/recipes/http-auth.md
+        - language-guides/java/recipes/openapi.md
         - language-guides/java/recipes/cosmosdb.md
         - language-guides/java/recipes/blob-storage.md
         - language-guides/java/recipes/queue.md
+        - language-guides/java/recipes/table-storage.md
         - language-guides/java/recipes/key-vault.md
         - language-guides/java/recipes/managed-identity.md
         - language-guides/java/recipes/timer.md
         - language-guides/java/recipes/durable-orchestration.md
+        - language-guides/java/recipes/durable-entities.md
+        - language-guides/java/recipes/durable-advanced.md
         - language-guides/java/recipes/event-grid.md
+        - language-guides/java/recipes/event-hub.md
+        - language-guides/java/recipes/service-bus.md
+        - language-guides/java/recipes/signalr.md
+        - language-guides/java/recipes/dependency-injection.md
+        - language-guides/java/recipes/retry.md
+        - language-guides/java/recipes/middleware.md
+        - language-guides/java/recipes/testing.md
         - language-guides/java/recipes/custom-domain-certificates.md
       - Java Reference:
         - language-guides/java/cli-cheatsheet.md
@@ -369,11 +414,66 @@ nav:
         - language-guides/java/host-json.md
         - language-guides/java/platform-limits.md
         - language-guides/java/troubleshooting.md
+    - PowerShell:
+      - language-guides/powershell/index.md
+      - language-guides/powershell/powershell-programming-model.md
+      - language-guides/powershell/powershell-runtime.md
+      - Tutorial:
+        - Overview & Plan Chooser: language-guides/powershell/tutorial/index.md
+        - Consumption (Y1):
+          - language-guides/powershell/tutorial/consumption/01-local-run.md
+          - language-guides/powershell/tutorial/consumption/02-first-deploy.md
+          - language-guides/powershell/tutorial/consumption/03-configuration.md
+          - language-guides/powershell/tutorial/consumption/04-logging-monitoring.md
+          - language-guides/powershell/tutorial/consumption/05-infrastructure-as-code.md
+          - language-guides/powershell/tutorial/consumption/06-ci-cd.md
+          - language-guides/powershell/tutorial/consumption/07-extending-triggers.md
+        - Flex Consumption (FC1):
+          - language-guides/powershell/tutorial/flex-consumption/01-local-run.md
+          - language-guides/powershell/tutorial/flex-consumption/02-first-deploy.md
+          - language-guides/powershell/tutorial/flex-consumption/03-configuration.md
+          - language-guides/powershell/tutorial/flex-consumption/04-logging-monitoring.md
+          - language-guides/powershell/tutorial/flex-consumption/05-infrastructure-as-code.md
+          - language-guides/powershell/tutorial/flex-consumption/06-ci-cd.md
+          - language-guides/powershell/tutorial/flex-consumption/07-extending-triggers.md
+        - Premium (EP):
+          - language-guides/powershell/tutorial/premium/01-local-run.md
+          - language-guides/powershell/tutorial/premium/02-first-deploy.md
+          - language-guides/powershell/tutorial/premium/03-configuration.md
+          - language-guides/powershell/tutorial/premium/04-logging-monitoring.md
+          - language-guides/powershell/tutorial/premium/05-infrastructure-as-code.md
+          - language-guides/powershell/tutorial/premium/06-ci-cd.md
+          - language-guides/powershell/tutorial/premium/07-extending-triggers.md
+        - Dedicated (App Service Plan):
+          - language-guides/powershell/tutorial/dedicated/01-local-run.md
+          - language-guides/powershell/tutorial/dedicated/02-first-deploy.md
+          - language-guides/powershell/tutorial/dedicated/03-configuration.md
+          - language-guides/powershell/tutorial/dedicated/04-logging-monitoring.md
+          - language-guides/powershell/tutorial/dedicated/05-infrastructure-as-code.md
+          - language-guides/powershell/tutorial/dedicated/06-ci-cd.md
+          - language-guides/powershell/tutorial/dedicated/07-extending-triggers.md
+      - PowerShell Recipes:
+        - language-guides/powershell/recipes/index.md
+        - language-guides/powershell/recipes/http-api.md
+        - language-guides/powershell/recipes/http-auth.md
+        - language-guides/powershell/recipes/blob-storage.md
+        - language-guides/powershell/recipes/queue.md
+        - language-guides/powershell/recipes/service-bus.md
+        - language-guides/powershell/recipes/key-vault.md
+        - language-guides/powershell/recipes/managed-identity.md
+        - language-guides/powershell/recipes/timer.md
+      - PowerShell Reference:
+        - language-guides/powershell/cli-cheatsheet.md
+        - language-guides/powershell/environment-variables.md
+        - language-guides/powershell/host-json.md
+        - language-guides/powershell/platform-limits.md
+        - language-guides/powershell/troubleshooting.md
   - Operations:
     - operations/index.md
     - operations/deployment.md
     - operations/configuration.md
     - operations/monitoring.md
+    - operations/opentelemetry.md
     - operations/alerts.md
     - operations/cold-start.md
     - operations/retries-and-poison-handling.md
@@ -442,6 +542,7 @@ nav:
     - reference/host-json.md
     - reference/environment-variables.md
     - reference/platform-limits.md
+    - reference/glossary.md
     - Metrics:
       - reference/metrics/index.md
       - reference/metrics/function-execution-metrics.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,10 +111,12 @@ nav:
     - Security: platform/security.md
     - Functions vs App Service: platform/functions-vs-app-service.md
     - Deployment Scenarios: platform/deployment-scenarios.md
+    - Storage Connectivity: platform/storage-connectivity.md
     - Networking Scenarios:
       - platform/networking-scenarios/index.md
       - platform/networking-scenarios/public-only.md
       - platform/networking-scenarios/private-egress.md
+      - platform/networking-scenarios/storage-service-endpoint.md
       - platform/networking-scenarios/private-ingress.md
       - platform/networking-scenarios/fixed-outbound-nat.md
   - Best Practices:


### PR DESCRIPTION
## Summary

Improves the accuracy of Azure Functions storage-networking guidance and fills the coverage gap between the two documented extremes (public-only vs. VNet + private endpoint). Adds the missing **Service Endpoint** scenario and a central **Storage Connectivity** reference.

Closes #78, #79, #80, #81.

## Changes

- **fix (#78)** `networking-scenarios/public-only.md` — the absolute "All traffic flows over the public internet" is corrected to distinguish *public-endpoint usage* from *internet routing* (Azure-to-Azure can stay on the Microsoft backbone). Line 226 warning refined similarly.
- **fix (#79)** `networking-scenarios/private-egress.md` — Step 7 now separates the two distinct controls:
    - `publicNetworkAccess = Enabled` + `defaultAction = Deny` → firewall-restricted (Selected networks)
    - `publicNetworkAccess = Disabled` → private-only
  Corrects the command-purpose table and adds accurate CLI for both.
- **new (#80)** `networking-scenarios/storage-service-endpoint.md` — Service Endpoint scenario: `Microsoft.Storage` on the integration subnet, subnet VNet rule on Selected networks, DNS still returns a public IP (expected), no Private DNS / Route All, applied across all storage roles; compared against the private-endpoint approach.
- **new (#81)** `platform/storage-connectivity.md` — central reference:
    - Storage **role** breakdown (Host / Content Share / Trigger-Binding / Deployment / App-data)
    - Authentication vs Network as independent axes
    - Public / Service / Private endpoint postures
    - Hosting-plan differences
    - **Network settings combination matrix** (9 rows incl. the silent-failure "Private Endpoint + missing Private DNS" case)
    - Host startup impact + DNS/connectivity verification
- **nav** wired new pages into `platform/index.md`, `networking-scenarios/index.md` (matrix row 2b), and `mkdocs.yml`.

## Not included

- **#82** (per-scenario portal screenshots) is intentionally left open — real Azure Portal captures require a live deployment and cannot be generated automatically. That issue tracks the human capture work with a PII-masking checklist.

## Validation

- `scripts/normalize_yaml_frontmatter.py --check` → 0 drift
- `scripts/validate_content_sources.py` → 0 errors
- `scripts/normalize_mslearn_locale.py --check` → 0 drift
- `mkdocs build --strict` → exit 0, 0 warnings

All new pages follow the Platform doc template with `content_sources` + verified `content_validation` blocks and MSLearn-cited claims.