### PR TITLE
docs: add tutorial steps 08 (testing/debugging) and 09 (container deployment)

### DIFF
--- a/docs/language-guides/dotnet/tutorial/flex-consumption/08-testing-and-debugging.md
+++ b/docs/language-guides/dotnet/tutorial/flex-consumption/08-testing-and-debugging.md
@@ -1,0 +1,160 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 08 - Testing and Local Debugging (Flex Consumption)
+
+Unit-test your .NET isolated-worker functions with xUnit, mock `HttpRequestData` and `FunctionContext`, run integration tests against Azurite, and attach the Visual Studio debugger to a running host.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| .NET SDK | 8.0 | Build and run functions and tests |
+| Azure Functions Core Tools | 4.x | Local host and debugging |
+| xUnit + Moq | Latest | Test frameworks |
+| Azurite | 3.x | Local Azure Storage emulator |
+| Visual Studio / VS Code | Latest | Breakpoint debugging |
+
+## What You'll Build
+
+You will add an xUnit test project that unit-tests business logic, mocks the isolated-worker HTTP types, runs an Azurite integration test, and attaches the debugger to a running host.
+
+## 1. Unit Test the Logic
+
+Keep logic out of the trigger so it tests without Functions types.
+
+```csharp
+// Greeter.cs
+public static class Greeter
+{
+    public static string Build(string? name) =>
+        $"Hello, {(string.IsNullOrWhiteSpace(name) ? "world" : name.Trim())}!";
+}
+```
+
+```csharp
+// tests/GreeterTests.cs
+using Xunit;
+
+public class GreeterTests
+{
+    [Theory]
+    [InlineData("  ada ", "Hello, ada!")]
+    [InlineData(null, "Hello, world!")]
+    public void Build_FormatsGreeting(string? input, string expected) =>
+        Assert.Equal(expected, Greeter.Build(input));
+}
+```
+
+```bash
+dotnet test
+```
+
+## 2. Mock the Isolated-Worker HTTP Types
+
+`HttpRequestData` and `HttpResponseData` are abstract, so mock a minimal `FunctionContext` with a service provider that supplies them.
+
+```csharp
+// tests/HttpFunctionTests.cs
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+public class HttpFunctionTests
+{
+    private static FunctionContext Context()
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        var ctx = new Mock<FunctionContext>();
+        ctx.SetupProperty(c => c.InstanceServices, services);
+        return ctx.Object;
+    }
+
+    [Fact]
+    public async Task Hello_Returns_Ok()
+    {
+        var context = Context();
+        var request = new FakeHttpRequestData(context, query: "name=grace");
+        var response = new HttpFunction().Run(request);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}
+```
+
+!!! tip "Reuse a test double"
+    Rather than mocking `HttpRequestData` repeatedly, write a small `FakeHttpRequestData : HttpRequestData` test double that exposes a settable query string and body stream, and reuse it across tests.
+
+## 3. Integration Test Against Azurite
+
+```bash
+npm install -g azurite
+azurite --silent --location ./.azurite &
+```
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+  }
+}
+```
+
+Use `Azure.Storage.Queues.QueueClient` with the `UseDevelopmentStorage=true` connection string inside an xUnit test to create a queue, send a message, receive it, and delete the queue — validating binding behavior without a real account.
+
+## 4. Breakpoint Debugging with Core Tools
+
+Start the host and attach the debugger:
+
+```bash
+func start
+```
+
+In Visual Studio choose **Debug > Attach to Process** and select the `func.exe` (or the isolated worker `dotnet` process). In VS Code use a `coreclr` attach configuration. Set a breakpoint in the function, then call `http://localhost:7071/api/hello?name=ada`.
+
+!!! info "Flex Consumption note"
+    Testing and debugging run entirely on your local machine and are identical across hosting plans. The Flex Consumption plan changes only how the deployed app scales and networks.
+
+## Verification
+
+- [ ] `dotnet test` reports all tests passing.
+- [ ] The Azurite integration test round-trips a queue message without a real storage account.
+- [ ] A breakpoint in the function is hit when you invoke the local endpoint.
+
+## Next Steps
+
+- Wire `dotnet test` into your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- Extend coverage to the triggers you added in [07 - Extending with Triggers](07-extending-triggers.md).
+
+## See Also
+
+- [Testing recipe](../../recipes/testing.md) — Framework-agnostic testing patterns
+- [Run functions locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) — Core Tools reference
+- [07 - Extending with Triggers](07-extending-triggers.md)
+
+## Sources
+
+- [Code and test Azure Functions locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Guide for running C# Azure Functions in an isolated worker process (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide)
+- [Use Azurite emulator for local Azure Storage development (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite)
+</content>

--- a/docs/language-guides/dotnet/tutorial/index.md
+++ b/docs/language-guides/dotnet/tutorial/index.md
@@ -68,6 +68,7 @@ flowchart TD
 - 05 [Infrastructure as Code](flex-consumption/05-infrastructure-as-code.md)
 - 06 [CI/CD](flex-consumption/06-ci-cd.md)
 - 07 [Extending Triggers](flex-consumption/07-extending-triggers.md)
+- 08 [Testing and Debugging](flex-consumption/08-testing-and-debugging.md)
 
 ### [Premium](premium/01-local-run.md)
 - 01 [Run Locally](premium/01-local-run.md)
@@ -77,6 +78,7 @@ flowchart TD
 - 05 [Infrastructure as Code](premium/05-infrastructure-as-code.md)
 - 06 [CI/CD](premium/06-ci-cd.md)
 - 07 [Extending Triggers](premium/07-extending-triggers.md)
+- 09 [Container Deployment](premium/09-container-deployment.md)
 
 ### [Dedicated](dedicated/01-local-run.md)
 - 01 [Run Locally](dedicated/01-local-run.md)

--- a/docs/language-guides/dotnet/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/dotnet/tutorial/premium/09-container-deployment.md
@@ -1,0 +1,136 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deploy-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/container-apps/functions-overview
+---
+# 09 - Container Deployment (Premium)
+
+Package your .NET isolated-worker function app as a Linux container with a multi-stage build, push it to Azure Container Registry, and deploy it to a Premium plan with a managed-identity registry pull.
+
+## Which Plans Support Custom Containers?
+
+Custom container images are **not** available on every hosting plan. Choose your target deliberately:
+
+| Hosting plan | Custom container image? | Notes |
+|---|:---:|---|
+| Consumption (Y1) | ❌ | Code deploy only (zip / run-from-package) |
+| Flex Consumption (FC1) | ❌ | One-deploy zip only; no custom image |
+| **Premium (EP)** | ✅ | Elastic Premium — this tutorial |
+| Dedicated (App Service) | ✅ | Also supports webhook-based continuous deployment |
+| Azure Container Apps | ✅ | Recommended for most **new** container workloads |
+
+!!! tip "New container workloads: consider Azure Container Apps"
+    Microsoft now recommends [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview) for most new containerized workloads. This tutorial targets the **Premium (EP) plan**, which is the right choice when you need custom containers alongside classic Functions networking and slots.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| .NET SDK | 8.0 | Function app runtime |
+| Azure Functions Core Tools | 4.x | Generate the Dockerfile |
+| Docker | Latest | Build the image locally (optional if using ACR build) |
+| Azure CLI | 2.83+ | Provision ACR, plan, and app |
+| Azure Container Registry | Existing or new | Store the image |
+
+## What You'll Build
+
+You will add a multi-stage Dockerfile to the .NET isolated app, build and push the image to ACR, create a Premium plan function app configured to pull that image, and grant the app's managed identity `AcrPull` so it authenticates without registry passwords.
+
+## 1. Generate the Dockerfile
+
+`func init --docker-only` (or the Visual Studio **Enable Docker** option) produces a multi-stage Dockerfile for the isolated worker:
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish -c Release -o /app/output
+
+FROM mcr.microsoft.com/azure-functions/dotnet-isolated:4-dotnet-isolated8.0
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+COPY --from=build /app/output /home/site/wwwroot
+```
+
+!!! warning "Keep the base image current"
+    You own the base image. Rebuild and redeploy monthly from the latest [`mcr.microsoft.com/azure-functions/dotnet-isolated`](https://mcr.microsoft.com/catalog?search=functions) tag to pick up runtime and security fixes.
+
+## 2. Build and Push to Azure Container Registry
+
+```bash
+az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
+az acr build --registry $REGISTRY_NAME --image functions/dotnet-app:v1.0.0 .
+```
+
+## 3. Create the Premium Plan and Function App
+
+```bash
+az functionapp plan create --resource-group $RG --name $PLAN_NAME \
+  --location $LOCATION --sku EP1 --is-linux
+
+az functionapp create --resource-group $RG --name $APP_NAME \
+  --storage-account $STORAGE_NAME --plan $PLAN_NAME \
+  --functions-version 4 --runtime dotnet-isolated \
+  --image $REGISTRY_NAME.azurecr.io/functions/dotnet-app:v1.0.0 \
+  --assign-identity "[system]"
+```
+
+## 4. Grant Managed-Identity Registry Pull
+
+```bash
+PRINCIPAL_ID=$(az functionapp identity show --resource-group $RG --name $APP_NAME --query principalId --output tsv)
+REGISTRY_ID=$(az acr show --name $REGISTRY_NAME --query id --output tsv)
+
+az role assignment create --assignee $PRINCIPAL_ID --role AcrPull --scope $REGISTRY_ID
+az resource update --ids "$(az functionapp show --resource-group $RG --name $APP_NAME --query id --output tsv)/config/web" \
+  --set properties.acrUseManagedIdentityCreds=true
+```
+
+## 5. Update the Image
+
+```bash
+az acr build --registry $REGISTRY_NAME --image functions/dotnet-app:v1.0.1 .
+az functionapp config container set --resource-group $RG --name $APP_NAME \
+  --image $REGISTRY_NAME.azurecr.io/functions/dotnet-app:v1.0.1
+```
+
+!!! info "Continuous deployment on Premium"
+    Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.
+
+## Verification
+
+- [ ] `az acr build` completes and the image appears in `az acr repository list --name $REGISTRY_NAME`.
+- [ ] The function app starts and serves requests from the container image.
+- [ ] `az functionapp config container show` reports the expected image, and `acrUseManagedIdentityCreds` is `true` (no stored registry password).
+
+## Next Steps
+
+- Automate build-and-push in your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- For webhook-based redeploys, evaluate the Dedicated plan or Azure Container Apps.
+
+## See Also
+
+- [08 - Testing and Debugging](../flex-consumption/08-testing-and-debugging.md) — Test before you containerize
+- [Work with Azure Functions in containers](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+
+## Sources
+
+- [Work with Azure Functions in containers (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Create a function app in a local Linux container (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry)
+- [Azure Container Apps hosting of Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+</content>

--- a/docs/language-guides/java/tutorial/flex-consumption/08-testing-and-debugging.md
+++ b/docs/language-guides/java/tutorial/flex-consumption/08-testing-and-debugging.md
@@ -1,0 +1,150 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 08 - Testing and Local Debugging (Flex Consumption)
+
+Unit-test your Java function methods with JUnit 5, mock `HttpRequestMessage` and `ExecutionContext` with Mockito, run integration tests against Azurite, and attach a remote debugger to the running host.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| Java | 17 | Run function code and tests |
+| Maven | 3.9 | Build and test runner |
+| Azure Functions Core Tools | 4.x | Local host and debugging |
+| JUnit 5 + Mockito | Latest | Test frameworks |
+| Azurite | 3.x | Local Azure Storage emulator |
+
+## What You'll Build
+
+You will add JUnit 5 tests to the Flex Consumption app that unit-test an HTTP function, mock the request and execution context, run an Azurite integration test, and attach IntelliJ or VS Code to a debug-enabled host.
+
+## 1. Unit Test the Function Method
+
+Keep logic in a plain method so it is testable without Azure types.
+
+```java
+// src/main/java/com/example/Greeter.java
+public final class Greeter {
+    public static String build(String name) {
+        String value = (name == null || name.isBlank()) ? "world" : name.trim();
+        return "Hello, " + value + "!";
+    }
+}
+```
+
+```java
+// src/test/java/com/example/GreeterTest.java
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class GreeterTest {
+    @Test
+    void buildsGreeting() {
+        assertEquals("Hello, ada!", Greeter.build("  ada "));
+    }
+}
+```
+
+```bash
+mvn test
+```
+
+## 2. Mock the Trigger with Mockito
+
+Mock `HttpRequestMessage`, `ExecutionContext`, and the response builder to test the trigger method end to end.
+
+```java
+// src/test/java/com/example/HttpFunctionTest.java
+import com.microsoft.azure.functions.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import java.util.*;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttpFunctionTest {
+    @Test
+    void returnsGreeting() {
+        @SuppressWarnings("unchecked")
+        HttpRequestMessage<Optional<String>> req = mock(HttpRequestMessage.class);
+        when(req.getQueryParameters()).thenReturn(Map.of("name", "grace"));
+
+        final HttpResponseMessage.Builder builder = mock(HttpResponseMessage.Builder.class);
+        when(req.createResponseBuilder(any(HttpStatus.class))).thenReturn(builder);
+        when(builder.body(any())).thenReturn(builder);
+        when(builder.build()).thenReturn(mock(HttpResponseMessage.class));
+
+        ExecutionContext ctx = mock(ExecutionContext.class);
+        when(ctx.getLogger()).thenReturn(java.util.logging.Logger.getGlobal());
+
+        new HttpFunction().run(req, ctx);
+        verify(req).createResponseBuilder(HttpStatus.OK);
+    }
+}
+```
+
+## 3. Integration Test Against Azurite
+
+```bash
+npm install -g azurite
+azurite --silent --location ./.azurite &
+```
+
+Use the well-known development connection string (`UseDevelopmentStorage=true`) with the Azure Storage Queue SDK to create, send, and read a message inside a JUnit test, then delete the queue. This validates binding behavior without a real storage account.
+
+## 4. Remote Debugging with Core Tools
+
+Start the host with JVM debug options and attach on port 5005.
+
+```bash
+mvn azure-functions:run -DenableDebug
+# or export JAVA_OPTS before func start:
+export JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+func start
+```
+
+Attach a **Remote JVM Debug** run configuration to `localhost:5005` in IntelliJ, set a breakpoint in the function method, then invoke `http://localhost:7071/api/hello?name=ada`.
+
+!!! info "Flex Consumption note"
+    Testing and debugging run entirely on your local machine and are identical across hosting plans. The Flex Consumption plan changes only how the deployed app scales and networks.
+
+## Verification
+
+- [ ] `mvn test` reports all tests passing.
+- [ ] The Azurite integration test round-trips a queue message without a real storage account.
+- [ ] A breakpoint in the function method is hit when you invoke the local endpoint over the JDWP attach.
+
+## Next Steps
+
+- Wire `mvn test` into your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- Extend coverage to the triggers you added in [07 - Extending with Triggers](07-extending-triggers.md).
+
+## See Also
+
+- [Testing recipe](../../recipes/testing.md) — Framework-agnostic testing patterns
+- [Run functions locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) — Core Tools reference
+- [07 - Extending with Triggers](07-extending-triggers.md)
+
+## Sources
+
+- [Code and test Azure Functions locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions Java developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java)
+- [Use Azurite emulator for local Azure Storage development (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite)
+</content>

--- a/docs/language-guides/java/tutorial/index.md
+++ b/docs/language-guides/java/tutorial/index.md
@@ -68,7 +68,7 @@ Always-ready instances and advanced deployment patterns for low-latency systems.
 
 Fixed-capacity hosting for teams already operating App Service footprints.
 
-## Seven-Step Learning Sequence
+## Learning Sequence
 
 | Step | Focus | Outcome |
 |------|-------|---------|
@@ -79,6 +79,8 @@ Fixed-capacity hosting for teams already operating App Service footprints.
 | 05 | Infrastructure as Code | Reproduce platform with Bicep templates |
 | 06 | CI/CD | Automate build, test, and deployment |
 | 07 | Extending Triggers | Add queue, blob, timer, and event-driven patterns |
+| 08 | Testing and Debugging | Unit test logic, mock bindings, integration test with Azurite, attach a debugger (Flex track) |
+| 09 | Container Deployment | Package as a Linux container, push to ACR, deploy with managed-identity pull (Premium track) |
 
 ## See Also
 

--- a/docs/language-guides/java/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/java/tutorial/premium/09-container-deployment.md
@@ -1,0 +1,138 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deploy-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/container-apps/functions-overview
+---
+# 09 - Container Deployment (Premium)
+
+Package your Java function app as a Linux container with a multi-stage build, push it to Azure Container Registry, and deploy it to a Premium plan with a managed-identity registry pull.
+
+## Which Plans Support Custom Containers?
+
+Custom container images are **not** available on every hosting plan. Choose your target deliberately:
+
+| Hosting plan | Custom container image? | Notes |
+|---|:---:|---|
+| Consumption (Y1) | ❌ | Code deploy only (zip / run-from-package) |
+| Flex Consumption (FC1) | ❌ | One-deploy zip only; no custom image |
+| **Premium (EP)** | ✅ | Elastic Premium — this tutorial |
+| Dedicated (App Service) | ✅ | Also supports webhook-based continuous deployment |
+| Azure Container Apps | ✅ | Recommended for most **new** container workloads |
+
+!!! tip "New container workloads: consider Azure Container Apps"
+    Microsoft now recommends [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview) for most new containerized workloads. This tutorial targets the **Premium (EP) plan**, which is the right choice when you need custom containers alongside classic Functions networking and slots.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| Java | 17 | Function app runtime |
+| Maven | 3.9 | Build the deployable artifact |
+| Azure Functions Core Tools | 4.x | Generate the Dockerfile |
+| Docker | Latest | Build the image locally (optional if using ACR build) |
+| Azure CLI | 2.83+ | Provision ACR, plan, and app |
+
+## What You'll Build
+
+You will add a multi-stage Dockerfile to the Java app, build and push the image to ACR, create a Premium plan function app configured to pull that image, and grant the app's managed identity `AcrPull` so it authenticates without registry passwords.
+
+## 1. Create a Multi-Stage Dockerfile
+
+Java requires a Maven build step. Use a builder stage, then copy the staged app into the Functions base image.
+
+```dockerfile
+# Build stage
+FROM mcr.microsoft.com/openjdk/jdk:17-mariner AS build
+WORKDIR /src
+COPY . .
+RUN mvn clean package -DskipTests
+
+# Runtime stage
+FROM mcr.microsoft.com/azure-functions/java:4-java17
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+COPY --from=build /src/target/azure-functions/*/ /home/site/wwwroot
+```
+
+!!! warning "Keep the base image current"
+    You own the base image. Rebuild and redeploy monthly from the latest [`mcr.microsoft.com/azure-functions/java`](https://mcr.microsoft.com/catalog?search=functions) tag to pick up runtime and security fixes.
+
+## 2. Build and Push to Azure Container Registry
+
+```bash
+az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
+az acr build --registry $REGISTRY_NAME --image functions/java-app:v1.0.0 .
+```
+
+## 3. Create the Premium Plan and Function App
+
+```bash
+az functionapp plan create --resource-group $RG --name $PLAN_NAME \
+  --location $LOCATION --sku EP1 --is-linux
+
+az functionapp create --resource-group $RG --name $APP_NAME \
+  --storage-account $STORAGE_NAME --plan $PLAN_NAME \
+  --functions-version 4 --runtime java \
+  --image $REGISTRY_NAME.azurecr.io/functions/java-app:v1.0.0 \
+  --assign-identity "[system]"
+```
+
+## 4. Grant Managed-Identity Registry Pull
+
+```bash
+PRINCIPAL_ID=$(az functionapp identity show --resource-group $RG --name $APP_NAME --query principalId --output tsv)
+REGISTRY_ID=$(az acr show --name $REGISTRY_NAME --query id --output tsv)
+
+az role assignment create --assignee $PRINCIPAL_ID --role AcrPull --scope $REGISTRY_ID
+az resource update --ids "$(az functionapp show --resource-group $RG --name $APP_NAME --query id --output tsv)/config/web" \
+  --set properties.acrUseManagedIdentityCreds=true
+```
+
+## 5. Update the Image
+
+```bash
+az acr build --registry $REGISTRY_NAME --image functions/java-app:v1.0.1 .
+az functionapp config container set --resource-group $RG --name $APP_NAME \
+  --image $REGISTRY_NAME.azurecr.io/functions/java-app:v1.0.1
+```
+
+!!! info "Continuous deployment on Premium"
+    Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.
+
+## Verification
+
+- [ ] `az acr build` completes and the image appears in `az acr repository list --name $REGISTRY_NAME`.
+- [ ] The function app starts and serves requests from the container image.
+- [ ] `az functionapp config container show` reports the expected image, and `acrUseManagedIdentityCreds` is `true` (no stored registry password).
+
+## Next Steps
+
+- Automate build-and-push in your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- For webhook-based redeploys, evaluate the Dedicated plan or Azure Container Apps.
+
+## See Also
+
+- [08 - Testing and Debugging](../flex-consumption/08-testing-and-debugging.md) — Test before you containerize
+- [Work with Azure Functions in containers](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+
+## Sources
+
+- [Work with Azure Functions in containers (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Create a function app in a local Linux container (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry)
+- [Azure Container Apps hosting of Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+</content>

--- a/docs/language-guides/nodejs/tutorial/flex-consumption/08-testing-and-debugging.md
+++ b/docs/language-guides/nodejs/tutorial/flex-consumption/08-testing-and-debugging.md
@@ -1,0 +1,189 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 08 - Testing and Local Debugging (Flex Consumption)
+
+Test your Node.js v4 handlers in isolation, mock the invocation context and bindings, run local integration tests against Azurite, and attach the Node inspector for breakpoint debugging.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| Node.js | 20 LTS | Run function code and tests |
+| Azure Functions Core Tools | 4.x | Local host and debugging |
+| Jest or Vitest | Latest | Test runner |
+| Azurite | 3.x | Local Azure Storage emulator |
+| Visual Studio Code | Latest | Breakpoint debugging (optional) |
+
+## What You'll Build
+
+You will add a test suite to the Flex Consumption app that unit-tests an HTTP handler, mocks the `InvocationContext`, runs an integration test against Azurite, and attaches the Node inspector to a running host.
+
+## 1. Unit Test the Handler
+
+In the v4 model a handler is a plain async function, so it tests cleanly. Keep logic separate from the trigger registration.
+
+```javascript
+// src/logic.js
+export function buildGreeting(name) {
+  return `Hello, ${(name ?? "world").trim()}!`;
+}
+```
+
+```javascript
+// src/functions/hello.js
+import { app } from "@azure/functions";
+import { buildGreeting } from "../logic.js";
+
+export async function hello(request, context) {
+  const name = request.query.get("name");
+  return { status: 200, body: buildGreeting(name) };
+}
+
+app.http("hello", { methods: ["GET"], authLevel: "function", handler: hello });
+```
+
+```javascript
+// test/logic.test.js
+import { buildGreeting } from "../src/logic.js";
+
+test("buildGreeting trims and formats", () => {
+  expect(buildGreeting("  ada ")).toBe("Hello, ada!");
+});
+```
+
+```bash
+npm install --save-dev jest
+npx jest
+```
+
+## 2. Mock the Invocation Context and Request
+
+Build lightweight fakes for `HttpRequest` and `InvocationContext` to exercise the handler directly.
+
+```javascript
+// test/hello.test.js
+import { hello } from "../src/functions/hello.js";
+
+function fakeRequest(query = {}) {
+  return { query: new Map(Object.entries(query)) };
+}
+
+function fakeContext() {
+  return { log: () => {}, error: () => {}, invocationId: "test-1" };
+}
+
+test("hello returns a greeting", async () => {
+  const res = await hello(fakeRequest({ name: "grace" }), fakeContext());
+  expect(res.status).toBe(200);
+  expect(res.body).toBe("Hello, grace!");
+});
+```
+
+!!! tip "Keep the handler exportable"
+    Export the handler function separately from the `app.http(...)` registration so tests can import it without booting the Functions host.
+
+## 3. Integration Test Against Azurite
+
+Azurite emulates Blob, Queue, and Table storage locally.
+
+```bash
+npm install -g azurite
+azurite --silent --location ./.azurite &
+```
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "node"
+  }
+}
+```
+
+```javascript
+// test/queue.integration.test.js
+import { QueueServiceClient } from "@azure/storage-queue";
+
+const CONN = "UseDevelopmentStorage=true";
+
+test("queue roundtrip against Azurite", async () => {
+  const svc = QueueServiceClient.fromConnectionString(CONN);
+  const queue = svc.getQueueClient("work-items");
+  await queue.createIfNotExists();
+  await queue.sendMessage(Buffer.from("job-42").toString("base64"));
+  const msgs = await queue.receiveMessages();
+  expect(Buffer.from(msgs.receivedMessageItems[0].messageText, "base64").toString()).toBe("job-42");
+  await queue.deleteIfExists();
+});
+```
+
+## 4. Breakpoint Debugging with the Node Inspector
+
+Start the host with the inspector enabled:
+
+```bash
+func start --node-inspect
+```
+
+Attach from VS Code with `.vscode/launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to Node Functions",
+      "type": "node",
+      "request": "attach",
+      "port": 9229
+    }
+  ]
+}
+```
+
+Set a breakpoint in `hello`, attach, then call `http://localhost:7071/api/hello?name=ada`.
+
+!!! info "Flex Consumption note"
+    Testing and debugging run entirely on your local machine and are identical across hosting plans. The Flex Consumption plan changes only how the deployed app scales and networks.
+
+## Verification
+
+- [ ] `npx jest` reports all tests passing.
+- [ ] The Azurite integration test round-trips a queue message without a real storage account.
+- [ ] A VS Code breakpoint in `hello` is hit when you invoke the local endpoint.
+
+## Next Steps
+
+- Wire these tests into your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- Extend coverage to the triggers you added in [07 - Extending with Triggers](07-extending-triggers.md).
+
+## See Also
+
+- [Testing recipe](../../recipes/testing.md) — Framework-agnostic testing patterns
+- [Run functions locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) — Core Tools reference
+- [07 - Extending with Triggers](07-extending-triggers.md)
+
+## Sources
+
+- [Code and test Azure Functions locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions Node.js developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-node)
+- [Use Azurite emulator for local Azure Storage development (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite)
+</content>

--- a/docs/language-guides/nodejs/tutorial/index.md
+++ b/docs/language-guides/nodejs/tutorial/index.md
@@ -17,7 +17,7 @@ content_sources:
 ---
 # Tutorial - Choose Your Hosting Plan
 
-This section provides four independent Node.js tutorial tracks. Each track follows the same seven steps from local development to production operations.
+This section provides four independent Node.js tutorial tracks. Each track follows the same core steps from local development to production operations, with additional steps on some tracks.
 
 ## Which Plan Should I Start With?
 
@@ -61,6 +61,8 @@ flowchart TD
 | 05 | Infrastructure as code |
 | 06 | CI/CD |
 | 07 | Extending triggers |
+| 08 | Testing and debugging (Flex track) |
+| 09 | Container deployment (Premium track) |
 
 ## See Also
 - [Node.js Language Guide](../index.md)

--- a/docs/language-guides/nodejs/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/nodejs/tutorial/premium/09-container-deployment.md
@@ -1,0 +1,140 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deploy-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/container-apps/functions-overview
+---
+# 09 - Container Deployment (Premium)
+
+Package your Node.js function app as a Linux container, push it to Azure Container Registry, and deploy it to a Premium plan with a managed-identity registry pull.
+
+## Which Plans Support Custom Containers?
+
+Custom container images are **not** available on every hosting plan. Choose your target deliberately:
+
+| Hosting plan | Custom container image? | Notes |
+|---|:---:|---|
+| Consumption (Y1) | ❌ | Code deploy only (zip / run-from-package) |
+| Flex Consumption (FC1) | ❌ | One-deploy zip only; no custom image |
+| **Premium (EP)** | ✅ | Elastic Premium — this tutorial |
+| Dedicated (App Service) | ✅ | Also supports webhook-based continuous deployment |
+| Azure Container Apps | ✅ | Recommended for most **new** container workloads |
+
+!!! tip "New container workloads: consider Azure Container Apps"
+    Microsoft now recommends [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview) for most new containerized workloads. This tutorial targets the **Premium (EP) plan**, which is the right choice when you need custom containers alongside classic Functions networking and slots.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| Node.js | 20 LTS | Function app runtime |
+| Azure Functions Core Tools | 4.x | Generate the Dockerfile |
+| Docker | Latest | Build the image locally (optional if using ACR build) |
+| Azure CLI | 2.83+ | Provision ACR, plan, and app |
+| Azure Container Registry | Existing or new | Store the image |
+
+## What You'll Build
+
+You will add a Dockerfile to the Node.js app, build and push the image to ACR, create a Premium plan function app configured to pull that image, and grant the app's managed identity `AcrPull` so it authenticates without registry passwords.
+
+## 1. Generate the Dockerfile
+
+```bash
+func init --docker-only
+```
+
+This adds a Dockerfile deriving from the official Node base image:
+
+```dockerfile
+FROM mcr.microsoft.com/azure-functions/node:4-node20
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY package*.json /home/site/wwwroot/
+RUN cd /home/site/wwwroot && npm install --omit=dev
+
+COPY . /home/site/wwwroot
+```
+
+!!! warning "Keep the base image current"
+    You own the base image. Rebuild and redeploy monthly from the latest [`mcr.microsoft.com/azure-functions/node`](https://mcr.microsoft.com/catalog?search=functions) tag to pick up runtime and security fixes.
+
+## 2. Build and Push to Azure Container Registry
+
+```bash
+az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
+az acr build --registry $REGISTRY_NAME --image functions/node-app:v1.0.0 .
+```
+
+## 3. Create the Premium Plan and Function App
+
+```bash
+az functionapp plan create --resource-group $RG --name $PLAN_NAME \
+  --location $LOCATION --sku EP1 --is-linux
+
+az functionapp create --resource-group $RG --name $APP_NAME \
+  --storage-account $STORAGE_NAME --plan $PLAN_NAME \
+  --functions-version 4 --runtime node \
+  --image $REGISTRY_NAME.azurecr.io/functions/node-app:v1.0.0 \
+  --assign-identity "[system]"
+```
+
+## 4. Grant Managed-Identity Registry Pull
+
+```bash
+PRINCIPAL_ID=$(az functionapp identity show --resource-group $RG --name $APP_NAME --query principalId --output tsv)
+REGISTRY_ID=$(az acr show --name $REGISTRY_NAME --query id --output tsv)
+
+az role assignment create --assignee $PRINCIPAL_ID --role AcrPull --scope $REGISTRY_ID
+az resource update --ids "$(az functionapp show --resource-group $RG --name $APP_NAME --query id --output tsv)/config/web" \
+  --set properties.acrUseManagedIdentityCreds=true
+```
+
+## 5. Update the Image
+
+```bash
+az acr build --registry $REGISTRY_NAME --image functions/node-app:v1.0.1 .
+az functionapp config container set --resource-group $RG --name $APP_NAME \
+  --image $REGISTRY_NAME.azurecr.io/functions/node-app:v1.0.1
+```
+
+!!! info "Continuous deployment on Premium"
+    Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.
+
+## Verification
+
+- [ ] `az acr build` completes and the image appears in `az acr repository list --name $REGISTRY_NAME`.
+- [ ] The function app starts and serves requests from the container image.
+- [ ] `az functionapp config container show` reports the expected image, and `acrUseManagedIdentityCreds` is `true` (no stored registry password).
+
+## Next Steps
+
+- Automate build-and-push in your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- For webhook-based redeploys, evaluate the Dedicated plan or Azure Container Apps.
+
+## See Also
+
+- [08 - Testing and Debugging](../flex-consumption/08-testing-and-debugging.md) — Test before you containerize
+- [Work with Azure Functions in containers](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+
+## Sources
+
+- [Work with Azure Functions in containers (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Create a function app in a local Linux container (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry)
+- [Azure Container Apps hosting of Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+</content>

--- a/docs/language-guides/powershell/tutorial/flex-consumption/08-testing-and-debugging.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/08-testing-and-debugging.md
@@ -1,0 +1,151 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 08 - Testing and Local Debugging (Flex Consumption)
+
+Unit-test your PowerShell function logic with Pester, mock output bindings, run integration tests against Azurite, and step through code with the PowerShell debugger.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| PowerShell | 7.4 | Run function code and tests |
+| Azure Functions Core Tools | 4.x | Local host and debugging |
+| Pester | 5.x | Test framework |
+| Azurite | 3.x | Local Azure Storage emulator |
+| Visual Studio Code | Latest | Breakpoint debugging (optional) |
+
+## What You'll Build
+
+You will add Pester tests to the Flex Consumption app that unit-test greeting logic, mock the `Push-OutputBinding` call, run an Azurite integration test, and step through `run.ps1` with the VS Code PowerShell debugger.
+
+## 1. Unit Test the Logic
+
+Extract logic into a module function so Pester can test it without the Functions host.
+
+```powershell
+# Modules/Greeting/Greeting.psm1
+function Build-Greeting {
+    param([string] $Name)
+    $value = if ([string]::IsNullOrWhiteSpace($Name)) { 'world' } else { $Name.Trim() }
+    "Hello, $value!"
+}
+Export-ModuleMember -Function Build-Greeting
+```
+
+```powershell
+# tests/Greeting.Tests.ps1
+BeforeAll {
+    Import-Module "$PSScriptRoot/../Modules/Greeting/Greeting.psm1" -Force
+}
+
+Describe 'Build-Greeting' {
+    It 'trims and formats the name' {
+        Build-Greeting -Name '  ada ' | Should -Be 'Hello, ada!'
+    }
+    It 'defaults to world' {
+        Build-Greeting -Name '' | Should -Be 'Hello, world!'
+    }
+}
+```
+
+```powershell
+Install-Module Pester -Scope CurrentUser -Force
+Invoke-Pester ./tests
+```
+
+## 2. Mock Output Bindings
+
+`Push-OutputBinding` is provided by the Functions worker. In a Pester test, mock it to assert what your `run.ps1` would send back.
+
+```powershell
+# tests/HttpTrigger.Tests.ps1
+Describe 'HttpTrigger' {
+    It 'pushes an OK response with the greeting' {
+        Mock Push-OutputBinding {}
+
+        $Request = [pscustomobject]@{ Query = @{ name = 'grace' } }
+        . "$PSScriptRoot/../HttpTrigger/run.ps1"
+
+        Should -Invoke Push-OutputBinding -Times 1 -ParameterFilter {
+            $Value.StatusCode -eq [System.Net.HttpStatusCode]::OK
+        }
+    }
+}
+```
+
+!!! tip "Make run.ps1 testable"
+    Dot-source `run.ps1` inside the test so its `param($Request, $TriggerMetadata)` block executes against your fake `$Request`. Keep heavy logic in a module function that you can test independently.
+
+## 3. Integration Test Against Azurite
+
+```bash
+npm install -g azurite
+azurite --silent --location ./.azurite &
+```
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "powershell",
+    "FUNCTIONS_WORKER_RUNTIME_VERSION": "7.4"
+  }
+}
+```
+
+Use the `Az.Storage` module (or the .NET `QueueClient`) with `UseDevelopmentStorage=true` inside a Pester test to create a queue, send a message, read it back, and delete the queue — validating storage behavior without a real account.
+
+## 4. Breakpoint Debugging with Core Tools
+
+Start the host, then attach the VS Code PowerShell debugger:
+
+```bash
+func start --verbose
+```
+
+Add a breakpoint in `run.ps1`, open the **Run and Debug** panel, and choose **PowerShell: Attach to Host Process** (select the `pwsh` worker process). Invoke `http://localhost:7071/api/HttpTrigger?name=ada` to hit the breakpoint. You can also set `Set-PSBreakpoint` interactively.
+
+!!! info "Flex Consumption note"
+    Testing and debugging run entirely on your local machine and are identical across hosting plans. Note that managed dependencies (`requirements.psd1`) are **not** supported on Flex Consumption — bundle modules in a `Modules` folder, which also keeps your local test imports and deployed runtime consistent.
+
+## Verification
+
+- [ ] `Invoke-Pester ./tests` reports all tests passing.
+- [ ] The output-binding mock asserts an OK response without a running host.
+- [ ] A breakpoint in `run.ps1` is hit when you invoke the local endpoint.
+
+## Next Steps
+
+- Wire `Invoke-Pester` into your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- Extend coverage to the triggers you added in [07 - Extending with Triggers](07-extending-triggers.md).
+
+## See Also
+
+- [Testing recipe](../../recipes/index.md) — Recipe index for cross-cutting patterns
+- [Run functions locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) — Core Tools reference
+- [07 - Extending with Triggers](07-extending-triggers.md)
+
+## Sources
+
+- [Code and test Azure Functions locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions PowerShell developer guide (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Use Azurite emulator for local Azure Storage development (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite)
+</content>

--- a/docs/language-guides/powershell/tutorial/index.md
+++ b/docs/language-guides/powershell/tutorial/index.md
@@ -105,6 +105,7 @@ Next-generation serverless — scale-to-zero with VNet integration. Microsoft's 
 | 05 | [Infrastructure as Code](flex-consumption/05-infrastructure-as-code.md) |
 | 06 | [CI/CD](flex-consumption/06-ci-cd.md) |
 | 07 | [Extending with Triggers](flex-consumption/07-extending-triggers.md) |
+| 08 | [Testing & Debugging](flex-consumption/08-testing-and-debugging.md) |
 
 ### 🚀 [Premium (EP)](premium/01-local-run.md)
 
@@ -119,6 +120,7 @@ Always-warm instances with VNet support and deployment slots. Best for latency-s
 | 05 | [Infrastructure as Code](premium/05-infrastructure-as-code.md) |
 | 06 | [CI/CD](premium/06-ci-cd.md) |
 | 07 | [Extending with Triggers](premium/07-extending-triggers.md) |
+| 09 | [Container Deployment](premium/09-container-deployment.md) |
 
 ### 🖥️ [Dedicated (App Service Plan)](dedicated/01-local-run.md)
 
@@ -145,6 +147,8 @@ Traditional App Service hosting with predictable pricing. Best when you already 
 | 05 | **Infrastructure as Code** | Define all resources in Bicep, deploy reproducibly |
 | 06 | **CI/CD** | Automate build and deploy with GitHub Actions |
 | 07 | **Extending with Triggers** | Add Timer, Queue, and Blob triggers beyond HTTP |
+| 08 | **Testing & Debugging** | Unit test logic, mock triggers/bindings, integration test with Azurite, attach a debugger (Flex track) |
+| 09 | **Container Deployment** | Package as a Linux container, push to ACR, deploy with managed-identity pull (Premium track) |
 
 ## See Also
 

--- a/docs/language-guides/powershell/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/powershell/tutorial/premium/09-container-deployment.md
@@ -1,0 +1,142 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deploy-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/container-apps/functions-overview
+---
+# 09 - Container Deployment (Premium)
+
+Package your PowerShell function app as a Linux container, push it to Azure Container Registry, and deploy it to a Premium plan with a managed-identity registry pull.
+
+## Which Plans Support Custom Containers?
+
+Custom container images are **not** available on every hosting plan. Choose your target deliberately:
+
+| Hosting plan | Custom container image? | Notes |
+|---|:---:|---|
+| Consumption (Y1) | ❌ | Code deploy only (zip / run-from-package) |
+| Flex Consumption (FC1) | ❌ | One-deploy zip only; no custom image |
+| **Premium (EP)** | ✅ | Elastic Premium — this tutorial |
+| Dedicated (App Service) | ✅ | Also supports webhook-based continuous deployment |
+| Azure Container Apps | ✅ | Recommended for most **new** container workloads |
+
+!!! tip "New container workloads: consider Azure Container Apps"
+    Microsoft now recommends [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview) for most new containerized workloads, because it gives you the full Container Apps feature set with the Functions programming model. This tutorial targets the **Premium (EP) plan**, which is the right choice when you need custom containers alongside classic Functions networking and slots.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| PowerShell | 7.4 | Function app runtime |
+| Azure Functions Core Tools | 4.x | Generate the Dockerfile |
+| Docker | Latest | Build the image locally (optional if using ACR build) |
+| Azure CLI | 2.83+ | Provision ACR, plan, and app |
+| Azure Container Registry | Existing or new | Store the image |
+
+## What You'll Build
+
+You will add a Dockerfile to the PowerShell app, build and push the image to ACR, create a Premium plan function app configured to pull that image, and grant the app's managed identity `AcrPull` so it authenticates without registry passwords.
+
+## 1. Generate the Dockerfile
+
+```bash
+func init --docker-only
+```
+
+This adds a Dockerfile deriving from the official PowerShell base image:
+
+```dockerfile
+FROM mcr.microsoft.com/azure-functions/powershell:4-powershell7.4
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY . /home/site/wwwroot
+```
+
+!!! warning "Keep the base image current"
+    You own the base image. Rebuild and redeploy monthly from the latest [`mcr.microsoft.com/azure-functions/powershell`](https://mcr.microsoft.com/catalog?search=functions) tag to pick up runtime and security fixes.
+
+## 2. Build and Push to Azure Container Registry
+
+Build the image directly in ACR (no local Docker required):
+
+```bash
+az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
+az acr build --registry $REGISTRY_NAME --image functions/powershell-app:v1.0.0 .
+```
+
+## 3. Create the Premium Plan and Function App
+
+```bash
+az functionapp plan create --resource-group $RG --name $PLAN_NAME \
+  --location $LOCATION --sku EP1 --is-linux
+
+az functionapp create --resource-group $RG --name $APP_NAME \
+  --storage-account $STORAGE_NAME --plan $PLAN_NAME \
+  --functions-version 4 --runtime powershell \
+  --image $REGISTRY_NAME.azurecr.io/functions/powershell-app:v1.0.0 \
+  --assign-identity "[system]"
+```
+
+## 4. Grant Managed-Identity Registry Pull
+
+Avoid storing registry credentials — let the app's system-assigned identity pull the image.
+
+```bash
+PRINCIPAL_ID=$(az functionapp identity show --resource-group $RG --name $APP_NAME --query principalId --output tsv)
+REGISTRY_ID=$(az acr show --name $REGISTRY_NAME --query id --output tsv)
+
+az role assignment create --assignee $PRINCIPAL_ID --role AcrPull --scope $REGISTRY_ID
+az resource update --ids "$(az functionapp show --resource-group $RG --name $APP_NAME --query id --output tsv)/config/web" \
+  --set properties.acrUseManagedIdentityCreds=true
+```
+
+## 5. Update the Image
+
+Rebuild with a new tag and point the app at it:
+
+```bash
+az acr build --registry $REGISTRY_NAME --image functions/powershell-app:v1.0.1 .
+az functionapp config container set --resource-group $RG --name $APP_NAME \
+  --image $REGISTRY_NAME.azurecr.io/functions/powershell-app:v1.0.1
+```
+
+!!! info "Continuous deployment on Premium"
+    Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy the container on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.
+
+## Verification
+
+- [ ] `az acr build` completes and the image appears in `az acr repository list --name $REGISTRY_NAME`.
+- [ ] The function app starts and serves requests from the container image.
+- [ ] `az functionapp config container show` reports the expected image, and `acrUseManagedIdentityCreds` is `true` (no stored registry password).
+
+## Next Steps
+
+- Automate build-and-push in your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- For webhook-based redeploys, evaluate the Dedicated plan or Azure Container Apps.
+
+## See Also
+
+- [08 - Testing and Debugging](../flex-consumption/08-testing-and-debugging.md) — Test before you containerize
+- [Work with Azure Functions in containers](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+
+## Sources
+
+- [Work with Azure Functions in containers (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Create a function app in a local Linux container (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry)
+- [Azure Container Apps hosting of Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)

--- a/docs/language-guides/python/tutorial/flex-consumption/08-testing-and-debugging.md
+++ b/docs/language-guides/python/tutorial/flex-consumption/08-testing-and-debugging.md
@@ -1,0 +1,188 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+---
+# 08 - Testing and Local Debugging (Flex Consumption)
+
+Test your Python function logic in isolation, mock triggers and bindings, run local integration tests against Azurite, and attach a debugger with Azure Functions Core Tools.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| Python | 3.11 | Run function code and tests |
+| Azure Functions Core Tools | 4.x | Local host and debugging |
+| pytest | 8.x | Unit and integration test runner |
+| Azurite | 3.x | Local Azure Storage emulator |
+| Visual Studio Code | Latest | Breakpoint debugging (optional) |
+
+## What You'll Build
+
+You will add a `tests/` suite to the Flex Consumption app that unit-tests HTTP handler logic, mocks a queue binding, runs an integration test against the Azurite storage emulator, and attaches the VS Code debugger to a running function host.
+
+## 1. Unit Test the Function Logic
+
+Keep business logic in plain functions so it can be tested without the Functions runtime. The trigger entry point should be a thin wrapper.
+
+```python
+# function_app.py
+import azure.functions as func
+from logic import build_greeting
+
+app = func.FunctionApp()
+
+@app.route(route="hello", auth_level=func.AuthLevel.FUNCTION)
+def hello(req: func.HttpRequest) -> func.HttpResponse:
+    name = req.params.get("name") or "world"
+    return func.HttpResponse(build_greeting(name), status_code=200)
+```
+
+```python
+# logic.py
+def build_greeting(name: str) -> str:
+    return f"Hello, {name.strip().title()}!"
+```
+
+```python
+# tests/test_logic.py
+from logic import build_greeting
+
+def test_build_greeting_titlecases():
+    assert build_greeting("  ada lovelace ") == "Hello, Ada Lovelace!"
+```
+
+Run the tests:
+
+```bash
+pip install pytest azure-functions
+python -m pytest -v
+```
+
+## 2. Mock Triggers and Bindings
+
+Construct an `HttpRequest` directly to exercise the trigger without a running host.
+
+```python
+# tests/test_hello.py
+import azure.functions as func
+from function_app import hello
+
+def test_hello_returns_greeting():
+    req = func.HttpRequest(
+        method="GET",
+        url="/api/hello",
+        params={"name": "grace"},
+        body=b"",
+    )
+    resp = hello.build().get_user_function()(req)
+    assert resp.status_code == 200
+    assert resp.get_body() == b"Hello, Grace!"
+```
+
+!!! tip "Testing decorated functions"
+    In the Python v2 model, `hello` is a `Function` object. Use `.build().get_user_function()` to reach the underlying callable, or refactor the body into `logic.py` and unit-test that directly.
+
+## 3. Integration Test Against Azurite
+
+Azurite emulates Blob, Queue, and Table storage locally so tests never touch a real account.
+
+```bash
+npm install -g azurite
+azurite --silent --location ./.azurite &
+```
+
+Point `AzureWebJobsStorage` at the emulator in `local.settings.json`:
+
+```json
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "python"
+  }
+}
+```
+
+```python
+# tests/test_queue_integration.py
+from azure.storage.queue import QueueClient
+
+CONN = "UseDevelopmentStorage=true"
+
+def test_queue_message_roundtrip():
+    queue = QueueClient.from_connection_string(CONN, "work-items")
+    queue.create_queue()
+    queue.send_message("job-42")
+    msg = queue.receive_message()
+    assert msg.content == "job-42"
+    queue.delete_queue()
+```
+
+## 4. Breakpoint Debugging with Core Tools
+
+Start the host so it waits for a debugger and attach from VS Code.
+
+```bash
+func start --verbose
+```
+
+Add an attach configuration to `.vscode/launch.json`:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to Python Functions",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": { "host": "localhost", "port": 9091 }
+    }
+  ]
+}
+```
+
+Set a breakpoint in `hello`, start the attach configuration, then call `http://localhost:7071/api/hello?name=ada`. Execution pauses at the breakpoint.
+
+!!! info "Flex Consumption note"
+    Testing and debugging happen entirely on your local machine and are identical across hosting plans. The Flex Consumption plan only affects how the app scales and networks once deployed — it does not change how you test.
+
+## Verification
+
+- [ ] `python -m pytest -v` reports all tests passing.
+- [ ] The Azurite integration test creates, reads, and deletes a queue without a real storage account.
+- [ ] A VS Code breakpoint in `hello` is hit when you invoke the local endpoint.
+
+## Next Steps
+
+- Wire these tests into your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- Extend coverage to the triggers you added in [07 - Extending with Triggers](07-extending-triggers.md).
+
+## See Also
+
+- [Testing recipe](../../recipes/testing.md) — Framework-agnostic testing patterns
+- [Run functions locally](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) — Core Tools reference
+- [07 - Extending with Triggers](07-extending-triggers.md)
+
+## Sources
+
+- [Code and test Azure Functions locally (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-develop-local)
+- [Azure Functions Python developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Use Azurite emulator for local Azure Storage development (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite)
+</content>
+</invoke>

--- a/docs/language-guides/python/tutorial/index.md
+++ b/docs/language-guides/python/tutorial/index.md
@@ -331,6 +331,7 @@ Next-generation serverless — scale-to-zero with VNet integration, configurable
 | 05 | [Infrastructure as Code](flex-consumption/05-infrastructure-as-code.md) |
 | 06 | [CI/CD](flex-consumption/06-ci-cd.md) |
 | 07 | [Extending with Triggers](flex-consumption/07-extending-triggers.md) |
+| 08 | [Testing & Debugging](flex-consumption/08-testing-and-debugging.md) |
 
 ### 🚀 [Premium (EP)](premium/01-local-run.md)
 
@@ -345,6 +346,7 @@ Always-warm instances with VNet support and deployment slots. Best for latency-s
 | 05 | [Infrastructure as Code](premium/05-infrastructure-as-code.md) |
 | 06 | [CI/CD](premium/06-ci-cd.md) |
 | 07 | [Extending with Triggers](premium/07-extending-triggers.md) |
+| 09 | [Container Deployment](premium/09-container-deployment.md) |
 
 ### 🖥️ [Dedicated (App Service Plan)](dedicated/01-local-run.md)
 
@@ -371,6 +373,8 @@ Traditional App Service hosting with predictable pricing. Best when you already 
 | 05 | **Infrastructure as Code** | Define all resources in Bicep, deploy reproducibly |
 | 06 | **CI/CD** | Automate build, test, and deploy with GitHub Actions |
 | 07 | **Extending with Triggers** | Add Timer, Blob, Queue, and Event Grid triggers beyond HTTP |
+| 08 | **Testing & Debugging** | Unit test logic, mock triggers/bindings, integration test with Azurite, attach a debugger (Flex track) |
+| 09 | **Container Deployment** | Package as a Linux container, push to ACR, deploy with managed-identity pull (Premium track) |
 
 ## See Also
 

--- a/docs/language-guides/python/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/python/tutorial/premium/09-container-deployment.md
@@ -1,0 +1,146 @@
+---
+validation:
+  az_cli:
+    last_tested:
+    result: not_tested
+  bicep:
+    last_tested:
+    result: not_tested
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-deploy-container
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/container-apps/functions-overview
+---
+# 09 - Container Deployment (Premium)
+
+Package your Python function app as a Linux container, push it to Azure Container Registry, and deploy it to a Premium plan with a managed-identity registry pull.
+
+## Which Plans Support Custom Containers?
+
+Custom container images are **not** available on every hosting plan. Choose your target deliberately:
+
+| Hosting plan | Custom container image? | Notes |
+|---|:---:|---|
+| Consumption (Y1) | ❌ | Code deploy only (zip / run-from-package) |
+| Flex Consumption (FC1) | ❌ | One-deploy zip only; no custom image |
+| **Premium (EP)** | ✅ | Elastic Premium — this tutorial |
+| Dedicated (App Service) | ✅ | Also supports webhook-based continuous deployment |
+| Azure Container Apps | ✅ | Recommended for most **new** container workloads |
+
+!!! tip "New container workloads: consider Azure Container Apps"
+    Microsoft now recommends [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview) for most new containerized workloads, because it gives you the full Container Apps feature set with the Functions programming model. This tutorial targets the **Premium (EP) plan**, which is the right choice when you need custom containers alongside classic Functions networking and slots.
+
+## Prerequisites
+
+| Tool | Minimum version | Purpose |
+|---|---|---|
+| Python | 3.11 | Function app runtime |
+| Azure Functions Core Tools | 4.x | Generate the Dockerfile |
+| Docker | Latest | Build the image locally (optional if using ACR build) |
+| Azure CLI | 2.83+ | Provision ACR, plan, and app |
+| Azure Container Registry | Existing or new | Store the image |
+
+## What You'll Build
+
+You will add a Dockerfile to the Python app, build and push the image to ACR, create a Premium plan function app configured to pull that image, and grant the app's managed identity `AcrPull` so it authenticates without registry passwords.
+
+## 1. Generate the Dockerfile
+
+```bash
+func init --docker-only
+```
+
+This adds a Dockerfile deriving from the official Python base image:
+
+```dockerfile
+FROM mcr.microsoft.com/azure-functions/python:4-python3.11
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+COPY requirements.txt /
+RUN pip install --no-cache-dir -r /requirements.txt
+
+COPY . /home/site/wwwroot
+```
+
+!!! warning "Keep the base image current"
+    You own the base image. Rebuild and redeploy monthly from the latest [`mcr.microsoft.com/azure-functions/python`](https://mcr.microsoft.com/catalog?search=functions) tag to pick up runtime and security fixes.
+
+## 2. Build and Push to Azure Container Registry
+
+Build the image directly in ACR (no local Docker required):
+
+```bash
+az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
+az acr build --registry $REGISTRY_NAME --image functions/python-app:v1.0.0 .
+```
+
+## 3. Create the Premium Plan and Function App
+
+```bash
+az functionapp plan create --resource-group $RG --name $PLAN_NAME \
+  --location $LOCATION --sku EP1 --is-linux
+
+az functionapp create --resource-group $RG --name $APP_NAME \
+  --storage-account $STORAGE_NAME --plan $PLAN_NAME \
+  --functions-version 4 --runtime python \
+  --image $REGISTRY_NAME.azurecr.io/functions/python-app:v1.0.0 \
+  --assign-identity "[system]"
+```
+
+## 4. Grant Managed-Identity Registry Pull
+
+Avoid storing registry credentials — let the app's system-assigned identity pull the image.
+
+```bash
+PRINCIPAL_ID=$(az functionapp identity show --resource-group $RG --name $APP_NAME --query principalId --output tsv)
+REGISTRY_ID=$(az acr show --name $REGISTRY_NAME --query id --output tsv)
+
+az role assignment create --assignee $PRINCIPAL_ID --role AcrPull --scope $REGISTRY_ID
+az resource update --ids "$(az functionapp show --resource-group $RG --name $APP_NAME --query id --output tsv)/config/web" \
+  --set properties.acrUseManagedIdentityCreds=true
+```
+
+## 5. Update the Image
+
+Rebuild with a new tag and point the app at it:
+
+```bash
+az acr build --registry $REGISTRY_NAME --image functions/python-app:v1.0.1 .
+az functionapp config container set --resource-group $RG --name $APP_NAME \
+  --image $REGISTRY_NAME.azurecr.io/functions/python-app:v1.0.1
+```
+
+!!! info "Continuous deployment on Premium"
+    Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy the container on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.
+
+## Verification
+
+- [ ] `az acr build` completes and the image appears in `az acr repository list --name $REGISTRY_NAME`.
+- [ ] The function app starts and serves requests from the container image.
+- [ ] `az functionapp config container show` reports the expected image, and `acrUseManagedIdentityCreds` is `true` (no stored registry password).
+
+## Next Steps
+
+- Automate build-and-push in your pipeline — see [06 - CI/CD](06-ci-cd.md).
+- For webhook-based redeploys, evaluate the Dedicated plan or Azure Container Apps.
+
+## See Also
+
+- [08 - Testing and Debugging](../flex-consumption/08-testing-and-debugging.md) — Test before you containerize
+- [Work with Azure Functions in containers](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Azure Functions on Azure Container Apps](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+
+## Sources
+
+- [Work with Azure Functions in containers (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-custom-container)
+- [Create a function app in a local Linux container (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-create-container-registry)
+- [Azure Container Apps hosting of Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/container-apps/functions-overview)
+</content>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,6 +165,7 @@ nav:
           - language-guides/python/tutorial/flex-consumption/05-infrastructure-as-code.md
           - language-guides/python/tutorial/flex-consumption/06-ci-cd.md
           - language-guides/python/tutorial/flex-consumption/07-extending-triggers.md
+          - language-guides/python/tutorial/flex-consumption/08-testing-and-debugging.md
         - Premium (EP):
           - language-guides/python/tutorial/premium/01-local-run.md
           - language-guides/python/tutorial/premium/02-first-deploy.md
@@ -174,6 +175,7 @@ nav:
           - language-guides/python/tutorial/premium/05-infrastructure-as-code.md
           - language-guides/python/tutorial/premium/06-ci-cd.md
           - language-guides/python/tutorial/premium/07-extending-triggers.md
+          - language-guides/python/tutorial/premium/09-container-deployment.md
         - Dedicated (App Service Plan):
           - language-guides/python/tutorial/dedicated/01-local-run.md
           - language-guides/python/tutorial/dedicated/02-first-deploy.md
@@ -235,6 +237,7 @@ nav:
           - language-guides/nodejs/tutorial/flex-consumption/05-infrastructure-as-code.md
           - language-guides/nodejs/tutorial/flex-consumption/06-ci-cd.md
           - language-guides/nodejs/tutorial/flex-consumption/07-extending-triggers.md
+          - language-guides/nodejs/tutorial/flex-consumption/08-testing-and-debugging.md
         - Premium (EP):
           - language-guides/nodejs/tutorial/premium/01-local-run.md
           - language-guides/nodejs/tutorial/premium/02-first-deploy.md
@@ -244,6 +247,7 @@ nav:
           - language-guides/nodejs/tutorial/premium/05-infrastructure-as-code.md
           - language-guides/nodejs/tutorial/premium/06-ci-cd.md
           - language-guides/nodejs/tutorial/premium/07-extending-triggers.md
+          - language-guides/nodejs/tutorial/premium/09-container-deployment.md
         - Dedicated (App Service Plan):
           - language-guides/nodejs/tutorial/dedicated/01-local-run.md
           - language-guides/nodejs/tutorial/dedicated/02-first-deploy.md
@@ -305,6 +309,7 @@ nav:
           - language-guides/dotnet/tutorial/flex-consumption/05-infrastructure-as-code.md
           - language-guides/dotnet/tutorial/flex-consumption/06-ci-cd.md
           - language-guides/dotnet/tutorial/flex-consumption/07-extending-triggers.md
+          - language-guides/dotnet/tutorial/flex-consumption/08-testing-and-debugging.md
         - Premium (EP):
           - language-guides/dotnet/tutorial/premium/01-local-run.md
           - language-guides/dotnet/tutorial/premium/02-first-deploy.md
@@ -314,6 +319,7 @@ nav:
           - language-guides/dotnet/tutorial/premium/05-infrastructure-as-code.md
           - language-guides/dotnet/tutorial/premium/06-ci-cd.md
           - language-guides/dotnet/tutorial/premium/07-extending-triggers.md
+          - language-guides/dotnet/tutorial/premium/09-container-deployment.md
         - Dedicated (App Service Plan):
           - language-guides/dotnet/tutorial/dedicated/01-local-run.md
           - language-guides/dotnet/tutorial/dedicated/02-first-deploy.md
@@ -376,6 +382,7 @@ nav:
           - language-guides/java/tutorial/flex-consumption/05-infrastructure-as-code.md
           - language-guides/java/tutorial/flex-consumption/06-ci-cd.md
           - language-guides/java/tutorial/flex-consumption/07-extending-triggers.md
+          - language-guides/java/tutorial/flex-consumption/08-testing-and-debugging.md
         - Premium (EP):
           - language-guides/java/tutorial/premium/01-local-run.md
           - language-guides/java/tutorial/premium/02-first-deploy.md
@@ -385,6 +392,7 @@ nav:
           - language-guides/java/tutorial/premium/05-infrastructure-as-code.md
           - language-guides/java/tutorial/premium/06-ci-cd.md
           - language-guides/java/tutorial/premium/07-extending-triggers.md
+          - language-guides/java/tutorial/premium/09-container-deployment.md
         - Dedicated (App Service Plan):
           - language-guides/java/tutorial/dedicated/01-local-run.md
           - language-guides/java/tutorial/dedicated/02-first-deploy.md
@@ -445,6 +453,7 @@ nav:
           - language-guides/powershell/tutorial/flex-consumption/05-infrastructure-as-code.md
           - language-guides/powershell/tutorial/flex-consumption/06-ci-cd.md
           - language-guides/powershell/tutorial/flex-consumption/07-extending-triggers.md
+          - language-guides/powershell/tutorial/flex-consumption/08-testing-and-debugging.md
         - Premium (EP):
           - language-guides/powershell/tutorial/premium/01-local-run.md
           - language-guides/powershell/tutorial/premium/02-first-deploy.md
@@ -453,6 +462,7 @@ nav:
           - language-guides/powershell/tutorial/premium/05-infrastructure-as-code.md
           - language-guides/powershell/tutorial/premium/06-ci-cd.md
           - language-guides/powershell/tutorial/premium/07-extending-triggers.md
+          - language-guides/powershell/tutorial/premium/09-container-deployment.md
         - Dedicated (App Service Plan):
           - language-guides/powershell/tutorial/dedicated/01-local-run.md
           - language-guides/powershell/tutorial/dedicated/02-first-deploy.md


### PR DESCRIPTION
## Summary
- Adds **step 08 — Testing and Debugging** to the Flex Consumption track for all 5 languages (python, nodejs, java, dotnet, powershell). Covers unit testing function logic, mocking triggers/bindings, local integration testing with Azurite, and breakpoint/attach debugging with Core Tools. Resolves #103.
- Adds **step 09 — Container Deployment** to the Premium track for all 5 languages. Covers the Functions base-image Dockerfile per language, `func init --docker-only`, building/pushing to ACR, deploying a custom container image, and managed-identity `AcrPull`. Includes a plan-support table clarifying that custom containers require Premium/Dedicated/Container Apps (not Consumption or Flex). Resolves #104.
- Wires both steps into `mkdocs.yml` nav and every `tutorial/index.md` step table.

## Placement rationale
- Step 08 (testing, plan-independent) lives on the **Flex Consumption** track (the recommended default plan).
- Step 09 (containers) lives on the **Premium** track for accuracy — Consumption and Flex Consumption do not support custom container images.

## Validation
- `python3 scripts/normalize_yaml_frontmatter.py --check` — 0 drift
- `python3 scripts/validate_content_sources.py` — 0 errors
- `mkdocs build --strict` — EXIT=0, no broken links

All new pages carry `validation:` frontmatter (`result: not_tested`) and `## See Also` + `## Sources` tail sections. No Mermaid diagrams (prose-only pages).