### PR TITLE
docs: add Testing and Migration guides

### DIFF
--- a/docs/best-practices/index.md
+++ b/docs/best-practices/index.md
@@ -80,6 +80,7 @@ The Best Practices tab is organized into nine practical sub-pages.
 | `deployment.md` | Safe rollout, rollback, and slot strategy by plan | Lowers release failure blast radius |
 | `cost-optimization.md` | Cost guardrails with scale and telemetry controls | Keeps spend predictable during bursts |
 | `common-anti-patterns.md` | Frequent Functions-specific mistakes and alternatives | Speeds architecture and code reviews |
+| `testing.md` | Test pyramid, local emulation, and CI integration strategy | Prevents binding-configuration and retry-path defects reaching production |
 
 !!! note "Current publishing state"
     This landing page includes the full planned map so teams can align review checklists and ownership early.

--- a/docs/best-practices/testing.md
+++ b/docs/best-practices/testing.md
@@ -1,0 +1,104 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-test-a-function
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection
+content_validation:
+  status: verified
+  last_reviewed: 2026-07-18
+  reviewer: agent
+  core_claims:
+    - claim: "Azurite emulator supports local testing of Storage-based triggers and bindings without cloud dependencies"
+      source: https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+      verified: true
+    - claim: "Azure Functions unit tests should isolate function code from the Functions host by mocking binding inputs and outputs"
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-test-a-function
+      verified: true
+    - claim: "Azure Functions Core Tools can run functions locally to validate trigger and binding behavior before deployment"
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local
+      verified: true
+    - claim: "Dependency injection enables testable function architectures by decoupling handler logic from the Functions runtime"
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection
+      verified: true
+---
+
+# Testing Best Practices
+
+Azure Functions couple business logic to an event-driven host through triggers and bindings, which makes naive testing brittle. This page defines a cross-language testing strategy — the test pyramid, local emulation, and CI integration — and points to the per-language recipes for concrete implementation.
+
+## Why This Matters
+
+- Functions carry implicit dependencies (triggers, bindings, the host runtime) that are invisible in the handler signature, so untested binding configuration is a frequent source of production surprises.
+- Cloud-only testing is slow, flaky, and costly. A fast local feedback loop with emulators keeps iteration cheap.
+- The stateless execution model means idempotency, retry, and poison-message behavior must be tested explicitly — they are not exercised by happy-path HTTP tests.
+- Each hosting plan behaves differently under scale-out, so tests that pass at low concurrency can still hide production defects.
+
+## Recommended Practices
+
+### Adopt a Test Pyramid for Functions
+
+Bias toward many fast, isolated tests and few slow, deployed ones:
+
+| Layer | Scope | What it validates | Rough share |
+|---|---|---|---|
+| Unit | Handler/business logic with mocked bindings | Pure logic, branching, error mapping | ~70% |
+| Integration | Core Tools + Azurite against real binding contracts | Trigger/binding wiring, serialization, output bindings | ~20% |
+| End-to-end | Deployed slot smoke tests | Real platform behavior, auth, networking | ~10% |
+
+### Design for Testability
+
+- Separate handler logic from binding plumbing. Keep the trigger entry point thin and delegate to a plain service class or function that has no dependency on the Functions runtime types.
+- Use dependency injection so collaborators (clients, repositories, configuration) can be replaced with test doubles. All modern models support this — the .NET isolated worker, the Python v2 model, the Node.js v4 model, and Java.
+- Pass binding data in and return binding data out rather than reaching into global state, so a unit test can call the function as an ordinary function.
+
+### Emulate Locally with Azurite
+
+- Use [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) as the local Azure Storage emulator to exercise Queue, Blob, and Table triggers and bindings without provisioning cloud resources.
+- Set `AzureWebJobsStorage` to `UseDevelopmentStorage=true` in `local.settings.json` so both the host and Storage bindings target Azurite.
+- Azurite covers Storage bindings only. Cosmos DB, Event Hubs, and Service Bus have no first-party emulator in this repository's scope — mock their clients in unit tests, or test against a dedicated non-production namespace when a real contract must be validated.
+
+### Integrate Tests into CI
+
+- Start Azurite as a background service (a service container in GitHub Actions, or `azurite &` in a script step), run `func start` when an end-to-end host is needed, then execute the language test runner.
+- Gate deployments on the test job: a failed unit or integration stage must block the deploy stage.
+- Keep secrets out of the test path — CI tests should target Azurite and mocks, never live subscription keys.
+
+## Common Mistakes / Anti-Patterns
+
+- **Testing against live Azure resources in CI.** This is slow, flaky, and incurs cost. Reserve live resources for a small, opt-in end-to-end suite.
+- **Assuming unit tests are enough.** Passing unit tests say nothing about whether the binding configuration (decorators, `function.json`, attributes) is correct. Cover binding contracts with integration tests.
+- **Mocking the entire Functions host.** Mock the *inputs and outputs* of your handler, not the runtime. Over-mocking the host produces tests that pass while the real wiring is broken.
+- **Ignoring poison and retry paths.** Async triggers retry and dead-letter. If those paths are untested, the first real failure is discovered in production.
+- **Committing live connection strings to `local.settings.json`.** Use `UseDevelopmentStorage=true` and keep the file out of source control.
+
+## Validation Checklist
+
+- [ ] Every function has unit tests for its business logic with bindings mocked.
+- [ ] Binding contracts are covered by an integration test (Core Tools + Azurite) or an equivalent emulator test.
+- [ ] CI runs the full test suite before every deployment and blocks on failure.
+- [ ] Poison-message and retry paths have at least one test.
+- [ ] `local.settings.json` uses Azurite (`UseDevelopmentStorage=true`), not live keys.
+- [ ] End-to-end smoke tests run against a deployment slot before production swap.
+
+## See Also
+
+- [Python Testing Recipe](../language-guides/python/recipes/testing.md)
+- [Node.js Testing Recipe](../language-guides/nodejs/recipes/testing.md)
+- [Java Testing Recipe](../language-guides/java/recipes/testing.md)
+- [.NET Testing Recipe](../language-guides/dotnet/recipes/testing.md)
+- [PowerShell Testing Recipe](../language-guides/powershell/recipes/testing.md)
+- [Reliability Best Practices](reliability.md)
+- [Deployment Best Practices](deployment.md)
+
+## Sources
+
+- [Strategies for testing your code in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-test-a-function)
+- [Use the Azurite emulator for local Azure Storage development (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite)
+- [Develop Azure Functions locally using Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Use dependency injection in .NET Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -59,6 +59,7 @@ flowchart TD
 - [Security](security.md)
 - [Cost Optimization](cost-optimization.md)
 - [Recovery](recovery.md)
+- [Migration Guide](migration.md)
 
 ## Review Matrix
 

--- a/docs/operations/migration.md
+++ b/docs/operations/migration.md
@@ -1,0 +1,145 @@
+---
+content_sources:
+  references:
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+    - type: mslearn-adapted
+      url: https://learn.microsoft.com/en-us/azure/azure-functions/migrate-version-3-version-4
+content_validation:
+  status: verified
+  last_reviewed: 2026-07-18
+  reviewer: agent
+  core_claims:
+    - claim: "Migrating from Consumption (Y1) to Flex Consumption (FC1) requires creating a new function app; an in-place plan SKU change is not supported"
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+      verified: true
+    - claim: "The .NET in-process model is retired and .NET functions must run on the isolated worker model"
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model
+      verified: true
+    - claim: "The Python v2 programming model uses decorators instead of function.json for defining triggers and bindings"
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python
+      verified: true
+    - claim: "The Dedicated (App Service) plan runs functions on fixed-capacity instances and does not provide event-driven dynamic scaling"
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan
+      verified: true
+    - claim: "Flex Consumption provides always-ready instances and per-function scaling as alternatives to Premium pre-warmed instances"
+      source: https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan
+      verified: true
+---
+
+# Migration Guide
+
+Migrating an Azure Functions workload — whether across hosting plans or across programming models — is a day-2 operation performed against a running app. This guide provides the decision matrix, breaking-change tables, verification steps, and rollback procedures for each supported path, and links to the language-specific recipes for step-by-step code changes.
+
+## Prerequisites
+
+- An existing function app on the source plan or programming model.
+- Azure CLI 2.60 or later with the current `functionapp` commands available.
+- A staging slot or a secondary function app to enable a safe cutover (blue-green) rather than an in-place change.
+- Application Insights enabled on both source and target so migration can be verified with telemetry.
+- Source control access to the app code, so a redeploy of the previous version is always possible.
+
+## When to Use
+
+| Migration path | Typical trigger |
+|---|---|
+| Consumption (Y1) → Flex Consumption (FC1) | Need VNet integration, per-function scaling, or reduced cold start |
+| .NET in-process → isolated worker | In-process model retirement; move to current .NET versions |
+| Python v1 → v2 | Decorator model, blueprints, cleaner project layout |
+| Premium ↔ Dedicated | Cost optimization, or adding/removing dynamic event-driven scale |
+
+## Procedure
+
+### Migration Decision Matrix
+
+| Source → Target | New app required? | Expected downtime | Reversibility |
+|---|---|---|---|
+| Y1 → FC1 | Yes (create new FC1 app) | Cutover only (DNS/slot swap) | High — keep old app until validated |
+| In-process → isolated | No (same app, code change) | Deploy window | Medium — redeploy previous package |
+| Python v1 → v2 | No (same app, code change) | Deploy window | Medium — redeploy previous package |
+| Premium ↔ Dedicated | No (change plan SKU) | Brief restart | High — change SKU back |
+
+### Path 1: Consumption (Y1) → Flex Consumption (FC1)
+
+- **Motivation.** Flex Consumption adds VNet integration, per-function scaling groups, always-ready instances, and faster cold start compared to the legacy Consumption plan.
+- **What changes.** There is no in-place SKU conversion from Y1 to FC1 — you create a new Flex Consumption app and deploy your code to it, then cut traffic over. Deployment uses a storage container for the app package rather than the legacy content share.
+- **App settings delta.**
+
+    | Setting | Y1 | FC1 |
+    |---|---|---|
+    | `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` | Required | Not used (no content share) |
+    | `WEBSITE_CONTENTSHARE` | Required | Not used |
+    | Deployment | Zip to content share / `RUN_FROM_PACKAGE` | Zip to deployment storage container |
+    | Scaling | Automatic, per-app | Per-function scaling groups, configurable maximum instances |
+
+- **Steps (high level).** Create the FC1 app and its deployment storage container, deploy the code package, validate on the new hostname, then cut over DNS or swap slots.
+- **Breaking changes.** In-portal `function.json` editing is not part of the Flex workflow; the scaling model differs, so revisit any assumptions baked into per-instance concurrency.
+
+### Path 2: .NET In-Process → Isolated Worker
+
+- **Motivation.** The in-process model is retired; the isolated worker model is the supported path and unlocks current .NET versions, full control of the middleware pipeline, and standard `Program.cs` startup.
+- **Breaking-change summary.**
+
+    | Area | In-process | Isolated worker |
+    |---|---|---|
+    | Host coupling | Shares the host runtime | Separate worker process |
+    | Startup | `Startup.cs` (`FunctionsStartup`) | `Program.cs` with `HostBuilder` |
+    | HTTP types | `HttpRequest` / `IActionResult` | `HttpRequestData` / `HttpResponseData` |
+    | Middleware | Limited | First-class middleware pipeline |
+    | DI lifetimes | Host-managed | Worker-managed |
+
+- **Step-by-step.** Follow [Migrate .NET In-Process to Isolated Worker](../language-guides/dotnet/recipes/migrate-to-isolated.md) for the project file, `Program.cs`, function signature, and configuration changes.
+
+### Path 3: Python v1 → v2
+
+- **Motivation.** The v2 programming model replaces per-function `function.json` files with decorators, supports blueprints for modular apps, and gives a cleaner, type-hinted project layout.
+- **Breaking-change summary.**
+
+    | Area | v1 | v2 |
+    |---|---|---|
+    | Trigger/binding definition | `function.json` per function | Python decorators in code |
+    | App entry point | Folder-per-function | Single app object (`func.FunctionApp()`) with blueprints |
+    | Project layout | One folder per function | Consolidated modules |
+
+- **Step-by-step.** Follow the [Python v2 Programming Model](../language-guides/python/v2-programming-model.md) page for the decorator syntax and project restructuring.
+
+### Path 4: Premium ↔ Dedicated
+
+- **When to move.** Choose Dedicated to reuse an existing App Service estate or to run on fixed, predictable capacity; choose Premium to keep event-driven dynamic scale with pre-warmed instances and enterprise networking.
+- **Configuration deltas.** Moving to Dedicated changes the plan SKU and removes event-driven dynamic scaling — you manage instance count and rely on "Always On" instead of pre-warmed instances. Moving to Premium restores dynamic scale-out and always-ready instances. Re-validate VNet integration and cold-start expectations after the change, as they differ between the two plans.
+
+## Verification
+
+- Confirm the plan and SKU with `az functionapp show --resource-group $RG --name $APP_NAME --query "sku" --output tsv` (and the plan resource for dedicated/premium).
+- In Application Insights, run a `requests` query to confirm executions are succeeding on the target with expected `resultCode` values.
+- Smoke-test each critical trigger (HTTP, queue, timer) against the migrated app.
+- Compare latency and error rate before and after migration in Application Insights to catch regressions early.
+
+## Rollback / Troubleshooting
+
+- **Plan/app migrations (Y1→FC1, Premium↔Dedicated).** Keep the source app or previous SKU until the target is validated; roll back by cutting DNS/slot traffic to the source app or changing the SKU back.
+- **Model migrations (in-process→isolated, v1→v2).** Roll back by redeploying the previous package from source control.
+- **Common failure: missing app settings after migration.** Diff the source and target app settings; settings such as connection strings and feature flags are not copied automatically to a new app.
+- **Common failure: binding extension version mismatch.** After a model change, confirm the extension bundle or NuGet extension versions match what the new model expects.
+
+## See Also
+
+- [Hosting Plan Selection](../best-practices/hosting-plan-selection.md)
+- [Deployment Scenarios](../platform/deployment-scenarios.md)
+- [.NET Migrate to Isolated Worker](../language-guides/dotnet/recipes/migrate-to-isolated.md)
+- [Python v2 Programming Model](../language-guides/python/v2-programming-model.md)
+- [Operations: Deployment](deployment.md)
+
+## Sources
+
+- [Azure Functions Flex Consumption plan (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan)
+- [Migrate .NET apps to the isolated worker model (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-to-isolated-model)
+- [Azure Functions Python developer reference (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-python)
+- [Dedicated (App Service) plan for Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/dedicated-plan)
+- [Migrate apps to Azure Functions runtime version 4.x (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-version-3-version-4)

--- a/docs/reference/content-validation-status.md
+++ b/docs/reference/content-validation-status.md
@@ -11,12 +11,12 @@ This page tracks `content_validation` metadata for **in-scope factual-claim docu
 
 ## Summary
 
-*Generated: 2026-07-17*
+*Generated: 2026-07-18*
 
 | Content Type | Total | Verified | Pending | Unverified | No Metadata |
 |---|---:|---:|---:|---:|---:|
-| Mermaid Diagrams | 556 | 556 | 0 | 0 | 0 |
-| In-Scope Factual-Claim Documents | 62 | 62 | 0 | 0 | 0 |
+| Mermaid Diagrams | 566 | 566 | 0 | 0 | 0 |
+| In-Scope Factual-Claim Documents | 64 | 64 | 0 | 0 | 0 |
 
 !!! success "All In-Scope Documents Verified"
     Every in-scope factual-claim document has verified Microsoft Learn sources for its core claims.
@@ -24,7 +24,7 @@ This page tracks `content_validation` metadata for **in-scope factual-claim docu
 <!-- diagram-id: content-validation-status-pie -->
 ```mermaid
 pie title In-Scope Document Validation Status
-    "Verified" : 62
+    "Verified" : 64
 ```
 
 ## By Section
@@ -64,6 +64,7 @@ pie title In-Scope Document Validation Status
 | [Reliability](../best-practices/reliability.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Scaling](../best-practices/scaling.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Security](../best-practices/security.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
+| [Testing](../best-practices/testing.md) | ✅ | ✅ Verified | 4/4 | 2026-07-18 |
 | [Trigger And Binding](../best-practices/trigger-and-binding.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 
 ### Operations
@@ -75,6 +76,7 @@ pie title In-Scope Document Validation Status
 | [Configuration](../operations/configuration.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Cost Optimization](../operations/cost-optimization.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Deployment](../operations/deployment.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
+| [Migration](../operations/migration.md) | ✅ | ✅ Verified | 5/5 | 2026-07-18 |
 | [Monitoring](../operations/monitoring.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |
 | [Opentelemetry](../operations/opentelemetry.md) | ✅ | ✅ Verified | 4/4 | 2026-07-17 |
 | [Recovery](../operations/recovery.md) | ✅ | ✅ Verified | 4/4 | 2026-04-12 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
     - best-practices/deployment.md
     - best-practices/cost-optimization.md
     - best-practices/common-anti-patterns.md
+    - best-practices/testing.md
   - Language Guides:
     - language-guides/index.md
     - Python:
@@ -510,6 +511,7 @@ nav:
     - operations/security.md
     - operations/cost-optimization.md
     - operations/recovery.md
+    - operations/migration.md
   - Troubleshooting:
     - troubleshooting/index.md
     - troubleshooting/architecture-overview.md


### PR DESCRIPTION
## Summary

Closes #91 and #92.

- **#91** — Adds `docs/best-practices/testing.md`: a cross-language testing **strategy** page (test pyramid, testable architecture, Azurite local emulation, CI integration, anti-patterns, validation checklist). It delegates all implementation detail to the 5 existing per-language `recipes/testing.md` pages and tutorial step 08 rather than duplicating them.
- **#92** — Adds `docs/operations/migration.md`: a central migration guide covering Consumption(Y1)→Flex(FC1), .NET in-process→isolated worker, Python v1→v2, and Premium↔Dedicated — with a decision matrix, breaking-change/setting-delta tables, verification, and rollback. Delegates step-by-step code changes to the existing `dotnet/recipes/migrate-to-isolated.md` and `python/v2-programming-model.md`.
- Wires both into `mkdocs.yml` nav and the Best Practices / Operations index pages.
- Regenerates the content-validation dashboard (64/64 verified).

## Placement rationale

Per-language testing recipes and a `.NET migrate-to-isolated` recipe already existed, so these two new pages are deliberately **strategy/decision hubs** that link out, not step-by-step duplicates. Placement (best-practices vs operations, Platform vs Operations template) was decided via Oracle consultation.

## Verification

- `mkdocs build --strict` passes — no broken links.
- `python3 scripts/normalize_yaml_frontmatter.py --check` → 0 drift.
- content_validation dashboard regenerated; both pages `verified` with MS Learn-traceable core claims.
- Oracle merge-gate review: 94/100, no blocking issues.