### PR TITLE
docs: add 11 PowerShell recipes for language-guide parity

### DIFF
--- a/docs/language-guides/powershell/recipes/cosmosdb.md
+++ b/docs/language-guides/powershell/recipes/cosmosdb.md
@@ -1,0 +1,93 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Azure Cosmos DB
+
+React to document changes and read/write items with Azure Cosmos DB bindings in PowerShell.
+
+## Change Feed Trigger
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Documents",
+      "type": "cosmosDBTrigger",
+      "direction": "in",
+      "databaseName": "catalog",
+      "containerName": "products",
+      "connection": "CosmosDbConnection",
+      "leaseContainerName": "leases",
+      "createLeaseContainerIfNotExists": true
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($Documents, $TriggerMetadata)
+
+Write-Information "Change feed delivered $($Documents.Count) document(s)"
+foreach ($doc in $Documents) {
+    Write-Information "Changed document id: $($doc.id)"
+}
+```
+
+The trigger uses a lease container to track its position in the change feed. Keep the lease container in the same account as the monitored container.
+
+## Input Binding
+
+Read a single item by id and partition key:
+
+```json
+{
+  "name": "Product",
+  "type": "cosmosDB",
+  "direction": "in",
+  "databaseName": "catalog",
+  "containerName": "products",
+  "connection": "CosmosDbConnection",
+  "id": "{Query.id}",
+  "partitionKey": "{Query.category}"
+}
+```
+
+## Output Binding
+
+```json
+{
+  "name": "OutputDocument",
+  "type": "cosmosDB",
+  "direction": "out",
+  "databaseName": "catalog",
+  "containerName": "products",
+  "connection": "CosmosDbConnection"
+}
+```
+
+```powershell
+Push-OutputBinding -Name OutputDocument -Value @{ id = [guid]::NewGuid().ToString(); category = "books"; name = "Sample" }
+```
+
+!!! tip "Identity-based connections"
+    Configure `CosmosDbConnection__accountEndpoint` with a managed identity instead of an account key. See [Managed Identity](managed-identity.md).
+
+## See Also
+
+- [Table Storage](table-storage.md)
+- [Managed Identity](managed-identity.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Azure Cosmos DB bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/powershell/recipes/custom-domain-certificates.md
@@ -1,0 +1,58 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Custom Domain and Certificates
+
+Configure an HTTPS custom domain and TLS certificate for a PowerShell Function App.
+
+## Add a Custom Hostname
+
+Point a CNAME (or A record) at the Function App, then bind the hostname:
+
+```bash
+az functionapp config hostname add --name "$APP_NAME" --resource-group "$RG" --hostname "api.example.com"
+```
+
+## Create a Managed Certificate
+
+App Service managed certificates are free and auto-renew:
+
+```bash
+az functionapp config ssl create --name "$APP_NAME" --resource-group "$RG" --hostname "api.example.com"
+```
+
+## Bind the Certificate
+
+```bash
+az functionapp config ssl bind --name "$APP_NAME" --resource-group "$RG" --certificate-thumbprint "<thumbprint>" --ssl-type SNI
+```
+
+## Enforce HTTPS
+
+Redirect all HTTP traffic to HTTPS:
+
+```bash
+az functionapp update --name "$APP_NAME" --resource-group "$RG" --set httpsOnly=true
+```
+
+!!! warning "Hosting plan support"
+    Flex Consumption does not support managed/platform certificates. Use Premium or Dedicated plans when you need a bound custom-domain certificate, or front the app with Azure Front Door.
+
+!!! tip "Automating certificate provisioning"
+    Use the `Az.Websites` PowerShell module (`New-AzWebAppSSLBinding`) to script certificate binding in a deployment pipeline instead of manual portal steps.
+
+## See Also
+
+- [HTTP Authentication](http-auth.md)
+- [Managed Identity](managed-identity.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Add and manage TLS/SSL certificates (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/app-service/configure-ssl-certificate)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/durable-advanced.md
+++ b/docs/language-guides/powershell/recipes/durable-advanced.md
@@ -35,7 +35,7 @@ return ($results | Measure-Object -Sum).Sum
 Use durable timers for reliable delays and timeouts instead of `Start-Sleep`:
 
 ```powershell
-$expiry = $Context.CurrentUtcDateTime.AddHours(1)
+# Suspend the orchestration for one hour, then resume deterministically
 Start-DurableTimer -Duration (New-TimeSpan -Hours 1)
 ```
 

--- a/docs/language-guides/powershell/recipes/durable-advanced.md
+++ b/docs/language-guides/powershell/recipes/durable-advanced.md
@@ -1,0 +1,113 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Durable Advanced Patterns
+
+Apply fan-out/fan-in, external events, durable timers, and eternal orchestrations with Durable Functions in PowerShell. These patterns build on the [Durable Orchestration](durable-orchestration.md) basics.
+
+## Fan-Out / Fan-In
+
+Run activities in parallel with `-NoWait`, then join the results:
+
+```powershell
+param($Context)
+
+$items = $Context.Input
+
+$parallelTasks = foreach ($item in $items) {
+    Invoke-DurableActivity -FunctionName 'ProcessItem' -Input $item -NoWait
+}
+
+$results = Wait-ActivityFunction -Task $parallelTasks
+
+return ($results | Measure-Object -Sum).Sum
+```
+
+`Wait-ActivityFunction` blocks until all scheduled tasks complete and returns their results in order.
+
+## Durable Timers
+
+Use durable timers for reliable delays and timeouts instead of `Start-Sleep`:
+
+```powershell
+$expiry = $Context.CurrentUtcDateTime.AddHours(1)
+Start-DurableTimer -Duration (New-TimeSpan -Hours 1)
+```
+
+## Waiting for External Events
+
+Suspend an orchestration until an external signal (such as a human approval) arrives:
+
+```powershell
+param($Context)
+
+$approval = Start-DurableExternalEventListener -EventName "ApprovalReceived"
+
+if ($approval.approved) {
+    Invoke-DurableActivity -FunctionName 'Publish' -Input $Context.Input
+}
+```
+
+Raise the event from a client function:
+
+```powershell
+Send-DurableExternalEvent -InstanceId $instanceId -EventName "ApprovalReceived" -EventData @{ approved = $true }
+```
+
+## Timeout with Event Race
+
+Combine a durable timer with an event listener to enforce an approval deadline:
+
+```powershell
+$timeoutTask  = Start-DurableTimer -Duration (New-TimeSpan -Days 1) -NoWait
+$approvalTask = Start-DurableExternalEventListener -EventName "ApprovalReceived" -NoWait
+
+$winner = Wait-DurableTask -Task @($approvalTask, $timeoutTask) -Any
+
+if ($winner -eq $approvalTask) {
+    Write-Information "Approved in time"
+} else {
+    Write-Information "Approval timed out"
+}
+```
+
+## Recurring Work (Periodic Orchestrations)
+
+PowerShell does not support the `ContinueAsNew` / continue-as-new pattern used by other Durable Functions SDKs. For recurring cleanup or monitoring, run a **singleton** orchestration (fixed instance ID) that loops with a durable timer:
+
+```powershell
+param($Context)
+
+while ($true) {
+    Invoke-DurableActivity -FunctionName 'RunHealthCheck'
+    Start-DurableTimer -Duration (New-TimeSpan -Minutes 5)
+}
+```
+
+Start it as a singleton from the client so only one instance runs:
+
+```powershell
+$instanceId = Start-DurableOrchestration -FunctionName 'HealthCheckOrchestrator' -InstanceId 'singleton-healthcheck'
+```
+
+!!! warning "History growth"
+    Because PowerShell cannot reset orchestration history with continue-as-new, a long-running loop accumulates history over time. Keep the per-iteration work small and consider a Timer trigger instead for simple schedules. See [Timer Trigger](timer.md).
+
+!!! warning "Entities not supported"
+    Durable **entities** (entity triggers and entity clients) are not supported in the PowerShell model. Model stateful coordination with orchestrations and external storage instead.
+
+## See Also
+
+- [Durable Orchestration](durable-orchestration.md)
+- [Retries and Error Handling](retry.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Durable Functions overview (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/durable-advanced.md
+++ b/docs/language-guides/powershell/recipes/durable-advanced.md
@@ -23,12 +23,12 @@ $parallelTasks = foreach ($item in $items) {
     Invoke-DurableActivity -FunctionName 'ProcessItem' -Input $item -NoWait
 }
 
-$results = Wait-ActivityFunction -Task $parallelTasks
+$results = Wait-DurableTask -Task $parallelTasks
 
 return ($results | Measure-Object -Sum).Sum
 ```
 
-`Wait-ActivityFunction` blocks until all scheduled tasks complete and returns their results in order.
+`Wait-DurableTask` blocks until all scheduled tasks complete and returns their results in order. (`Wait-ActivityFunction` is a backward-compatible alias for the same cmdlet.)
 
 ## Durable Timers
 

--- a/docs/language-guides/powershell/recipes/durable-orchestration.md
+++ b/docs/language-guides/powershell/recipes/durable-orchestration.md
@@ -33,6 +33,32 @@ Durable Functions require the extension bundle and the managed dependency to ins
 
 An HTTP-triggered client starts the orchestration and returns status URLs. It uses an `httpTrigger`, an `http` output, and a `durableClient` input binding.
 
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Request",
+      "type": "httpTrigger",
+      "direction": "in",
+      "methods": ["post"],
+      "route": "orders"
+    },
+    {
+      "name": "Response",
+      "type": "http",
+      "direction": "out"
+    },
+    {
+      "name": "starter",
+      "type": "durableClient",
+      "direction": "in"
+    }
+  ]
+}
+```
+
 `run.ps1`:
 
 ```powershell

--- a/docs/language-guides/powershell/recipes/durable-orchestration.md
+++ b/docs/language-guides/powershell/recipes/durable-orchestration.md
@@ -1,0 +1,89 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Durable Orchestration
+
+Coordinate multi-step, long-running workflows with Durable Functions in PowerShell. A Durable app has three function types: a **client** that starts orchestrations, an **orchestrator** that defines the workflow, and **activities** that do the work.
+
+## Prerequisites
+
+Durable Functions require the extension bundle and the managed dependency to install the PowerShell SDK.
+
+`host.json`:
+
+```json
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "managedDependency": {
+    "enabled": true
+  }
+}
+```
+
+## Client Function
+
+An HTTP-triggered client starts the orchestration and returns status URLs. It uses an `httpTrigger`, an `http` output, and a `durableClient` input binding.
+
+`run.ps1`:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+$instanceId = Start-DurableOrchestration -FunctionName 'OrderOrchestrator' -Input $Request.Body
+$response = New-DurableOrchestrationCheckStatusResponse -Request $Request -InstanceId $instanceId
+Push-OutputBinding -Name Response -Value $response
+```
+
+## Orchestrator Function
+
+The orchestrator defines the workflow. It must be deterministic — never call external services or use random values directly; call activities instead. Binding type: `orchestrationTrigger`.
+
+`run.ps1`:
+
+```powershell
+param($Context)
+
+$order = $Context.Input
+
+$reserved = Invoke-DurableActivity -FunctionName 'ReserveInventory' -Input $order
+$charged  = Invoke-DurableActivity -FunctionName 'ChargePayment' -Input $order
+$shipped  = Invoke-DurableActivity -FunctionName 'ShipOrder' -Input $order
+
+return @{ reserved = $reserved; charged = $charged; shipped = $shipped }
+```
+
+## Activity Function
+
+Activities do the actual work and may call external services. Binding type: `activityTrigger`.
+
+`run.ps1`:
+
+```powershell
+param($order)
+
+Write-Information "Reserving inventory for order $($order.orderId)"
+return "reserved"
+```
+
+!!! warning "Determinism"
+    Orchestrator code replays as the workflow progresses. Avoid `Get-Date`, `Get-Random`, and direct I/O in orchestrators — use `$Context.CurrentUtcDateTime` and delegate side effects to activities.
+
+## See Also
+
+- [Durable Advanced Patterns](durable-advanced.md)
+- [Service Bus](service-bus.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Durable Functions bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-bindings)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/event-grid.md
+++ b/docs/language-guides/powershell/recipes/event-grid.md
@@ -1,0 +1,93 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Event Grid
+
+Handle discrete events from Azure services and custom topics with Event Grid triggers in PowerShell.
+
+## Event Grid Trigger
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "EventGridEvent",
+      "type": "eventGridTrigger",
+      "direction": "in"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($EventGridEvent, $TriggerMetadata)
+
+Write-Information "Event type: $($EventGridEvent.eventType)"
+Write-Information "Subject: $($EventGridEvent.subject)"
+Write-Information "Data: $($EventGridEvent.data | ConvertTo-Json -Compress)"
+```
+
+Event Grid delivers a single event per invocation. The runtime handles the subscription validation handshake automatically for the Event Grid schema.
+
+## Routing by Event Type
+
+```powershell
+switch ($EventGridEvent.eventType) {
+    "Microsoft.Storage.BlobCreated" {
+        Write-Information "New blob: $($EventGridEvent.data.url)"
+    }
+    "Microsoft.Storage.BlobDeleted" {
+        Write-Information "Blob removed: $($EventGridEvent.data.url)"
+    }
+    default {
+        Write-Information "Unhandled event type"
+    }
+}
+```
+
+## Output Binding
+
+Publish events to a custom topic:
+
+```json
+{
+  "name": "OutputEvent",
+  "type": "eventGrid",
+  "direction": "out",
+  "topicEndpointUri": "EventGridTopicEndpoint",
+  "topicKeySetting": "EventGridTopicKey"
+}
+```
+
+```powershell
+Push-OutputBinding -Name OutputEvent -Value @{
+    id        = [guid]::NewGuid().ToString()
+    subject   = "orders/created"
+    eventType = "Contoso.Order.Created"
+    eventTime = (Get-Date).ToUniversalTime().ToString("o")
+    data      = @{ orderId = 1234 }
+}
+```
+
+!!! tip "Event Grid vs Event Hubs"
+    Use Event Grid for reactive, discrete event handling and Event Hubs for high-throughput streaming. See [Event Hubs](event-hub.md).
+
+## See Also
+
+- [Event Hubs](event-hub.md)
+- [Blob Storage](blob-storage.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Event Grid bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-grid)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/event-hub.md
+++ b/docs/language-guides/powershell/recipes/event-hub.md
@@ -1,0 +1,82 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Event Hubs
+
+Ingest high-throughput event streams with Event Hubs triggers and output bindings in PowerShell.
+
+## Event Hub Trigger
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Events",
+      "type": "eventHubTrigger",
+      "direction": "in",
+      "eventHubName": "telemetry",
+      "connection": "EventHubConnection",
+      "cardinality": "many",
+      "consumerGroup": "$Default"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($Events, $TriggerMetadata)
+
+Write-Information "Received batch of $($Events.Count) event(s)"
+foreach ($event in $Events) {
+    Write-Information "Event body: $event"
+}
+```
+
+With `cardinality` set to `many`, the trigger delivers events as an array for efficient batch processing. Use `one` only for low-volume debugging.
+
+## Accessing Event Metadata
+
+The `$TriggerMetadata` object exposes per-event system properties such as `PartitionContext`, `EnqueuedTimeUtc`, and `SequenceNumber`:
+
+```powershell
+Write-Information "Partition: $($TriggerMetadata.PartitionContext.PartitionId)"
+```
+
+## Output Binding
+
+```json
+{
+  "name": "OutputEvent",
+  "type": "eventHub",
+  "direction": "out",
+  "eventHubName": "processed",
+  "connection": "EventHubConnection"
+}
+```
+
+```powershell
+Push-OutputBinding -Name OutputEvent -Value (@{ deviceId = "sensor-01"; value = 42 } | ConvertTo-Json)
+```
+
+!!! warning "Checkpoint and scaling"
+    Event Hubs triggers checkpoint per partition. A slow function increases checkpoint lag and delays scaling. Keep per-event work minimal and offload heavy processing.
+
+## See Also
+
+- [Service Bus](service-bus.md)
+- [Event Grid](event-grid.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Event Hubs bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-event-hubs)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/index.md
+++ b/docs/language-guides/powershell/recipes/index.md
@@ -23,6 +23,8 @@ graph TD
     A --> C[Storage & Messaging]
     A --> D[Security]
     A --> E[Scheduling]
+    A --> F[Orchestration]
+    A --> G[API & Quality]
 ```
 
 !!! tip "Pair recipes with platform guidance"
@@ -44,6 +46,11 @@ graph TD
 | [Blob Storage](blob-storage.md) | Blob trigger and blob binding patterns for file processing. |
 | [Queue Storage](queue.md) | Queue trigger consumer patterns and output bindings. |
 | [Service Bus](service-bus.md) | Enterprise messaging with queue/topic triggers and dead-lettering. |
+| [Event Hubs](event-hub.md) | High-throughput stream ingestion with batch triggers. |
+| [Event Grid](event-grid.md) | Reactive handling of discrete events and custom topics. |
+| [Cosmos DB](cosmosdb.md) | Change feed trigger and item input/output bindings. |
+| [Table Storage](table-storage.md) | Structured NoSQL entity read/write bindings. |
+| [SignalR Service](signalr.md) | Real-time messaging with negotiate and broadcast bindings. |
 
 ### Security
 
@@ -57,6 +64,29 @@ graph TD
 | Recipe | Description |
 |--------|-------------|
 | [Timer Trigger](timer.md) | Scheduled jobs, cron semantics, and idempotent batch execution. |
+
+### Orchestration
+
+| Recipe | Description |
+|--------|-------------|
+| [Durable Orchestration](durable-orchestration.md) | Client, orchestrator, and activity functions for long-running workflows. |
+| [Durable Advanced Patterns](durable-advanced.md) | Fan-out/fan-in, external events, durable timers, and eternal orchestrations. |
+
+### API & Quality
+
+| Recipe | Description |
+|--------|-------------|
+| [Retries and Error Handling](retry.md) | Retry policies, defensive error handling, and idempotency. |
+| [OpenAPI Documentation](openapi.md) | Serve an API contract from a dedicated HTTP endpoint. |
+| [Testing](testing.md) | Unit-test function logic with Pester. |
+| [Custom Domain and Certificates](custom-domain-certificates.md) | HTTPS custom domains and TLS certificate binding. |
+
+!!! note "Not applicable in the PowerShell model"
+    Some recipes available for other languages have no idiomatic PowerShell equivalent:
+
+    - **Dependency injection** — PowerShell has no DI container. Share initialized state (clients, config) through `profile.ps1` and module-scoped variables instead.
+    - **Middleware** — PowerShell has no invocation pipeline. Put cross-cutting logic (logging, auth checks) in `profile.ps1` or shared helper modules imported by each function.
+    - **Durable entities** — Entity triggers and clients are not supported for PowerShell. Use orchestrations with external storage for stateful coordination. See [Durable Advanced Patterns](durable-advanced.md).
 
 ## How to consume recipes effectively
 

--- a/docs/language-guides/powershell/recipes/openapi.md
+++ b/docs/language-guides/powershell/recipes/openapi.md
@@ -1,0 +1,74 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger
+---
+# OpenAPI Documentation
+
+Publish a discoverable HTTP API contract for PowerShell functions.
+
+## Approach for PowerShell
+
+The Azure Functions OpenAPI extension provides first-class attribute-based generation for C#, but PowerShell functions do not have those attributes. Instead, serve a hand-authored or generated OpenAPI document from a dedicated HTTP function.
+
+## Serving the OpenAPI Document
+
+Place an `openapi.json` (or `openapi.yaml`) spec alongside your function and return it from an HTTP endpoint:
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Request",
+      "type": "httpTrigger",
+      "direction": "in",
+      "authLevel": "anonymous",
+      "methods": ["get"],
+      "route": "openapi.json"
+    },
+    {
+      "name": "Response",
+      "type": "http",
+      "direction": "out"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+$specPath = Join-Path $PSScriptRoot "openapi.json"
+$spec = Get-Content -Path $specPath -Raw
+
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode  = [System.Net.HttpStatusCode]::OK
+    Headers     = @{ "Content-Type" = "application/json" }
+    Body        = $spec
+})
+```
+
+## Keeping the Spec Accurate
+
+Treat the OpenAPI document as source-controlled API contract. Validate it in CI with a linter such as `spectral`, and review it whenever routes, parameters, or response shapes change.
+
+!!! tip "Serve a UI"
+    Host Swagger UI or Redoc as static content (for example on the same Function App via a static route or on Azure Static Web Apps) and point it at your `openapi.json` endpoint.
+
+## See Also
+
+- [HTTP API Patterns](http-api.md)
+- [HTTP Authentication](http-auth.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [HTTP trigger (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-trigger)

--- a/docs/language-guides/powershell/recipes/retry.md
+++ b/docs/language-guides/powershell/recipes/retry.md
@@ -1,0 +1,70 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Retries and Error Handling
+
+Recover from transient failures with retry policies and defensive error handling in PowerShell.
+
+## Retry Policies
+
+Configure a retry policy in `host.json`. It applies to trigger types that support it (such as Timer, Event Hubs, and Service Bus). The policy re-runs the whole function on an unhandled exception.
+
+`host.json`:
+
+```json
+{
+  "version": "2.0",
+  "retry": {
+    "strategy": "exponentialBackoff",
+    "maxRetryCount": 5,
+    "minimumInterval": "00:00:02",
+    "maximumInterval": "00:01:00"
+  }
+}
+```
+
+Use `"strategy": "fixedDelay"` with a `"delayInterval"` for a constant wait instead of exponential backoff.
+
+!!! warning "Retry support varies by trigger"
+    Built-in retry policies do not apply to every trigger. HTTP triggers, for example, do not retry. Check the binding documentation and, where the source supports it (Service Bus, Queue), rely on the platform's native delivery-count and dead-letter behavior.
+
+## Handling Errors in Code
+
+Wrap fallible work in `try/catch` and throw to signal failure so the retry policy or platform dead-lettering engages:
+
+```powershell
+param($Message, $TriggerMetadata)
+
+try {
+    Invoke-RestMethod -Uri $env:DownstreamApi -Method Post -Body $Message -ErrorAction Stop
+}
+catch {
+    Write-Error "Downstream call failed: $($_.Exception.Message)"
+    throw
+}
+```
+
+Set `-ErrorAction Stop` on cmdlets so non-terminating errors become catchable terminating errors.
+
+## Idempotency
+
+Because a function may run more than once, make handlers idempotent — use a natural key or a processed-message table so reprocessing the same message is safe.
+
+!!! tip "Poison messages"
+    For Queue and Service Bus triggers, messages that keep failing move to a poison queue or dead-letter subqueue after the max delivery count. Monitor and reprocess these separately.
+
+## See Also
+
+- [Service Bus](service-bus.md)
+- [Queue Storage](queue.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Azure Functions error handling and retries (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-error-pages)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/retry.md
+++ b/docs/language-guides/powershell/recipes/retry.md
@@ -12,13 +12,20 @@ Recover from transient failures with retry policies and defensive error handling
 
 ## Retry Policies
 
-Configure a retry policy in `host.json`. It applies to trigger types that support it (such as Timer, Event Hubs, and Service Bus). The policy re-runs the whole function on an unhandled exception.
+Configure a retry policy per-function in `function.json`, as a sibling of `bindings`. It applies to trigger types that support runtime-enforced retries (such as Timer, Event Hubs, and Azure Cosmos DB). The policy re-runs the whole function on an unhandled exception.
 
-`host.json`:
+`function.json`:
 
 ```json
 {
-  "version": "2.0",
+  "bindings": [
+    {
+      "name": "Timer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 */5 * * * *"
+    }
+  ],
   "retry": {
     "strategy": "exponentialBackoff",
     "maxRetryCount": 5,

--- a/docs/language-guides/powershell/recipes/signalr.md
+++ b/docs/language-guides/powershell/recipes/signalr.md
@@ -1,0 +1,90 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# SignalR Service
+
+Add real-time messaging to clients with Azure SignalR Service bindings in PowerShell.
+
+## Negotiate Function
+
+Clients first call a negotiate endpoint to obtain connection info. Use the `signalRConnectionInfo` input binding:
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Request",
+      "type": "httpTrigger",
+      "direction": "in",
+      "methods": ["post"]
+    },
+    {
+      "name": "Response",
+      "type": "http",
+      "direction": "out"
+    },
+    {
+      "name": "ConnectionInfo",
+      "type": "signalRConnectionInfo",
+      "direction": "in",
+      "hubName": "notifications",
+      "connectionStringSetting": "AzureSignalRConnectionString"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($Request, $ConnectionInfo, $TriggerMetadata)
+
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = ($ConnectionInfo | ConvertTo-Json)
+})
+```
+
+## Broadcasting Messages
+
+Use the `signalR` output binding to push messages to connected clients:
+
+```json
+{
+  "name": "SignalRMessages",
+  "type": "signalR",
+  "direction": "out",
+  "hubName": "notifications",
+  "connectionStringSetting": "AzureSignalRConnectionString"
+}
+```
+
+```powershell
+Push-OutputBinding -Name SignalRMessages -Value @{
+    target    = "newMessage"
+    arguments = @( @{ text = "Order shipped"; timestamp = (Get-Date).ToString("o") } )
+}
+```
+
+Set `userId` on the message to target a single user, or `groupName` to target a group.
+
+!!! tip "Serverless mode"
+    Configure the SignalR Service instance in **Serverless** mode so it works with Azure Functions rather than a self-hosted hub.
+
+## See Also
+
+- [HTTP API Patterns](http-api.md)
+- [Event Grid](event-grid.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [SignalR Service bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-signalr-service)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/table-storage.md
+++ b/docs/language-guides/powershell/recipes/table-storage.md
@@ -1,0 +1,92 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+---
+# Table Storage
+
+Persist and query structured NoSQL data with Azure Table storage bindings in PowerShell.
+
+## Input Binding
+
+Read entities filtered by partition key:
+
+`function.json`:
+
+```json
+{
+  "bindings": [
+    {
+      "name": "Request",
+      "type": "httpTrigger",
+      "direction": "in",
+      "methods": ["get"]
+    },
+    {
+      "name": "Response",
+      "type": "http",
+      "direction": "out"
+    },
+    {
+      "name": "Orders",
+      "type": "table",
+      "direction": "in",
+      "tableName": "Orders",
+      "partitionKey": "{Query.customerId}",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}
+```
+
+`run.ps1`:
+
+```powershell
+param($Request, $Orders, $TriggerMetadata)
+
+Write-Information "Retrieved $($Orders.Count) order(s)"
+Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
+    StatusCode = [System.Net.HttpStatusCode]::OK
+    Body       = ($Orders | ConvertTo-Json)
+})
+```
+
+## Output Binding
+
+Write one or more entities. Each must include `PartitionKey` and `RowKey`:
+
+```json
+{
+  "name": "OutputOrder",
+  "type": "table",
+  "direction": "out",
+  "tableName": "Orders",
+  "connection": "AzureWebJobsStorage"
+}
+```
+
+```powershell
+Push-OutputBinding -Name OutputOrder -Value @{
+    PartitionKey = "customer-42"
+    RowKey       = [guid]::NewGuid().ToString()
+    Total        = 99.5
+    Status       = "created"
+}
+```
+
+!!! tip "Choosing keys"
+    Pick a `PartitionKey` that distributes writes evenly and groups the entities you query together. A monotonic `RowKey` (such as a reverse-timestamp) keeps recent items first.
+
+## See Also
+
+- [Cosmos DB](cosmosdb.md)
+- [Blob Storage](blob-storage.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [Table storage bindings (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-table)
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)

--- a/docs/language-guides/powershell/recipes/testing.md
+++ b/docs/language-guides/powershell/recipes/testing.md
@@ -1,0 +1,89 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-test-a-function
+---
+# Testing
+
+Unit-test PowerShell function logic with Pester.
+
+## Structuring for Testability
+
+Keep `run.ps1` thin and move business logic into a shared module (for example under a `Modules/` folder or a `.psm1` next to your functions). Pure functions with explicit inputs and outputs are far easier to test than binding-coupled handlers.
+
+`Modules/OrderLogic.psm1`:
+
+```powershell
+function Get-OrderTotal {
+    param([object[]] $Items)
+    ($Items | Measure-Object -Property Price -Sum).Sum
+}
+
+Export-ModuleMember -Function Get-OrderTotal
+```
+
+`run.ps1` calls the module:
+
+```powershell
+param($Request, $TriggerMetadata)
+
+Import-Module "$PSScriptRoot/../Modules/OrderLogic.psm1"
+$total = Get-OrderTotal -Items $Request.Body.items
+```
+
+## Writing Pester Tests
+
+`OrderLogic.Tests.ps1`:
+
+```powershell
+BeforeAll {
+    Import-Module "$PSScriptRoot/Modules/OrderLogic.psm1" -Force
+}
+
+Describe "Get-OrderTotal" {
+    It "sums item prices" {
+        $items = @(
+            @{ Price = 10 },
+            @{ Price = 5.5 }
+        )
+        Get-OrderTotal -Items $items | Should -Be 15.5
+    }
+
+    It "returns null for an empty cart" {
+        Get-OrderTotal -Items @() | Should -BeNullOrEmpty
+    }
+}
+```
+
+## Running Tests
+
+```powershell
+Invoke-Pester -Path . -Output Detailed
+```
+
+In CI, fail the build on any failing test and publish the results:
+
+```powershell
+Invoke-Pester -Configuration (New-PesterConfiguration -Hashtable @{
+    Run    = @{ Path = "." }
+    Output = @{ Verbosity = "Detailed" }
+    Run    = @{ Exit = $true }
+})
+```
+
+!!! tip "Mock external calls"
+    Use Pester's `Mock` to stub `Invoke-RestMethod`, `Connect-AzAccount`, and other cmdlets so unit tests never touch live Azure resources.
+
+## See Also
+
+- [HTTP API Patterns](http-api.md)
+- [Retries and Error Handling](retry.md)
+- [Recipes Index](index.md)
+
+## Sources
+
+- [PowerShell developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-powershell)
+- [Testing Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-test-a-function)

--- a/docs/language-guides/powershell/recipes/testing.md
+++ b/docs/language-guides/powershell/recipes/testing.md
@@ -68,9 +68,8 @@ In CI, fail the build on any failing test and publish the results:
 
 ```powershell
 Invoke-Pester -Configuration (New-PesterConfiguration -Hashtable @{
-    Run    = @{ Path = "." }
+    Run    = @{ Path = "."; Exit = $true }
     Output = @{ Verbosity = "Detailed" }
-    Run    = @{ Exit = $true }
 })
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -471,6 +471,17 @@ nav:
         - language-guides/powershell/recipes/key-vault.md
         - language-guides/powershell/recipes/managed-identity.md
         - language-guides/powershell/recipes/timer.md
+        - language-guides/powershell/recipes/openapi.md
+        - language-guides/powershell/recipes/cosmosdb.md
+        - language-guides/powershell/recipes/table-storage.md
+        - language-guides/powershell/recipes/event-grid.md
+        - language-guides/powershell/recipes/event-hub.md
+        - language-guides/powershell/recipes/signalr.md
+        - language-guides/powershell/recipes/durable-orchestration.md
+        - language-guides/powershell/recipes/durable-advanced.md
+        - language-guides/powershell/recipes/retry.md
+        - language-guides/powershell/recipes/testing.md
+        - language-guides/powershell/recipes/custom-domain-certificates.md
       - PowerShell Reference:
         - language-guides/powershell/cli-cheatsheet.md
         - language-guides/powershell/environment-variables.md


### PR DESCRIPTION
## Summary
Adds 11 PowerShell recipes to bring the PowerShell language guide toward recipe parity with python/nodejs/java/dotnet. Closes the only genuine recipe gap identified in the guide (PowerShell previously had 8 recipes vs 22 for the other languages).

New recipes (`docs/language-guides/powershell/recipes/`):
- **Storage & Messaging**: cosmosdb, event-hub, event-grid, table-storage, signalr
- **Orchestration**: durable-orchestration, durable-advanced
- **API & Quality**: retry, openapi, testing (Pester), custom-domain-certificates

Also updates `recipes/index.md` (new category tables + a "not applicable in the PowerShell model" note) and wires all 11 pages into `mkdocs.yml` nav.

## Intentionally excluded (documented as non-applicable in the index)
- **dependency-injection** — PowerShell has no DI container (use `profile.ps1` / module scope).
- **middleware** — PowerShell has no invocation pipeline (use `profile.ps1` / helper modules).
- **durable-entities** — Per Microsoft Learn, entity triggers/clients are **not supported for PowerShell**.

All recipes follow the existing PowerShell `function.json` + `run.ps1` style (no Python-v2 decorators, no Mermaid). Durable syntax verified against Microsoft Learn / the azure-functions-durable-powershell SDK, including the correction that PowerShell does not support `ContinueAsNew` (singleton + durable-timer loop documented instead).

## Validation
- `scripts/normalize_yaml_frontmatter.py --check` → pass
- `scripts/validate_content_sources.py` → pass
- `mkdocs build --strict` → exit 0

Tracking: #117