### PR TITLE
docs: refine testing and migration guides for accuracy

### DIFF
--- a/docs/best-practices/testing.md
+++ b/docs/best-practices/testing.md
@@ -61,7 +61,7 @@ Bias toward many fast, isolated tests and few slow, deployed ones:
 
 - Use [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite) as the local Azure Storage emulator to exercise Queue, Blob, and Table triggers and bindings without provisioning cloud resources.
 - Set `AzureWebJobsStorage` to `UseDevelopmentStorage=true` in `local.settings.json` so both the host and Storage bindings target Azurite.
-- Azurite covers Storage bindings only. Cosmos DB, Event Hubs, and Service Bus have no first-party emulator in this repository's scope — mock their clients in unit tests, or test against a dedicated non-production namespace when a real contract must be validated.
+- Azurite covers Storage bindings only. Cosmos DB, Service Bus, and Event Hubs each have their own local emulators ([Cosmos DB emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator), [Service Bus emulator](https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator), [Event Hubs emulator](https://learn.microsoft.com/en-us/azure/event-hubs/test-locally-with-event-hub-emulator)); use them when a real binding contract must be validated, and otherwise mock the clients in unit tests.
 
 ### Integrate Tests into CI
 
@@ -101,4 +101,6 @@ Bias toward many fast, isolated tests and few slow, deployed ones:
 - [Strategies for testing your code in Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-test-a-function)
 - [Use the Azurite emulator for local Azure Storage development (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite)
 - [Develop Azure Functions locally using Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
+- [Azure Service Bus emulator for local testing (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator)
+- [Azure Event Hubs emulator for local testing (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/event-hubs/test-locally-with-event-hub-emulator)
 - [Use dependency injection in .NET Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection)

--- a/docs/best-practices/testing.md
+++ b/docs/best-practices/testing.md
@@ -103,4 +103,5 @@ Bias toward many fast, isolated tests and few slow, deployed ones:
 - [Develop Azure Functions locally using Core Tools (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local)
 - [Azure Service Bus emulator for local testing (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator)
 - [Azure Event Hubs emulator for local testing (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/event-hubs/test-locally-with-event-hub-emulator)
+- [Azure Cosmos DB emulator for local development (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator)
 - [Use dependency injection in .NET Azure Functions (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection)

--- a/docs/operations/migration.md
+++ b/docs/operations/migration.md
@@ -40,7 +40,7 @@ Migrating an Azure Functions workload — whether across hosting plans or across
 ## Prerequisites
 
 - An existing function app on the source plan or programming model.
-- Azure CLI 2.60 or later with the current `functionapp` commands available.
+- A current Azure CLI with the `functionapp` command group, including the Flex Consumption options used below. Upgrade with `az upgrade` if plan or SKU commands are missing.
 - A staging slot or a secondary function app to enable a safe cutover (blue-green) rather than an in-place change.
 - Application Insights enabled on both source and target so migration can be verified with telemetry.
 - Source control access to the app code, so a redeploy of the previous version is always possible.
@@ -63,7 +63,7 @@ Migrating an Azure Functions workload — whether across hosting plans or across
 | Y1 → FC1 | Yes (create new FC1 app) | Cutover only (DNS/slot swap) | High — keep old app until validated |
 | In-process → isolated | No (same app, code change) | Deploy window | Medium — redeploy previous package |
 | Python v1 → v2 | No (same app, code change) | Deploy window | Medium — redeploy previous package |
-| Premium ↔ Dedicated | No (change plan SKU) | Brief restart | High — change SKU back |
+| Premium ↔ Dedicated | Usually no (SKU change); new app in some cases | Brief restart | High — change SKU back |
 
 ### Path 1: Consumption (Y1) → Flex Consumption (FC1)
 
@@ -112,7 +112,7 @@ Migrating an Azure Functions workload — whether across hosting plans or across
 ### Path 4: Premium ↔ Dedicated
 
 - **When to move.** Choose Dedicated to reuse an existing App Service estate or to run on fixed, predictable capacity; choose Premium to keep event-driven dynamic scale with pre-warmed instances and enterprise networking.
-- **Configuration deltas.** Moving to Dedicated changes the plan SKU and removes event-driven dynamic scaling — you manage instance count and rely on "Always On" instead of pre-warmed instances. Moving to Premium restores dynamic scale-out and always-ready instances. Re-validate VNet integration and cold-start expectations after the change, as they differ between the two plans.
+- **Configuration deltas.** Moving to Dedicated changes the plan SKU and removes event-driven dynamic scaling — you manage instance count and rely on "Always On" instead of pre-warmed instances. Moving to Premium restores dynamic scale-out and always-ready instances. A same-app plan change is the common path, but some direction or region changes require creating a new app on the target plan and redeploying rather than an in-place SKU switch — confirm the app can move before scheduling downtime. Re-validate VNet integration and cold-start expectations after the change, as they differ between the two plans.
 
 ## Verification
 


### PR DESCRIPTION
## Summary
Accuracy follow-up to #120 (post-review nits).

- `best-practices/testing.md`: note that Cosmos DB, Service Bus, and Event Hubs each have first-party local emulators (with MSLearn links), instead of implying none exist.
- `operations/migration.md`: replace the arbitrary `CLI 2.60` version claim with an `az upgrade` guidance line; add a caveat that Premium↔Dedicated may require creating a new app on the target plan in some cases (prose + decision-matrix row).

## Verification
- `mkdocs build --strict`: pass
- `scripts/normalize_yaml_frontmatter.py --check`: 0 drift
- All new MSLearn emulator URLs verified 200 (en-us locale)