### PR TITLE
docs(troubleshooting): clarify architecture pages with role-explicit renames (#73)

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -39,7 +39,8 @@ Thank you for your interest in contributing to Azure Functions Practical Guide!
 │   ├── start-here/             # Overview, learning paths, repository map
 │   ├── stylesheets/            # Custom CSS
 │   └── troubleshooting/        # Troubleshooting hub
-│       ├── architecture.md
+│       ├── architecture-components-reference.md
+│       ├── request-flow-for-incident-response.md
 │       ├── evidence-map.md
 │       ├── first-10-minutes/   # First-10-minutes guides
 │       ├── kql/                # KQL query packs

--- a/docs/platform/networking.md
+++ b/docs/platform/networking.md
@@ -483,7 +483,7 @@ Runtime focus areas:
 - [Hosting](hosting.md)
 - [Scaling](scaling.md)
 - [Security](security.md)
-- [Troubleshooting architecture](../troubleshooting/architecture.md)
+- [Request flow for incident response](../troubleshooting/request-flow-for-incident-response.md)
 - [Troubleshooting playbooks](../troubleshooting/playbooks/index.md)
 - [Deployment Scenarios](deployment-scenarios.md) — Cross-plan comparison of VNet, PE, identity, and deployment patterns
 

--- a/docs/reference/content-validation-status.md
+++ b/docs/reference/content-validation-status.md
@@ -88,8 +88,7 @@ pie title In-Scope Document Validation Status
 | Document | Has Sources | Status | Claims | Last Reviewed |
 |---|---|---|---|---|
 | [App Settings Misconfiguration](../troubleshooting/playbooks/auth-config/app-settings-misconfiguration.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Architecture](../troubleshooting/architecture.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
-| [Architecture Overview](../troubleshooting/architecture-overview.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
+| [Architecture Components Reference](../troubleshooting/architecture-components-reference.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Blob Trigger Not Firing](../troubleshooting/playbooks/blob-trigger-not-firing.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Decision Tree](../troubleshooting/decision-tree.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Deployment Failures](../troubleshooting/playbooks/deployment-failures.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
@@ -108,6 +107,7 @@ pie title In-Scope Document Validation Status
 | [Out Of Memory Worker Crash](../troubleshooting/playbooks/scaling/out-of-memory-worker-crash.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Queue Piling Up](../troubleshooting/playbooks/queue-piling-up.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Quick Diagnosis Cards](../troubleshooting/quick-diagnosis-cards.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
+| [Request Flow For Incident Response](../troubleshooting/request-flow-for-incident-response.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Scaling Issues](../troubleshooting/first-10-minutes/scaling-issues.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Timeout Execution Limit](../troubleshooting/playbooks/triggers/timeout-execution-limit.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |
 | [Triggers Not Firing](../troubleshooting/first-10-minutes/triggers-not-firing.md) | ✅ | ✅ Verified | 1/1 | 2026-04-12 |

--- a/docs/troubleshooting/architecture-components-reference.md
+++ b/docs/troubleshooting/architecture-components-reference.md
@@ -206,11 +206,15 @@ content_validation:
       verified: true
 ---
 
-# Troubleshooting Architecture Overview
+# Architecture Components Reference
 
 This page answers the first practical question during an Azure Functions incident: **which platform segment is failing?**
 
 Before opening a deep playbook, map the symptom to the correct layer: hosting plan behavior, trigger delivery, scale controller decisions, worker startup, Durable Functions state coordination, or downstream service integration. That classification tells you which telemetry to query first and which mitigation is realistic.
+
+!!! info "When to use this page"
+    Use this page as a **component-by-component reference** when you need to identify *which platform segment* is failing (hosting plan, trigger/binding delivery, scale controller, cold start, Durable state, service integration).
+    For a **request-flow and incident-flow view** that traces symptoms through architecture layers, see [Request flow for incident response](request-flow-for-incident-response.md) instead.
 
 ## Why this page exists
 
@@ -622,7 +626,7 @@ az monitor log-analytics query --workspace "$WORKSPACE_ID" --analytics-query "Ap
 ## See Also
 
 - [Troubleshooting](index.md)
-- [Troubleshooting Architecture](architecture.md)
+- [Request flow for incident response](request-flow-for-incident-response.md)
 - [Evidence Map](evidence-map.md)
 - [Decision Tree](decision-tree.md)
 - [Troubleshooting Mental Model](mental-model.md)

--- a/docs/troubleshooting/decision-tree.md
+++ b/docs/troubleshooting/decision-tree.md
@@ -241,7 +241,7 @@ az monitor activity-log list \
 
 - [Troubleshooting Method](methodology/troubleshooting-method.md)
 - [Detector Map](methodology/detector-map.md)
-- [Architecture](architecture.md)
+- [Request flow for incident response](request-flow-for-incident-response.md)
 - [Evidence Map](evidence-map.md)
 - [Mental Model](mental-model.md)
 - [First 10 Minutes: Triggers Not Firing](first-10-minutes/triggers-not-firing.md)

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -100,7 +100,7 @@ flowchart TD
 
 ## Quick investigation flow
 
-- For architecture context, see [Troubleshooting Architecture](architecture.md).
+- For a symptom-to-layer request and incident-flow view, see [Request flow for incident response](request-flow-for-incident-response.md); for a component-by-component reference, see [Architecture components reference](architecture-components-reference.md).
 - For "where do I look first?", see [Evidence Map](evidence-map.md).
 - For fast triage sequence, start at [First 10 Minutes](first-10-minutes/index.md).
 
@@ -114,7 +114,8 @@ flowchart TD
 | [Playbooks](playbooks/index.md) | Scenario-based diagnostics and mitigations |
 | [Methodology](methodology.md) | Reproducible Observe → Hypothesize → Test → Fix → Verify workflow |
 | [KQL Query Library](kql/index.md) | Reusable telemetry and evidence queries |
-| [Troubleshooting Architecture](architecture.md) | Component boundaries and failure-domain context |
+| [Request flow for incident response](request-flow-for-incident-response.md) | Request/incident-flow view mapping symptoms to architecture layers |
+| [Architecture components reference](architecture-components-reference.md) | Component-by-component reference: hosting, triggers, scale controller, cold start, Durable |
 | [Evidence Map](evidence-map.md) | Symptom-to-evidence lookup for first-query selection |
 | [Lab Guides](lab-guides/index.md) | Failure drills for response readiness |
 

--- a/docs/troubleshooting/lab-guides/event-hub-checkpoint-lag.md
+++ b/docs/troubleshooting/lab-guides/event-hub-checkpoint-lag.md
@@ -1004,7 +1004,7 @@ If this is a shared troubleshooting environment, keep resources and only disable
 
 ## See Also
 
-- [Troubleshooting architecture](../architecture.md)
+- [Request flow for incident response](../request-flow-for-incident-response.md)
 - [Troubleshooting evidence map](../evidence-map.md)
 - [Troubleshooting methodology](../methodology.md)
 - [KQL quick reference](../kql/index.md)

--- a/docs/troubleshooting/mental-model.md
+++ b/docs/troubleshooting/mental-model.md
@@ -314,7 +314,7 @@ sequenceDiagram
 - [Decision Tree](decision-tree.md)
 - [Troubleshooting Method](methodology/troubleshooting-method.md)
 - [Detector Map](methodology/detector-map.md)
-- [Architecture](architecture.md)
+- [Request flow for incident response](request-flow-for-incident-response.md)
 - [Evidence Map](evidence-map.md)
 - [First 10 Minutes](first-10-minutes/index.md)
 

--- a/docs/troubleshooting/playbooks/auth-config/app-settings-misconfiguration.md
+++ b/docs/troubleshooting/playbooks/auth-config/app-settings-misconfiguration.md
@@ -543,7 +543,7 @@ timestamp                    message
 5. Keep canonical Key Vault reference examples in shared runbooks and lint setting values before apply.
 
 ## See Also
-- [Troubleshooting Architecture](../../architecture.md)
+- [Request flow for incident response](../../request-flow-for-incident-response.md)
 - [Troubleshooting Methodology](../../methodology.md)
 - [KQL Query Guide](../../kql/index.md)
 - [Troubleshooting Playbooks Index](../index.md)

--- a/docs/troubleshooting/playbooks/auth-config/managed-identity-rbac-failure.md
+++ b/docs/troubleshooting/playbooks/auth-config/managed-identity-rbac-failure.md
@@ -542,7 +542,7 @@ timeline
 6. Run quarterly access reviews to remove stale assignments without breaking trigger identities.
 
 ## See Also
-- [Troubleshooting Architecture](../../architecture.md)
+- [Request flow for incident response](../../request-flow-for-incident-response.md)
 - [Troubleshooting Methodology](../../methodology.md)
 - [KQL Query Guide](../../kql/index.md)
 - [Troubleshooting Lab Guides](../../lab-guides/index.md)

--- a/docs/troubleshooting/playbooks/blob-trigger-not-firing.md
+++ b/docs/troubleshooting/playbooks/blob-trigger-not-firing.md
@@ -559,7 +559,7 @@ az monitor log-analytics query \
 
 ## See Also
 
-- [Troubleshooting Architecture](../architecture.md)
+- [Request flow for incident response](../request-flow-for-incident-response.md)
 - [First 10 Minutes](../first-10-minutes/index.md)
 - [Troubleshooting KQL](../kql/index.md)
 - [Troubleshooting Methodology](../methodology.md)

--- a/docs/troubleshooting/playbooks/functions-failing.md
+++ b/docs/troubleshooting/playbooks/functions-failing.md
@@ -578,7 +578,7 @@ az functionapp restart --resource-group "$RG" --name "$APP_NAME"
 - [First 10 Minutes](../first-10-minutes/index.md)
 - [KQL Query Library](../kql/index.md)
 - [Troubleshooting Evidence Map](../evidence-map.md)
-- [Troubleshooting Architecture](../architecture.md)
+- [Request flow for incident response](../request-flow-for-incident-response.md)
 
 ## Sources
 

--- a/docs/troubleshooting/playbooks/functions-not-executing.md
+++ b/docs/troubleshooting/playbooks/functions-not-executing.md
@@ -545,7 +545,7 @@ Recovery criteria:
 | Incident drill | Monthly | Incident commander | End-to-end triage < 15 minutes |
 
 ## See Also
-- [Troubleshooting Architecture](../architecture.md)
+- [Request flow for incident response](../request-flow-for-incident-response.md)
 - [First 10 Minutes](../first-10-minutes/index.md)
 - [KQL Query Library](../kql/index.md)
 - [Troubleshooting Methodology](../methodology.md)

--- a/docs/troubleshooting/playbooks/scaling/durable-orchestration-stuck.md
+++ b/docs/troubleshooting/playbooks/scaling/durable-orchestration-stuck.md
@@ -534,7 +534,7 @@ flowchart TD
 5. Add proactive alerts for long-running instance age, replay volume, and activity failure ratio.
 
 ## See Also
-- [Troubleshooting architecture](../../architecture.md)
+- [Request flow for incident response](../../request-flow-for-incident-response.md)
 - [Troubleshooting methodology](../../methodology.md)
 - [Troubleshooting KQL guide](../../kql/index.md)
 - [Durable replay storm lab guide](../../lab-guides/durable-replay-storm.md)

--- a/docs/troubleshooting/playbooks/scaling/out-of-memory-worker-crash.md
+++ b/docs/troubleshooting/playbooks/scaling/out-of-memory-worker-crash.md
@@ -519,7 +519,7 @@ Plan memory guidance for escalation decisions:
 5. Load test with production-like payload distributions before release, then validate no monotonic memory growth.
 
 ## See Also
-- [Troubleshooting architecture](../../architecture.md)
+- [Request flow for incident response](../../request-flow-for-incident-response.md)
 - [Troubleshooting methodology](../../methodology.md)
 - [Troubleshooting KQL guide](../../kql/index.md)
 - [Out of memory crash lab guide](../../lab-guides/out-of-memory-crash.md)

--- a/docs/troubleshooting/playbooks/triggers/event-hub-service-bus-lag.md
+++ b/docs/troubleshooting/playbooks/triggers/event-hub-service-bus-lag.md
@@ -523,7 +523,7 @@ az functionapp deployment source config-zip --name <app-name> --resource-group <
 5. Validate `host.json` extension tuning in load tests for realistic producer bursts before release.
 
 ## See Also
-- [Troubleshooting Architecture](../../architecture.md)
+- [Request flow for incident response](../../request-flow-for-incident-response.md)
 - [Troubleshooting Methodology](../../methodology.md)
 - [Troubleshooting KQL Guide](../../kql/index.md)
 - [Event Hub checkpoint lag lab guide](../../lab-guides/event-hub-checkpoint-lag.md)

--- a/docs/troubleshooting/playbooks/triggers/timeout-execution-limit.md
+++ b/docs/troubleshooting/playbooks/triggers/timeout-execution-limit.md
@@ -501,7 +501,7 @@ az functionapp deployment source config-zip --name <app-name> --resource-group <
 5. Validate `host.json` timeout values per environment and plan type during CI/CD policy checks.
 
 ## See Also
-- [Troubleshooting Architecture](../../architecture.md)
+- [Request flow for incident response](../../request-flow-for-incident-response.md)
 - [Troubleshooting Methodology](../../methodology.md)
 - [Troubleshooting KQL Guide](../../kql/index.md)
 - [Troubleshooting Lab Guides](../../lab-guides/index.md)

--- a/docs/troubleshooting/request-flow-for-incident-response.md
+++ b/docs/troubleshooting/request-flow-for-incident-response.md
@@ -82,11 +82,15 @@ content_validation:
       verified: true
 ---
 
-# Troubleshooting Architecture Map for Azure Functions
+# Request Flow for Incident Response
 
 This guide is a diagnostic architecture reference for incident response.
 It is intentionally failure-oriented so you can locate where symptoms originate and what evidence source to check first.
 Use it as a fast index from symptom category to architecture layer ownership.
+
+!!! info "When to use this page"
+    Use this page when you need a **request-flow and incident-flow view**: trace a symptom left-to-right through architecture layers to the evidence source that confirms it.
+    For a **component-by-component reference** (hosting, triggers, scale controller, cold start, Durable), see [Architecture components reference](architecture-components-reference.md) instead.
 
 !!! warning "How to use this document"
     This is not a design poster.
@@ -334,6 +338,7 @@ flowchart TD
 ## See Also
 
 - [First 10 Minutes](first-10-minutes/index.md)
+- [Architecture components reference](architecture-components-reference.md)
 - [Systematic Troubleshooting Methodology](methodology.md)
 - [KQL Query Library](kql/index.md)
 - [Functions not executing playbook](playbooks/functions-not-executing.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,10 @@ plugins:
       on_error_fail: true
   - minify:
       minify_html: true
+  - redirects:
+      redirect_maps:
+        troubleshooting/architecture-overview.md: troubleshooting/architecture-components-reference.md
+        troubleshooting/architecture.md: troubleshooting/request-flow-for-incident-response.md
 
 markdown_extensions:
   - admonition
@@ -514,8 +518,8 @@ nav:
     - operations/migration.md
   - Troubleshooting:
     - troubleshooting/index.md
-    - troubleshooting/architecture-overview.md
-    - troubleshooting/architecture.md
+    - troubleshooting/architecture-components-reference.md
+    - troubleshooting/request-flow-for-incident-response.md
     - troubleshooting/evidence-map.md
     - troubleshooting/decision-tree.md
     - troubleshooting/mental-model.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,7 @@
 mkdocs-material
 mkdocs-minify-plugin
 mkdocs-macros-plugin
+mkdocs-redirects
 pymdown-extensions
 PyYAML
 azure-guide-capture-toolkit @ git+https://github.com/yeongseon/azure-guide-capture-toolkit@v0.1.0


### PR DESCRIPTION
## Summary
Editorial IA clarification for the two complementary troubleshooting architecture pages (closes #73). No content loss, no consolidation.

- Rename `architecture-overview.md` → `architecture-components-reference.md` (H1: "Architecture Components Reference")
- Rename `architecture.md` → `request-flow-for-incident-response.md` (H1: "Request Flow for Incident Response")
- Add a `!!! info "When to use this page"` note atop each page + reciprocal See Also cross-links
- Add `mkdocs-redirects` (requirements-docs.txt + plugin config) with redirect_maps for both old paths
- Rewrite all inbound links (14 playbooks/docs) and labels to the new role-explicit names
- Update troubleshooting hub index with distinct "components reference" vs "request/incident flow" rows
- Update contributing ASCII tree; regenerate content-validation dashboard (64/64 verified)

## Verification
- `mkdocs build --strict`: pass
- `scripts/normalize_yaml_frontmatter.py --check`: 0 drift
- `scripts/generate_content_validation_status.py`: 64/64 verified