### PR TITLE
docs: document CDP capture auth for Conditional Access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,26 @@ Portal screenshots:
 - Use black-box masking only for unavoidable avatar/profile pixels and only with the repository-approved mask color.
 - If a screenshot cannot be visually verified, remove the Markdown reference or disclose the debt explicitly in the PR.
 
+### Authenticating the capture browser (Conditional Access)
+
+Portal captures use the reusable PII helper at [`scripts/portal-capture-helpers.js`](scripts/portal-capture-helpers.js) (usage in [`scripts/portal-capture-helpers.md`](scripts/portal-capture-helpers.md)). The capture browser MUST reuse a **device-compliant, interactively signed-in** session. A fresh, isolated Chromium — whether launched by standalone Playwright or by the MCP browser tool — is **not** an Intune-enrolled / device-compliant browser, so it CANNOT pass Microsoft Entra Conditional Access for the MSIT (`ms.portal.azure.com`) tenant. It loops on the sign-in / `ConditionalAccess/Enrollment` ("install Company Portal") wall. **Do not** burn cycles trying to defeat this from automation — it is a device-level security control, not a cookie problem.
+
+Working pattern (attach to a real, human-authenticated Chrome over CDP):
+
+1. **Launch the user's Chrome with a dedicated debug profile and a remote-debugging port.** A dedicated `--user-data-dir` avoids Chrome's block on debugging the default profile, and OS-level Platform SSO / Company Portal still satisfies device compliance:
+    ```bash
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+      --remote-debugging-port=9222 \
+      --user-data-dir="$HOME/.chrome-portal-capture" \
+      --no-first-run --no-default-browser-check \
+      "https://ms.portal.azure.com/"
+    ```
+2. **The human signs in interactively (including MFA) and navigates to the target blade.** The agent CANNOT complete MFA — hand this step to the user explicitly and wait.
+3. **Verify the port is bound before attaching:** `curl -s http://localhost:9222/json/version`, and poll `http://localhost:9222/json` to detect when the target blade URL has loaded.
+4. **Attach Playwright over CDP** with `chromium.connectOverCDP('http://localhost:9222')`, pick the page whose URL contains `portal.azure.com`, apply the PII helper, then screenshot. `browser.close()` on a CDP-attached browser only detaches the debugger; it does NOT close the user's Chrome.
+
+Common failure: relaunching the Chrome binary while Chrome is already running just opens a tab in the existing (non-debug) process and silently ignores `--remote-debugging-port`. Always confirm the port with `curl`/`nc` before assuming the debug instance is up.
+
 ## Microsoft Learn URL Locale
 
 All `learn.microsoft.com` URLs SHOULD use the `en-us` locale prefix.


### PR DESCRIPTION
## Summary
- Document the CDP-attach workflow for capturing Azure Portal screenshots under Microsoft Entra Conditional Access.
- Explains why an isolated Playwright/MCP Chromium cannot pass device-compliance Conditional Access on the MSIT tenant, and the working pattern: launch the user's real Chrome with `--remote-debugging-port=9222` + a dedicated `--user-data-dir`, have the human complete MFA interactively, then attach via `chromium.connectOverCDP`.
- Adds a "Common failure" note about relaunching Chrome while it is already running silently ignoring the debug port.