### PR TITLE
fix: enforce blank-line termination on CLI explanation tables

### DIFF
--- a/.github/workflows/validate-content-sources.yml
+++ b/.github/workflows/validate-content-sources.yml
@@ -139,11 +139,6 @@ jobs:
           python scripts/validate_content_sources.py
         continue-on-error: true
 
-      - name: Validate CLI explanation tables
-        run: |
-          python scripts/validate_cli_explanations.py
-        continue-on-error: true
-
       - name: Audit existing diagram IDs
         run: |
           # Count mermaid blocks
@@ -167,6 +162,27 @@ jobs:
 
           echo "All mermaid blocks have diagram-id comments."
         continue-on-error: true
+
+  validate-cli-explanations:
+    name: Validate CLI Explanation Tables
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+
+      - name: Run CLI explanation doctests
+        run: |
+          python -m doctest scripts/validate_cli_explanations.py -v
+
+      - name: Validate CLI explanation tables
+        run: |
+          python scripts/validate_cli_explanations.py
 
   validate-mslearn-urls:
     name: Validate MSLearn URLs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,6 +485,42 @@ az functionapp create --resource-group $RG --name $APP_NAME --plan $PLAN_NAME --
 az functionapp create -g $RG -n $APP_NAME  # ❌ Don't do this
 ```
 
+### CLI Explanation Table Rule (Quality Gate)
+
+Every `bash` code fence that contains an `az ...` command MUST be immediately followed by a command explanation table — typically `| Command/Parameter | Purpose |` (this repository's established variant), or another series variant such as `| Command | Purpose |` — listing the base command plus every long flag used, one row each. This is enforced by `scripts/validate_cli_explanations.py` (wired into the `Validate CLI Explanation Tables` CI job).
+
+**MANDATORY: the explanation table MUST be terminated by a blank line** (or end-of-file). A table that directly abuts the following line — `Example output:`, a `` ``` `` code fence, or any prose — is a **rendering defect**, not a cosmetic one.
+
+Why this is mandatory, and why generic gates miss it:
+
+- Python-Markdown's `tables` extension is block-level: it requires a blank line **after** the table. Without it, the first following non-blank line is silently absorbed **into the table as a phantom row** (e.g. `Example output:` renders as `<td>Example output:</td><td></td>`), corrupting both the table and the following block.
+- **`mkdocs build --strict` does NOT catch this.** Strict mode fails only on broken links and nav warnings; a malformed-but-parseable table still "builds" clean. A green strict build is therefore **not** evidence that tables render correctly.
+- **Source-only review (including Oracle text review) does NOT catch this.** Reviewing the Markdown source (which looks fine line-by-line) cannot reveal a rendering-level absorption bug. Rendered-HTML verification is required.
+- A table-existence check is insufficient: a validator that only asserts "a table follows the fence" will pass a table missing its trailing blank line. The validator MUST also assert table **termination** (blank line or EOF). `find_unterminated_tables()` in `scripts/validate_cli_explanations.py` enforces this, and its doctests are the executable spec.
+
+Correct:
+
+```markdown
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp create` | Create the function app. |
+| `--name` | Name of the function app. |
+
+Example output:
+```
+
+Broken (no blank line — `Example output:` is absorbed as a phantom table row):
+
+```markdown
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp create` | Create the function app. |
+| `--name` | Name of the function app. |
+Example output:
+```
+
+When generating or inserting explanation tables in bulk, always re-verify with the validator **and** spot-check the rendered HTML. Any scanner MUST skip fenced code regions, because KQL blocks use line-leading `|` (`| where`, `| summarize`) that would otherwise be miscounted as table rows — causing both false positives and missed real defects.
+
 ### Variable Naming Convention
 
 | Variable | Description | Example |

--- a/docs/best-practices/cost-optimization.md
+++ b/docs/best-practices/cost-optimization.md
@@ -180,6 +180,13 @@ az resource update \
     --resource-type "Microsoft.Web/sites" \
     --set properties.siteConfig.functionAppScaleLimit=20
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az resource update` | Update a resource property through the generic resource provider. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--resource-type` | Azure resource type to target. |
+| `--set` | Property path and value to set. |
 
 For Flex Consumption, set `scaleAndConcurrency.maximumInstanceCount` (or equivalent portal setting) aligned to dependency capacity.
 

--- a/docs/best-practices/deployment.md
+++ b/docs/best-practices/deployment.md
@@ -108,6 +108,12 @@ az functionapp config appsettings set \
     --name "<app-name>" \
     --settings WEBSITE_RUN_FROM_PACKAGE=1
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--settings` | Key=value application settings to apply. |
 
 !!! warning "Mutable deployment anti-pattern"
     Deploying without run-from-package can produce inconsistent behavior when trigger listeners restart while files are changing. For event-driven apps, this can surface as duplicate or missed processing windows.
@@ -157,6 +163,13 @@ az functionapp config appsettings set \
     --slot "staging" \
     --slot-settings AZURE_FUNCTIONS_ENVIRONMENT=Staging
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--slot` | Deployment slot name. |
+| `--slot-settings` | Slot-specific (sticky) application settings. |
 
 ### CI/CD pipeline design for Functions
 

--- a/docs/best-practices/networking.md
+++ b/docs/best-practices/networking.md
@@ -359,6 +359,11 @@ az functionapp vnet-integration list \
     --name "$APP_NAME" \
     --resource-group "$RG"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp vnet-integration list` | List the app's regional virtual-network integration. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
 
 ### Verify subnet delegation
 
@@ -369,6 +374,13 @@ az network vnet subnet show \
     --vnet-name "$VNET_NAME" \
     --query "delegations[].serviceName"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az network vnet subnet show` | Show details of a virtual-network subnet. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--vnet-name` | Name of the virtual network. |
+| `--query` | JMESPath query selecting fields from the response. |
 
 ### Verify private endpoint status
 
@@ -378,6 +390,12 @@ az network private-endpoint show \
     --resource-group "$RG" \
     --query "{provisioningState:provisioningState,networkInterfaces:networkInterfaces[].id}"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az network private-endpoint show` | Show details of a private endpoint. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--query` | JMESPath query selecting fields from the response. |
 
 ### Verify private DNS zone links
 
@@ -386,6 +404,11 @@ az network private-dns link vnet list \
     --resource-group "$DNS_RG" \
     --zone-name "privatelink.azurewebsites.net"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az network private-dns link vnet list` | List virtual-network links on a private DNS zone. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--zone-name` | Private DNS zone name. |
 
 ### Verify app access restrictions
 
@@ -394,6 +417,11 @@ az functionapp config access-restriction show \
     --name "$APP_NAME" \
     --resource-group "$RG"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config access-restriction show` | Show inbound access-restriction rules for the app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
 
 ??? tip "Cross-check with security controls"
     Networking isolation does not replace identity and secret hygiene. Apply [Security Best Practices](./security.md) together with these network controls.

--- a/docs/best-practices/scaling.md
+++ b/docs/best-practices/scaling.md
@@ -119,6 +119,13 @@ az resource update \
   --resource-type "Microsoft.Web/sites" \
   --set properties.siteConfig.functionAppScaleLimit=30
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az resource update` | Update a resource property through the generic resource provider. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--resource-type` | Azure resource type to target. |
+| `--set` | Property path and value to set. |
 
 ```bash
 # Per-instance HTTP concurrency (Flex Consumption ONLY)
@@ -127,6 +134,12 @@ az functionapp config appsettings set \
   --name "$APP_NAME" \
   --settings "FUNCTIONS_MAX_HTTP_TRIGGER_CONCURRENCY=50"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--settings` | Key=value application settings to apply. |
 
 !!! warning "Plan-specific concurrency controls"
     For **Consumption and Premium** plans, per-function concurrency is controlled through `host.json` settings (`maxConcurrentRequests` for HTTP, `batchSize` for queues, etc.) — not through the `FUNCTIONS_MAX_HTTP_TRIGGER_CONCURRENCY` app setting.

--- a/docs/best-practices/security.md
+++ b/docs/best-practices/security.md
@@ -366,6 +366,11 @@ az functionapp identity assign \
     --name "$APP_NAME" \
     --resource-group "$RG"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp identity assign` | Enable a managed identity on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
 
 Set HTTPS-only and TLS minimum:
 
@@ -380,6 +385,16 @@ az functionapp config set \
     --resource-group "$RG" \
     --min-tls-version "1.2"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp update` | Update top-level function app properties. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--https-only` | Require HTTPS for all traffic. |
+| `az functionapp config set` | Update the function app's site configuration. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--min-tls-version` | Minimum TLS version accepted. |
 
 Set Key Vault-backed app setting:
 
@@ -389,6 +404,12 @@ az functionapp config appsettings set \
     --resource-group "$RG" \
     --settings "DbPassword=@Microsoft.KeyVault(SecretUri=https://$KEYVAULT_NAME.vault.azure.net/secrets/DbPassword/)"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--settings` | Key=value application settings to apply. |
 
 Grant storage data role to managed identity principal:
 
@@ -399,6 +420,13 @@ az role assignment create \
     --role "Storage Blob Data Contributor" \
     --scope "/subscriptions/<subscription-id>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/$STORAGE_NAME"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az role assignment create` | Assign an Azure RBAC role to an identity. |
+| `--assignee-object-id` | Object ID of the identity receiving the role. |
+| `--assignee-principal-type` | Principal type of the assignee. |
+| `--role` | Azure RBAC role to assign. |
+| `--scope` | Scope at which the role applies. |
 
 ## Validation Checklist
 

--- a/docs/best-practices/trigger-and-binding.md
+++ b/docs/best-practices/trigger-and-binding.md
@@ -139,6 +139,12 @@ az functionapp cors add \
   --name "$APP_NAME" \
   --allowed-origins "https://portal.contoso.example"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp cors add` | Add an allowed CORS origin to the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--allowed-origins` | Origin(s) permitted by CORS. |
 
 ### Queue trigger best practices
 

--- a/docs/language-guides/dotnet/recipes/event-hub.md
+++ b/docs/language-guides/dotnet/recipes/event-hub.md
@@ -62,6 +62,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "EventHubConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--settings` | Key=value application settings to apply. |
 
 ### Host settings and checkpointing
 

--- a/docs/language-guides/dotnet/recipes/service-bus.md
+++ b/docs/language-guides/dotnet/recipes/service-bus.md
@@ -75,6 +75,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "ServiceBusConnection__fullyQualifiedNamespace=$NAMESPACE.servicebus.windows.net"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--settings` | Key=value application settings to apply. |
 
 Grant the managed identity the **Azure Service Bus Data Receiver** (and **Data Sender** for output) role.
 

--- a/docs/language-guides/dotnet/recipes/table-storage.md
+++ b/docs/language-guides/dotnet/recipes/table-storage.md
@@ -81,6 +81,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "TableConnection__tableServiceUri=https://$STORAGE_NAME.table.core.windows.net"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--settings` | Key=value application settings to apply. |
 
 Grant the managed identity **Storage Table Data Reader** (input) and **Storage Table Data Contributor** (output).
 

--- a/docs/language-guides/dotnet/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/dotnet/tutorial/premium/09-container-deployment.md
@@ -76,6 +76,16 @@ az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
 az acr build --registry $REGISTRY_NAME --image functions/dotnet-app:v1.0.0 .
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr create` | Creates an Azure Container Registry to store the function image. |
+| `--resource-group` | Resource group that will contain the registry. |
+| `--name` | Globally unique registry name. |
+| `--sku` | Registry pricing tier (`Basic`). |
+| `az acr build` | Builds the container image remotely in ACR (no local Docker). |
+| `--registry` | Target registry that runs the build. |
+| `--image` | Image name and tag to produce. |
+
 ## 3. Create the Premium Plan and Function App
 
 ```bash
@@ -89,6 +99,22 @@ az functionapp create --resource-group $RG --name $APP_NAME \
   --assign-identity "[system]"
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp plan create` | Creates the Elastic Premium hosting plan. |
+| `--resource-group` | Resource group for the plan. |
+| `--name` | Name of the Premium plan. |
+| `--location` | Azure region for the plan. |
+| `--sku` | Premium plan SKU (`EP1`). |
+| `--is-linux` | Creates a Linux plan required for container images. |
+| `az functionapp create` | Creates the function app on the Premium plan. |
+| `--storage-account` | Storage account backing the function app. |
+| `--plan` | Premium plan that hosts the app. |
+| `--functions-version` | Functions runtime major version (`4`). |
+| `--runtime` | Language runtime (`dotnet-isolated`). |
+| `--image` | Container image the app runs. |
+| `--assign-identity "[system]"` | Enables a system-assigned managed identity. |
+
 ## 4. Grant Managed-Identity Registry Pull
 
 ```bash
@@ -100,6 +126,21 @@ az resource update --ids "$(az functionapp show --resource-group $RG --name $APP
   --set properties.acrUseManagedIdentityCreds=true
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp identity show` | Reads the app's managed-identity principal ID. |
+| `--query principalId` | Projects only the principal ID. |
+| `--output tsv` | Emits a raw value for shell capture. |
+| `az acr show` | Reads the registry resource ID. |
+| `--query id` | Projects only the registry resource ID. |
+| `az role assignment create` | Grants the identity pull access to the registry. |
+| `--assignee` | Principal that receives the role. |
+| `--role AcrPull` | Least-privilege role for pulling images. |
+| `--scope` | Registry resource the role applies to. |
+| `az resource update` | Enables managed-identity credentials for the container config. |
+| `--ids` | Target `config/web` resource of the function app. |
+| `--set properties.acrUseManagedIdentityCreds=true` | Turns on identity-based registry pulls. |
+
 ## 5. Update the Image
 
 ```bash
@@ -107,6 +148,16 @@ az acr build --registry $REGISTRY_NAME --image functions/dotnet-app:v1.0.1 .
 az functionapp config container set --resource-group $RG --name $APP_NAME \
   --image $REGISTRY_NAME.azurecr.io/functions/dotnet-app:v1.0.1
 ```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr build` | Builds and pushes the new image tag in ACR. |
+| `--registry` | Target registry that runs the build. |
+| `--image` | New image name and tag to produce. |
+| `az functionapp config container set` | Points the app at the new image. |
+| `--resource-group` | Resource group of the function app. |
+| `--name` | Name of the function app. |
+| `--image` | Container image the app should run. |
 
 !!! info "Continuous deployment on Premium"
     Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.

--- a/docs/language-guides/java/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/java/tutorial/premium/09-container-deployment.md
@@ -78,6 +78,16 @@ az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
 az acr build --registry $REGISTRY_NAME --image functions/java-app:v1.0.0 .
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr create` | Creates an Azure Container Registry to store the function image. |
+| `--resource-group` | Resource group that will contain the registry. |
+| `--name` | Globally unique registry name. |
+| `--sku` | Registry pricing tier (`Basic`). |
+| `az acr build` | Builds the container image remotely in ACR (no local Docker). |
+| `--registry` | Target registry that runs the build. |
+| `--image` | Image name and tag to produce. |
+
 ## 3. Create the Premium Plan and Function App
 
 ```bash
@@ -91,6 +101,22 @@ az functionapp create --resource-group $RG --name $APP_NAME \
   --assign-identity "[system]"
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp plan create` | Creates the Elastic Premium hosting plan. |
+| `--resource-group` | Resource group for the plan. |
+| `--name` | Name of the Premium plan. |
+| `--location` | Azure region for the plan. |
+| `--sku` | Premium plan SKU (`EP1`). |
+| `--is-linux` | Creates a Linux plan required for container images. |
+| `az functionapp create` | Creates the function app on the Premium plan. |
+| `--storage-account` | Storage account backing the function app. |
+| `--plan` | Premium plan that hosts the app. |
+| `--functions-version` | Functions runtime major version (`4`). |
+| `--runtime` | Language runtime (`java`). |
+| `--image` | Container image the app runs. |
+| `--assign-identity "[system]"` | Enables a system-assigned managed identity. |
+
 ## 4. Grant Managed-Identity Registry Pull
 
 ```bash
@@ -102,6 +128,21 @@ az resource update --ids "$(az functionapp show --resource-group $RG --name $APP
   --set properties.acrUseManagedIdentityCreds=true
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp identity show` | Reads the app's managed-identity principal ID. |
+| `--query principalId` | Projects only the principal ID. |
+| `--output tsv` | Emits a raw value for shell capture. |
+| `az acr show` | Reads the registry resource ID. |
+| `--query id` | Projects only the registry resource ID. |
+| `az role assignment create` | Grants the identity pull access to the registry. |
+| `--assignee` | Principal that receives the role. |
+| `--role AcrPull` | Least-privilege role for pulling images. |
+| `--scope` | Registry resource the role applies to. |
+| `az resource update` | Enables managed-identity credentials for the container config. |
+| `--ids` | Target `config/web` resource of the function app. |
+| `--set properties.acrUseManagedIdentityCreds=true` | Turns on identity-based registry pulls. |
+
 ## 5. Update the Image
 
 ```bash
@@ -109,6 +150,16 @@ az acr build --registry $REGISTRY_NAME --image functions/java-app:v1.0.1 .
 az functionapp config container set --resource-group $RG --name $APP_NAME \
   --image $REGISTRY_NAME.azurecr.io/functions/java-app:v1.0.1
 ```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr build` | Builds and pushes the new image tag in ACR. |
+| `--registry` | Target registry that runs the build. |
+| `--image` | New image name and tag to produce. |
+| `az functionapp config container set` | Points the app at the new image. |
+| `--resource-group` | Resource group of the function app. |
+| `--name` | Name of the function app. |
+| `--image` | Container image the app should run. |
 
 !!! info "Continuous deployment on Premium"
     Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.

--- a/docs/language-guides/nodejs/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/nodejs/tutorial/premium/09-container-deployment.md
@@ -80,6 +80,16 @@ az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
 az acr build --registry $REGISTRY_NAME --image functions/node-app:v1.0.0 .
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr create` | Creates an Azure Container Registry to store the function image. |
+| `--resource-group` | Resource group that will contain the registry. |
+| `--name` | Globally unique registry name. |
+| `--sku` | Registry pricing tier (`Basic`). |
+| `az acr build` | Builds the container image remotely in ACR (no local Docker). |
+| `--registry` | Target registry that runs the build. |
+| `--image` | Image name and tag to produce. |
+
 ## 3. Create the Premium Plan and Function App
 
 ```bash
@@ -93,6 +103,22 @@ az functionapp create --resource-group $RG --name $APP_NAME \
   --assign-identity "[system]"
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp plan create` | Creates the Elastic Premium hosting plan. |
+| `--resource-group` | Resource group for the plan. |
+| `--name` | Name of the Premium plan. |
+| `--location` | Azure region for the plan. |
+| `--sku` | Premium plan SKU (`EP1`). |
+| `--is-linux` | Creates a Linux plan required for container images. |
+| `az functionapp create` | Creates the function app on the Premium plan. |
+| `--storage-account` | Storage account backing the function app. |
+| `--plan` | Premium plan that hosts the app. |
+| `--functions-version` | Functions runtime major version (`4`). |
+| `--runtime` | Language runtime (`node`). |
+| `--image` | Container image the app runs. |
+| `--assign-identity "[system]"` | Enables a system-assigned managed identity. |
+
 ## 4. Grant Managed-Identity Registry Pull
 
 ```bash
@@ -104,6 +130,21 @@ az resource update --ids "$(az functionapp show --resource-group $RG --name $APP
   --set properties.acrUseManagedIdentityCreds=true
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp identity show` | Reads the app's managed-identity principal ID. |
+| `--query principalId` | Projects only the principal ID. |
+| `--output tsv` | Emits a raw value for shell capture. |
+| `az acr show` | Reads the registry resource ID. |
+| `--query id` | Projects only the registry resource ID. |
+| `az role assignment create` | Grants the identity pull access to the registry. |
+| `--assignee` | Principal that receives the role. |
+| `--role AcrPull` | Least-privilege role for pulling images. |
+| `--scope` | Registry resource the role applies to. |
+| `az resource update` | Enables managed-identity credentials for the container config. |
+| `--ids` | Target `config/web` resource of the function app. |
+| `--set properties.acrUseManagedIdentityCreds=true` | Turns on identity-based registry pulls. |
+
 ## 5. Update the Image
 
 ```bash
@@ -111,6 +152,16 @@ az acr build --registry $REGISTRY_NAME --image functions/node-app:v1.0.1 .
 az functionapp config container set --resource-group $RG --name $APP_NAME \
   --image $REGISTRY_NAME.azurecr.io/functions/node-app:v1.0.1
 ```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr build` | Builds and pushes the new image tag in ACR. |
+| `--registry` | Target registry that runs the build. |
+| `--image` | New image name and tag to produce. |
+| `az functionapp config container set` | Points the app at the new image. |
+| `--resource-group` | Resource group of the function app. |
+| `--name` | Name of the function app. |
+| `--image` | Container image the app should run. |
 
 !!! info "Continuous deployment on Premium"
     Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.

--- a/docs/language-guides/powershell/recipes/custom-domain-certificates.md
+++ b/docs/language-guides/powershell/recipes/custom-domain-certificates.md
@@ -17,6 +17,12 @@ Point a CNAME (or A record) at the Function App, then bind the hostname:
 ```bash
 az functionapp config hostname add --name "$APP_NAME" --resource-group "$RG" --hostname "api.example.com"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config hostname add` | Add a custom hostname to the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--hostname` | Custom hostname. |
 
 ## Create a Managed Certificate
 
@@ -25,12 +31,25 @@ App Service managed certificates are free and auto-renew:
 ```bash
 az functionapp config ssl create --name "$APP_NAME" --resource-group "$RG" --hostname "api.example.com"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config ssl create` | Create a managed TLS certificate for the app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--hostname` | Custom hostname. |
 
 ## Bind the Certificate
 
 ```bash
 az functionapp config ssl bind --name "$APP_NAME" --resource-group "$RG" --certificate-thumbprint "<thumbprint>" --ssl-type SNI
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config ssl bind` | Bind a TLS certificate to a hostname. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--certificate-thumbprint` | Thumbprint of the certificate to bind. |
+| `--ssl-type` | TLS binding type (SNI or IP-based). |
 
 ## Enforce HTTPS
 
@@ -39,6 +58,12 @@ Redirect all HTTP traffic to HTTPS:
 ```bash
 az functionapp update --name "$APP_NAME" --resource-group "$RG" --set httpsOnly=true
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp update` | Update top-level function app properties. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--set` | Property path and value to set. |
 
 !!! warning "Hosting plan support"
     Flex Consumption does not support managed/platform certificates. Use Premium or Dedicated plans when you need a bound custom-domain certificate, or front the app with Azure Front Door.

--- a/docs/language-guides/powershell/recipes/http-auth.md
+++ b/docs/language-guides/powershell/recipes/http-auth.md
@@ -44,6 +44,12 @@ az functionapp function keys list \
   --resource-group $RG \
   --function-name secure
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp function keys list` | List the access keys for a function. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--function-name` | Name of the function. |
 
 ## Validating a Bearer Token
 

--- a/docs/language-guides/powershell/recipes/key-vault.md
+++ b/docs/language-guides/powershell/recipes/key-vault.md
@@ -20,6 +20,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "DbPassword=@Microsoft.KeyVault(SecretUri=https://my-vault.vault.azure.net/secrets/db-password/)"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--settings` | Key=value application settings to apply. |
 
 The function reads it as a normal environment variable:
 
@@ -57,6 +63,12 @@ az role assignment create \
   --role "Key Vault Secrets User" \
   --scope <key-vault-resource-id>
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az role assignment create` | Assign an Azure RBAC role to an identity. |
+| `--assignee` | Identity (object ID) receiving the role. |
+| `--role` | Azure RBAC role to assign. |
+| `--scope` | Scope at which the role applies. |
 
 !!! warning "Never log secrets"
     Do not pass secret values to `Write-Information`/`Write-Host` — they flow to Application Insights.

--- a/docs/language-guides/powershell/recipes/managed-identity.md
+++ b/docs/language-guides/powershell/recipes/managed-identity.md
@@ -17,6 +17,11 @@ az functionapp identity assign \
   --name $APP_NAME \
   --resource-group $RG
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp identity assign` | Enable a managed identity on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
 
 This injects `MSI_SECRET` and `IDENTITY_HEADER` into the app environment.
 
@@ -52,6 +57,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "AzureWebJobsStorage__accountName=$STORAGE_NAME"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--settings` | Key=value application settings to apply. |
 
 ## Grant RBAC
 
@@ -61,6 +72,12 @@ az role assignment create \
   --role "Storage Blob Data Contributor" \
   --scope <storage-account-resource-id>
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az role assignment create` | Assign an Azure RBAC role to an identity. |
+| `--assignee` | Identity (object ID) receiving the role. |
+| `--role` | Azure RBAC role to assign. |
+| `--scope` | Scope at which the role applies. |
 
 !!! warning "Concurrency and Az context"
     Azure PowerShell context is process-scoped. When in-process concurrency is enabled, call `Disable-AzContextAutosave -Scope Process` and validate for race conditions. See [PowerShell Runtime](../powershell-runtime.md#concurrency).

--- a/docs/language-guides/powershell/tutorial/consumption/02-first-deploy.md
+++ b/docs/language-guides/powershell/tutorial/consumption/02-first-deploy.md
@@ -49,6 +49,16 @@ az storage account create \
   --location $LOCATION \
   --sku Standard_LRS
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az group create` | Create the resource group that holds the tutorial resources. |
+| `--name` | Name of the resource group. |
+| `--location` | Azure region for the resource group. |
+| `az storage account create` | Create the storage account the function app requires. |
+| `--name` | Name of the storage account. |
+| `--resource-group` | Resource group that contains the storage account. |
+| `--location` | Azure region for the storage account. |
+| `--sku` | Storage replication SKU (`Standard_LRS` = locally redundant). |
 
 
 ### Step 3 - Create the function app
@@ -64,6 +74,17 @@ az functionapp create \
   --functions-version 4 \
   --os-type Windows
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp create` | Create the function app on a Consumption plan. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--storage-account` | Storage account backing the function app. |
+| `--consumption-plan-location` | Region for the auto-created Consumption plan. |
+| `--runtime` | Language runtime stack (`powershell`). |
+| `--runtime-version` | PowerShell runtime version. |
+| `--functions-version` | Azure Functions runtime major version. |
+| `--os-type` | Operating system for the app (`Windows`). |
 
 ### Step 4 - Deploy the code
 

--- a/docs/language-guides/powershell/tutorial/consumption/03-configuration.md
+++ b/docs/language-guides/powershell/tutorial/consumption/03-configuration.md
@@ -29,6 +29,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "GreetingPrefix=Hello" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--settings` | Key=value application settings to apply. |
 
 Read settings in PowerShell with `$env:GreetingPrefix`.
 
@@ -52,6 +58,12 @@ az functionapp config appsettings list \
   --resource-group $RG \
   --output table
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings list` | List the application settings on the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--output` | Output format (`table`). |
 
 Confirm `GreetingPrefix` appears with the expected value.
 

--- a/docs/language-guides/powershell/tutorial/consumption/04-logging-monitoring.md
+++ b/docs/language-guides/powershell/tutorial/consumption/04-logging-monitoring.md
@@ -34,6 +34,16 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az monitor app-insights component create` | Create the Application Insights component for telemetry. |
+| `--app` | Name of the Application Insights component. |
+| `--location` | Azure region for the component. |
+| `--resource-group` | Resource group that contains the component. |
+| `az functionapp config appsettings set` | Point the function app at Application Insights. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--settings` | Set the Application Insights connection string setting. |
 
 ## Logging in PowerShell
 
@@ -58,6 +68,11 @@ Write-Error "Downstream call failed"
 ```bash
 az functionapp log tail --name $APP_NAME --resource-group $RG
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp log tail` | Stream live log output from the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
 
 ## Verification
 

--- a/docs/language-guides/powershell/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/powershell/tutorial/consumption/05-infrastructure-as-code.md
@@ -59,12 +59,24 @@ az deployment group create \
   --template-file infra/main.bicep \
   --parameters appName=$APP_NAME storageName=$STORAGE_NAME
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group create` | Deploy the Bicep template to the resource group. |
+| `--resource-group` | Target resource group for the deployment. |
+| `--template-file` | Path to the Bicep template. |
+| `--parameters` | Template parameter values. |
 
 ## Verification
 
 ```bash
 az deployment group show --resource-group $RG --name main --query properties.provisioningState
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group show` | Show the status of a completed deployment. |
+| `--resource-group` | Resource group that contains the deployment. |
+| `--name` | Name of the deployment. |
+| `--query` | JMESPath query selecting the provisioning state. |
 
 Returns `Succeeded`.
 

--- a/docs/language-guides/powershell/tutorial/dedicated/02-first-deploy.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/02-first-deploy.md
@@ -49,6 +49,16 @@ az storage account create \
   --location $LOCATION \
   --sku Standard_LRS
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az group create` | Create the resource group that holds the tutorial resources. |
+| `--name` | Name of the resource group. |
+| `--location` | Azure region for the resource group. |
+| `az storage account create` | Create the storage account the function app requires. |
+| `--name` | Name of the storage account. |
+| `--resource-group` | Resource group that contains the storage account. |
+| `--location` | Azure region for the storage account. |
+| `--sku` | Storage replication SKU (`Standard_LRS` = locally redundant). |
 
 ### Step 2b - Create the hosting plan
 
@@ -60,6 +70,14 @@ az appservice plan create \
   --sku B1 \
   --is-linux
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az appservice plan create` | Create the App Service (Dedicated) plan that hosts the function app. |
+| `--name` | Name of the App Service plan. |
+| `--resource-group` | Resource group that contains the plan. |
+| `--location` | Azure region for the plan. |
+| `--sku` | Pricing tier for the plan (`B1`). |
+| `--is-linux` | Create the plan on Linux. |
 
 ### Step 3 - Create the function app
 
@@ -73,6 +91,16 @@ az functionapp create \
   --runtime-version 7.4 \
   --functions-version 4
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp create` | Create the function app on the pre-created plan. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--storage-account` | Storage account backing the function app. |
+| `--plan` | Existing plan that hosts the function app. |
+| `--runtime` | Language runtime stack (`powershell`). |
+| `--runtime-version` | PowerShell runtime version. |
+| `--functions-version` | Azure Functions runtime major version. |
 
 ### Step 4 - Deploy the code
 

--- a/docs/language-guides/powershell/tutorial/dedicated/03-configuration.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/03-configuration.md
@@ -29,6 +29,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "GreetingPrefix=Hello" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--settings` | Key=value application settings to apply. |
 
 Read settings in PowerShell with `$env:GreetingPrefix`.
 
@@ -52,6 +58,12 @@ az functionapp config appsettings list \
   --resource-group $RG \
   --output table
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings list` | List the application settings on the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--output` | Output format (`table`). |
 
 Confirm `GreetingPrefix` appears with the expected value.
 

--- a/docs/language-guides/powershell/tutorial/dedicated/04-logging-monitoring.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/04-logging-monitoring.md
@@ -34,6 +34,16 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az monitor app-insights component create` | Create the Application Insights component for telemetry. |
+| `--app` | Name of the Application Insights component. |
+| `--location` | Azure region for the component. |
+| `--resource-group` | Resource group that contains the component. |
+| `az functionapp config appsettings set` | Point the function app at Application Insights. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--settings` | Set the Application Insights connection string setting. |
 
 ## Logging in PowerShell
 
@@ -58,6 +68,11 @@ Write-Error "Downstream call failed"
 ```bash
 az functionapp log tail --name $APP_NAME --resource-group $RG
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp log tail` | Stream live log output from the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
 
 ## Verification
 

--- a/docs/language-guides/powershell/tutorial/dedicated/05-infrastructure-as-code.md
+++ b/docs/language-guides/powershell/tutorial/dedicated/05-infrastructure-as-code.md
@@ -59,12 +59,24 @@ az deployment group create \
   --template-file infra/main.bicep \
   --parameters appName=$APP_NAME storageName=$STORAGE_NAME
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group create` | Deploy the Bicep template to the resource group. |
+| `--resource-group` | Target resource group for the deployment. |
+| `--template-file` | Path to the Bicep template. |
+| `--parameters` | Template parameter values. |
 
 ## Verification
 
 ```bash
 az deployment group show --resource-group $RG --name main --query properties.provisioningState
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group show` | Show the status of a completed deployment. |
+| `--resource-group` | Resource group that contains the deployment. |
+| `--name` | Name of the deployment. |
+| `--query` | JMESPath query selecting the provisioning state. |
 
 Returns `Succeeded`.
 

--- a/docs/language-guides/powershell/tutorial/flex-consumption/02-first-deploy.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/02-first-deploy.md
@@ -49,6 +49,16 @@ az storage account create \
   --location $LOCATION \
   --sku Standard_LRS
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az group create` | Create the resource group that holds the tutorial resources. |
+| `--name` | Name of the resource group. |
+| `--location` | Azure region for the resource group. |
+| `az storage account create` | Create the storage account the function app requires. |
+| `--name` | Name of the storage account. |
+| `--resource-group` | Resource group that contains the storage account. |
+| `--location` | Azure region for the storage account. |
+| `--sku` | Storage replication SKU (`Standard_LRS` = locally redundant). |
 
 
 ### Step 3 - Create the function app
@@ -63,6 +73,16 @@ az functionapp create \
   --runtime-version 7.4 \
   --functions-version 4
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp create` | Create the function app on a Flex Consumption plan. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--storage-account` | Storage account backing the function app. |
+| `--flexconsumption-location` | Region for the Flex Consumption plan. |
+| `--runtime` | Language runtime stack (`powershell`). |
+| `--runtime-version` | PowerShell runtime version. |
+| `--functions-version` | Azure Functions runtime major version. |
 
 ### Step 4 - Deploy the code
 

--- a/docs/language-guides/powershell/tutorial/flex-consumption/03-configuration.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/03-configuration.md
@@ -29,6 +29,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "GreetingPrefix=Hello" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--settings` | Key=value application settings to apply. |
 
 Read settings in PowerShell with `$env:GreetingPrefix`.
 
@@ -50,6 +56,12 @@ az functionapp config appsettings list \
   --resource-group $RG \
   --output table
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings list` | List the application settings on the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--output` | Output format (`table`). |
 
 Confirm `GreetingPrefix` appears with the expected value.
 

--- a/docs/language-guides/powershell/tutorial/flex-consumption/04-logging-monitoring.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/04-logging-monitoring.md
@@ -34,6 +34,16 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az monitor app-insights component create` | Create the Application Insights component for telemetry. |
+| `--app` | Name of the Application Insights component. |
+| `--location` | Azure region for the component. |
+| `--resource-group` | Resource group that contains the component. |
+| `az functionapp config appsettings set` | Point the function app at Application Insights. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--settings` | Set the Application Insights connection string setting. |
 
 ## Logging in PowerShell
 
@@ -58,6 +68,11 @@ Write-Error "Downstream call failed"
 ```bash
 az functionapp log tail --name $APP_NAME --resource-group $RG
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp log tail` | Stream live log output from the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
 
 ## Verification
 

--- a/docs/language-guides/powershell/tutorial/flex-consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/powershell/tutorial/flex-consumption/05-infrastructure-as-code.md
@@ -59,12 +59,24 @@ az deployment group create \
   --template-file infra/main.bicep \
   --parameters appName=$APP_NAME storageName=$STORAGE_NAME
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group create` | Deploy the Bicep template to the resource group. |
+| `--resource-group` | Target resource group for the deployment. |
+| `--template-file` | Path to the Bicep template. |
+| `--parameters` | Template parameter values. |
 
 ## Verification
 
 ```bash
 az deployment group show --resource-group $RG --name main --query properties.provisioningState
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group show` | Show the status of a completed deployment. |
+| `--resource-group` | Resource group that contains the deployment. |
+| `--name` | Name of the deployment. |
+| `--query` | JMESPath query selecting the provisioning state. |
 
 Returns `Succeeded`.
 

--- a/docs/language-guides/powershell/tutorial/premium/02-first-deploy.md
+++ b/docs/language-guides/powershell/tutorial/premium/02-first-deploy.md
@@ -49,6 +49,16 @@ az storage account create \
   --location $LOCATION \
   --sku Standard_LRS
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az group create` | Create the resource group that holds the tutorial resources. |
+| `--name` | Name of the resource group. |
+| `--location` | Azure region for the resource group. |
+| `az storage account create` | Create the storage account the function app requires. |
+| `--name` | Name of the storage account. |
+| `--resource-group` | Resource group that contains the storage account. |
+| `--location` | Azure region for the storage account. |
+| `--sku` | Storage replication SKU (`Standard_LRS` = locally redundant). |
 
 ### Step 2b - Create the hosting plan
 
@@ -60,6 +70,14 @@ az functionapp plan create \
   --sku EP1 \
   --is-linux
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp plan create` | Create the Premium (Elastic Premium) plan that hosts the function app. |
+| `--name` | Name of the Premium plan. |
+| `--resource-group` | Resource group that contains the plan. |
+| `--location` | Azure region for the plan. |
+| `--sku` | Elastic Premium pricing tier (`EP1`). |
+| `--is-linux` | Create the plan on Linux. |
 
 ### Step 3 - Create the function app
 
@@ -73,6 +91,16 @@ az functionapp create \
   --runtime-version 7.4 \
   --functions-version 4
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp create` | Create the function app on the pre-created plan. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--storage-account` | Storage account backing the function app. |
+| `--plan` | Existing plan that hosts the function app. |
+| `--runtime` | Language runtime stack (`powershell`). |
+| `--runtime-version` | PowerShell runtime version. |
+| `--functions-version` | Azure Functions runtime major version. |
 
 ### Step 4 - Deploy the code
 

--- a/docs/language-guides/powershell/tutorial/premium/03-configuration.md
+++ b/docs/language-guides/powershell/tutorial/premium/03-configuration.md
@@ -29,6 +29,12 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "GreetingPrefix=Hello" "FUNCTIONS_WORKER_RUNTIME_VERSION=7.4"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--settings` | Key=value application settings to apply. |
 
 Read settings in PowerShell with `$env:GreetingPrefix`.
 
@@ -52,6 +58,12 @@ az functionapp config appsettings list \
   --resource-group $RG \
   --output table
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings list` | List the application settings on the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--output` | Output format (`table`). |
 
 Confirm `GreetingPrefix` appears with the expected value.
 

--- a/docs/language-guides/powershell/tutorial/premium/04-logging-monitoring.md
+++ b/docs/language-guides/powershell/tutorial/premium/04-logging-monitoring.md
@@ -34,6 +34,16 @@ az functionapp config appsettings set \
   --resource-group $RG \
   --settings "APPLICATIONINSIGHTS_CONNECTION_STRING=<connection-string>"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az monitor app-insights component create` | Create the Application Insights component for telemetry. |
+| `--app` | Name of the Application Insights component. |
+| `--location` | Azure region for the component. |
+| `--resource-group` | Resource group that contains the component. |
+| `az functionapp config appsettings set` | Point the function app at Application Insights. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
+| `--settings` | Set the Application Insights connection string setting. |
 
 ## Logging in PowerShell
 
@@ -58,6 +68,11 @@ Write-Error "Downstream call failed"
 ```bash
 az functionapp log tail --name $APP_NAME --resource-group $RG
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp log tail` | Stream live log output from the function app. |
+| `--name` | Name of the function app. |
+| `--resource-group` | Resource group that contains the function app. |
 
 ## Verification
 

--- a/docs/language-guides/powershell/tutorial/premium/05-infrastructure-as-code.md
+++ b/docs/language-guides/powershell/tutorial/premium/05-infrastructure-as-code.md
@@ -59,12 +59,24 @@ az deployment group create \
   --template-file infra/main.bicep \
   --parameters appName=$APP_NAME storageName=$STORAGE_NAME
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group create` | Deploy the Bicep template to the resource group. |
+| `--resource-group` | Target resource group for the deployment. |
+| `--template-file` | Path to the Bicep template. |
+| `--parameters` | Template parameter values. |
 
 ## Verification
 
 ```bash
 az deployment group show --resource-group $RG --name main --query properties.provisioningState
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group show` | Show the status of a completed deployment. |
+| `--resource-group` | Resource group that contains the deployment. |
+| `--name` | Name of the deployment. |
+| `--query` | JMESPath query selecting the provisioning state. |
 
 Returns `Succeeded`.
 

--- a/docs/language-guides/powershell/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/powershell/tutorial/premium/09-container-deployment.md
@@ -79,6 +79,16 @@ az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
 az acr build --registry $REGISTRY_NAME --image functions/powershell-app:v1.0.0 .
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr create` | Creates an Azure Container Registry to store the function image. |
+| `--resource-group` | Resource group that will contain the registry. |
+| `--name` | Globally unique registry name. |
+| `--sku` | Registry pricing tier (`Basic`). |
+| `az acr build` | Builds the container image remotely in ACR (no local Docker). |
+| `--registry` | Target registry that runs the build. |
+| `--image` | Image name and tag to produce. |
+
 ## 3. Create the Premium Plan and Function App
 
 ```bash
@@ -91,6 +101,22 @@ az functionapp create --resource-group $RG --name $APP_NAME \
   --image $REGISTRY_NAME.azurecr.io/functions/powershell-app:v1.0.0 \
   --assign-identity "[system]"
 ```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp plan create` | Creates the Elastic Premium hosting plan. |
+| `--resource-group` | Resource group for the plan. |
+| `--name` | Name of the Premium plan. |
+| `--location` | Azure region for the plan. |
+| `--sku` | Premium plan SKU (`EP1`). |
+| `--is-linux` | Creates a Linux plan required for container images. |
+| `az functionapp create` | Creates the function app on the Premium plan. |
+| `--storage-account` | Storage account backing the function app. |
+| `--plan` | Premium plan that hosts the app. |
+| `--functions-version` | Functions runtime major version (`4`). |
+| `--runtime` | Language runtime (`powershell`). |
+| `--image` | Container image the app runs. |
+| `--assign-identity "[system]"` | Enables a system-assigned managed identity. |
 
 ## 4. Grant Managed-Identity Registry Pull
 
@@ -105,6 +131,21 @@ az resource update --ids "$(az functionapp show --resource-group $RG --name $APP
   --set properties.acrUseManagedIdentityCreds=true
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp identity show` | Reads the app's managed-identity principal ID. |
+| `--query principalId` | Projects only the principal ID. |
+| `--output tsv` | Emits a raw value for shell capture. |
+| `az acr show` | Reads the registry resource ID. |
+| `--query id` | Projects only the registry resource ID. |
+| `az role assignment create` | Grants the identity pull access to the registry. |
+| `--assignee` | Principal that receives the role. |
+| `--role AcrPull` | Least-privilege role for pulling images. |
+| `--scope` | Registry resource the role applies to. |
+| `az resource update` | Enables managed-identity credentials for the container config. |
+| `--ids` | Target `config/web` resource of the function app. |
+| `--set properties.acrUseManagedIdentityCreds=true` | Turns on identity-based registry pulls. |
+
 ## 5. Update the Image
 
 Rebuild with a new tag and point the app at it:
@@ -114,6 +155,16 @@ az acr build --registry $REGISTRY_NAME --image functions/powershell-app:v1.0.1 .
 az functionapp config container set --resource-group $RG --name $APP_NAME \
   --image $REGISTRY_NAME.azurecr.io/functions/powershell-app:v1.0.1
 ```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr build` | Builds and pushes the new image tag in ACR. |
+| `--registry` | Target registry that runs the build. |
+| `--image` | New image name and tag to produce. |
+| `az functionapp config container set` | Points the app at the new image. |
+| `--resource-group` | Resource group of the function app. |
+| `--name` | Name of the function app. |
+| `--image` | Container image the app should run. |
 
 !!! info "Continuous deployment on Premium"
     Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy the container on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.

--- a/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
+++ b/docs/language-guides/python/tutorial/consumption/05-infrastructure-as-code.md
@@ -186,6 +186,12 @@ az deployment group create \
   --template-file "infra/consumption/main.bicep" \
   --parameters baseName="func-consumption-demo"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group create` | Deploy a Bicep/ARM template to a resource group. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--template-file` | Path to the Bicep/ARM template. |
+| `--parameters` | Template parameter values. |
 
 ### Step 4 - Deploy the Bicep template
 
@@ -195,6 +201,12 @@ az deployment group create \
   --template-file "infra/consumption/main.bicep" \
   --parameters baseName="func-consumption-demo"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az deployment group create` | Deploy a Bicep/ARM template to a resource group. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--template-file` | Path to the Bicep/ARM template. |
+| `--parameters` | Template parameter values. |
 
 !!! tip "Parameter names"
     The simplified template above uses `appName` and `storageName` parameters. The production template at `infra/consumption/main.bicep` uses a single `baseName` parameter that derives all resource names automatically.
@@ -208,6 +220,13 @@ az functionapp show \
   --query "{kind:kind,state:state,defaultHostName:defaultHostName}" \
   --output json
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp show` | Show details of the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--query` | JMESPath query selecting fields from the response. |
+| `--output` | Output format. |
 
 !!! info "Not available on Consumption"
     VNet integration requires Flex Consumption, Premium, or Dedicated plan.

--- a/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
@@ -205,6 +205,11 @@ flowchart TD
       --name "$APP_NAME" \
       --resource-group "$RG"
     ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az webapp log tail` | Stream live log output from the app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
 
 7. Validate Premium trigger behavior.
 

--- a/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
+++ b/docs/language-guides/python/tutorial/premium/07-extending-triggers.md
@@ -182,18 +182,21 @@ flowchart TD
       --file "/tmp/sample.txt" \
       --account-name "$STORAGE_NAME" \
       --auth-mode login
+    ```
+
+    | Command/Parameter | Purpose |
+    | --- | --- |
+    | `az storage container create` | Create a blob container in the storage account. |
+    | `az storage blob upload` | Upload a local file to a blob container. |
+    | `--name` | Name of the target resource (container or blob). |
+    | `--account-name` | Storage account that hosts the container. |
+    | `--auth-mode` | Authentication mode; `login` uses your Microsoft Entra identity. |
+    | `--container-name` | Container to upload the blob into. |
+    | `--file` | Local file path to upload. |
 
 5. Publish updated code to Premium.
 
     ```bash
-
-    | CLI element | Explanation |
-    |---|---|
-    | Command(s) | `az storage container create`, `az storage blob upload` |
-    | Key flags | `--name`, `--account-name`, `--auth-mode`, `--container-name`, `--file` |
-    | Variables | `$STORAGE_NAME` |
-    | Expected result | Azure CLI returns provisioning details; confirm the resource name and successful provisioning state before continuing. |
-
     cd apps/python
     func azure functionapp publish "$APP_NAME" --python
     ```
@@ -205,11 +208,12 @@ flowchart TD
       --name "$APP_NAME" \
       --resource-group "$RG"
     ```
-| Command/Parameter | Purpose |
-| --- | --- |
-| `az webapp log tail` | Stream live log output from the app. |
-| `--name` | Name of the target resource. |
-| `--resource-group` | Resource group that contains the resource. |
+
+    | Command/Parameter | Purpose |
+    | --- | --- |
+    | `az webapp log tail` | Stream live log output from the app. |
+    | `--name` | Name of the target resource. |
+    | `--resource-group` | Resource group that contains the resource. |
 
 7. Validate Premium trigger behavior.
 

--- a/docs/language-guides/python/tutorial/premium/09-container-deployment.md
+++ b/docs/language-guides/python/tutorial/premium/09-container-deployment.md
@@ -82,6 +82,16 @@ az acr create --resource-group $RG --name $REGISTRY_NAME --sku Basic
 az acr build --registry $REGISTRY_NAME --image functions/python-app:v1.0.0 .
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr create` | Creates an Azure Container Registry to store the function image. |
+| `--resource-group` | Resource group that will contain the registry. |
+| `--name` | Globally unique registry name. |
+| `--sku` | Registry pricing tier (`Basic`). |
+| `az acr build` | Builds the container image remotely in ACR (no local Docker). |
+| `--registry` | Target registry that runs the build. |
+| `--image` | Image name and tag to produce. |
+
 ## 3. Create the Premium Plan and Function App
 
 ```bash
@@ -94,6 +104,22 @@ az functionapp create --resource-group $RG --name $APP_NAME \
   --image $REGISTRY_NAME.azurecr.io/functions/python-app:v1.0.0 \
   --assign-identity "[system]"
 ```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp plan create` | Creates the Elastic Premium hosting plan. |
+| `--resource-group` | Resource group for the plan. |
+| `--name` | Name of the Premium plan. |
+| `--location` | Azure region for the plan. |
+| `--sku` | Premium plan SKU (`EP1`). |
+| `--is-linux` | Creates a Linux plan required for container images. |
+| `az functionapp create` | Creates the function app on the Premium plan. |
+| `--storage-account` | Storage account backing the function app. |
+| `--plan` | Premium plan that hosts the app. |
+| `--functions-version` | Functions runtime major version (`4`). |
+| `--runtime` | Language runtime (`python`). |
+| `--image` | Container image the app runs. |
+| `--assign-identity "[system]"` | Enables a system-assigned managed identity. |
 
 ## 4. Grant Managed-Identity Registry Pull
 
@@ -108,6 +134,21 @@ az resource update --ids "$(az functionapp show --resource-group $RG --name $APP
   --set properties.acrUseManagedIdentityCreds=true
 ```
 
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az functionapp identity show` | Reads the app's managed-identity principal ID. |
+| `--query principalId` | Projects only the principal ID. |
+| `--output tsv` | Emits a raw value for shell capture. |
+| `az acr show` | Reads the registry resource ID. |
+| `--query id` | Projects only the registry resource ID. |
+| `az role assignment create` | Grants the identity pull access to the registry. |
+| `--assignee` | Principal that receives the role. |
+| `--role AcrPull` | Least-privilege role for pulling images. |
+| `--scope` | Registry resource the role applies to. |
+| `az resource update` | Enables managed-identity credentials for the container config. |
+| `--ids` | Target `config/web` resource of the function app. |
+| `--set properties.acrUseManagedIdentityCreds=true` | Turns on identity-based registry pulls. |
+
 ## 5. Update the Image
 
 Rebuild with a new tag and point the app at it:
@@ -117,6 +158,16 @@ az acr build --registry $REGISTRY_NAME --image functions/python-app:v1.0.1 .
 az functionapp config container set --resource-group $RG --name $APP_NAME \
   --image $REGISTRY_NAME.azurecr.io/functions/python-app:v1.0.1
 ```
+
+| Command/Parameter | Purpose |
+|-------------------|---------|
+| `az acr build` | Builds and pushes the new image tag in ACR. |
+| `--registry` | Target registry that runs the build. |
+| `--image` | New image name and tag to produce. |
+| `az functionapp config container set` | Points the app at the new image. |
+| `--resource-group` | Resource group of the function app. |
+| `--name` | Name of the function app. |
+| `--image` | Container image the app should run. |
 
 !!! info "Continuous deployment on Premium"
     Webhook-based container CD is **not** supported on the Elastic Premium plan. Either restart the app after pushing a new image, or deploy the container on a **Dedicated (App Service) plan** if you need webhook auto-redeploy. If the container listens on a non-default port, set the `WEBSITES_PORT` app setting.

--- a/docs/operations/configuration.md
+++ b/docs/operations/configuration.md
@@ -115,6 +115,7 @@ Common settings:
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | Monitoring destination |
 | `WEBSITE_RUN_FROM_PACKAGE` | Immutable package deployment behavior |
 | Custom settings | Feature flags and endpoints |
+
 Set values:
 ```bash
 az functionapp config appsettings set \
@@ -192,6 +193,7 @@ az functionapp config appsettings list \
 | `az functionapp config appsettings list` | Lists application settings |
 | `--query` | Filters for settings prefixed with `AzureFunctionsJobHost__` |
 | `--output table` | Formats the output as a table |
+
 Example output:
 ```text
 Name                                                                  Value
@@ -381,6 +383,7 @@ az monitor app-insights query \
 | `az monitor app-insights query` | Runs a KQL query against Application Insights |
 | `--analytics-query` | Checks the trace log for recent host startup success |
 | `--output table` | Formats results as a table |
+
 Example output:
 ```text
 Timestamp                    Message

--- a/docs/platform/hosting.md
+++ b/docs/platform/hosting.md
@@ -265,6 +265,15 @@ az functionapp create \
   --runtime node \
   --functions-version 4
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp create` | Create the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--storage-account` | Storage account backing the function app. |
+| `--consumption-plan-location` | Region for the Consumption plan. |
+| `--runtime` | Language runtime stack. |
+| `--functions-version` | Azure Functions runtime major version. |
 
 ```bash
 # Flex Consumption Function App
@@ -276,6 +285,15 @@ az functionapp create \
   --runtime python \
   --runtime-version 3.12
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp create` | Create the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--storage-account` | Storage account backing the function app. |
+| `--flexconsumption-location` | Region for the Flex Consumption plan. |
+| `--runtime` | Language runtime stack. |
+| `--runtime-version` | Runtime language version. |
 
 ```bash
 # Premium plan + Function App
@@ -294,6 +312,21 @@ az functionapp create \
   --runtime dotnet-isolated \
   --functions-version 4
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp plan create` | Create the hosting plan for the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--location` | Azure region. |
+| `--sku` | Pricing/SKU tier. |
+| `--is-linux` | Create the plan on Linux. |
+| `az functionapp create` | Create the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--plan` | Hosting plan for the app. |
+| `--storage-account` | Storage account backing the function app. |
+| `--runtime` | Language runtime stack. |
+| `--functions-version` | Azure Functions runtime major version. |
 
 #### CLI inspection examples with output
 
@@ -304,6 +337,12 @@ az functionapp plan show \
   --name "$PLAN_NAME" \
   --output json
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp plan show` | Show details of a function app hosting plan. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--output` | Output format. |
 
 Example output (PII masked):
 
@@ -332,6 +371,11 @@ az functionapp list \
   --resource-group "$RG" \
   --output table
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp list` | List function apps in a resource group. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--output` | Output format. |
 
 Example output (PII masked):
 

--- a/docs/platform/networking-scenarios/storage-service-endpoint.md
+++ b/docs/platform/networking-scenarios/storage-service-endpoint.md
@@ -165,6 +165,12 @@ az storage account update \
   --resource-group "$RG" \
   --default-action Allow
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az storage account update` | Update the storage account's network rules. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--default-action` | Default network access action. |
 
 ## See Also
 

--- a/docs/platform/networking.md
+++ b/docs/platform/networking.md
@@ -89,6 +89,10 @@ Prepare these items before applying networking controls:
 ```bash
 az account show --output table
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az account show` | Show the active Azure subscription. |
+| `--output` | Output format. |
 
 Example output (sanitized):
 
@@ -160,6 +164,15 @@ az functionapp config access-restriction add \
   --action Allow \
   --ip-address "203.0.113.0/24"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config access-restriction add` | Add an inbound access-restriction rule to the app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--rule-name` | Name of the access-restriction rule. |
+| `--priority` | Rule priority (lower value = higher precedence). |
+| `--action` | Allow or Deny the matched traffic. |
+| `--ip-address` | CIDR range the rule matches. |
 
 List current restrictions:
 
@@ -169,6 +182,12 @@ az webapp config access-restriction show \
   --resource-group "$RG" \
   --output json
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az webapp config access-restriction show` | Show inbound access-restriction rules for the app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--output` | Output format. |
 
 Example output (sanitized):
 
@@ -205,6 +224,16 @@ az network private-endpoint create \
   --group-id "sites" \
   --connection-name "pe-conn-$APP_NAME"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az network private-endpoint create` | Create a private endpoint for the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--vnet-name` | Name of the virtual network. |
+| `--subnet` | Subnet to use. |
+| `--private-connection-resource-id` | Resource ID the private endpoint connects to. |
+| `--group-id` | Sub-resource (group ID) to target. |
+| `--connection-name` | Name of the private-link connection. |
 
 Inspect private endpoint status:
 
@@ -214,6 +243,12 @@ az network private-endpoint show \
   --resource-group "$RG" \
   --output json
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az network private-endpoint show` | Show details of a private endpoint. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--output` | Output format. |
 
 Example output (sanitized):
 
@@ -262,6 +297,13 @@ az functionapp vnet-integration add \
   --vnet "$VNET_NAME" \
   --subnet "$INTEGRATION_SUBNET"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp vnet-integration add` | Add regional virtual-network integration to the app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--vnet` | Virtual network to integrate with. |
+| `--subnet` | Subnet to use. |
 
 Validate integration:
 
@@ -271,6 +313,12 @@ az functionapp vnet-integration list \
   --resource-group "$RG" \
   --output json
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp vnet-integration list` | List the app's regional virtual-network integration. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--output` | Output format. |
 
 Example output (sanitized):
 
@@ -294,6 +342,12 @@ az functionapp config appsettings set \
   --resource-group "$RG" \
   --settings "WEBSITE_VNET_ROUTE_ALL=1"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings set` | Add or update application settings on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--settings` | Key=value application settings to apply. |
 
 Flex Consumption already routes outbound traffic through the integrated VNet path, so `WEBSITE_VNET_ROUTE_ALL=1` is not required on Flex.
 

--- a/docs/platform/reliability.md
+++ b/docs/platform/reliability.md
@@ -417,15 +417,38 @@ Use CLI checks during reviews and incidents to confirm reliability-related confi
 ```bash
 az functionapp config show   --resource-group "rg-functions-prod"   --name "func-reliability-prod"   --query "{alwaysOn:alwaysOn,http20Enabled:http20Enabled,ftpsState:ftpsState,minTlsVersion:minTlsVersion}"   --output json
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config show` | Show the function app's site configuration. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--query` | JMESPath query selecting fields from the response. |
+| `--output` | Output format. |
 
 **Query failure and retry metrics**
 ```bash
 az monitor metrics list   --resource "/subscriptions/<subscription-id>/resourceGroups/rg-functions-prod/providers/Microsoft.Web/sites/func-reliability-prod"   --metric "FunctionExecutionCount,FunctionExecutionUnits,FunctionExecutionFailureCount"   --interval "PT5M"   --aggregation "Total"   --output table
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az monitor metrics list` | List platform metrics for a resource. |
+| `--resource` | Resource ID to query metrics for. |
+| `--metric` | Metric(s) to retrieve. |
+| `--interval` | Aggregation interval. |
+| `--aggregation` | Aggregation type. |
+| `--output` | Output format. |
 
 ```bash
 az monitor metrics list   --resource "/subscriptions/<subscription-id>/resourceGroups/rg-functions-prod/providers/Microsoft.ServiceBus/namespaces/sb-functions-prod"   --metric "DeadletteredMessages,IncomingMessages,SuccessfulRequests,ServerErrors"   --interval "PT5M"   --aggregation "Total"   --output table
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az monitor metrics list` | List platform metrics for a resource. |
+| `--resource` | Resource ID to query metrics for. |
+| `--metric` | Metric(s) to retrieve. |
+| `--interval` | Aggregation interval. |
+| `--aggregation` | Aggregation type. |
+| `--output` | Output format. |
 
 ### Troubleshooting matrix
 | Symptom | Likely Cause | Validation Path |

--- a/docs/platform/scaling.md
+++ b/docs/platform/scaling.md
@@ -339,13 +339,13 @@ Example output (PII masked):
 
 Inspect scale profile details:
 ```bash
-az functionapp scale show \
+az functionapp scale config show \
     --resource-group $RG \
     --name $APP_NAME
 ```
 | Command/Parameter | Purpose |
 | --- | --- |
-| `az functionapp scale show` | Show the scale configuration of the function app. |
+| `az functionapp scale config show` | Show the scale configuration of the function app. |
 | `--resource-group` | Resource group that contains the resource. |
 | `--name` | Name of the target resource. |
 

--- a/docs/platform/scaling.md
+++ b/docs/platform/scaling.md
@@ -319,6 +319,12 @@ az functionapp show \
     --name $APP_NAME \
     --query siteConfig
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp show` | Show details of the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--query` | JMESPath query selecting fields from the response. |
 
 Example output (PII masked):
 ```json
@@ -337,6 +343,11 @@ az functionapp scale show \
     --resource-group $RG \
     --name $APP_NAME
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp scale show` | Show the scale configuration of the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
 
 Example output (PII masked):
 ```json
@@ -359,6 +370,15 @@ az monitor metrics list \
     --start-time 2026-01-10T09:00:00Z \
     --end-time 2026-01-10T10:00:00Z
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az monitor metrics list` | List platform metrics for a resource. |
+| `--resource` | Resource ID to query metrics for. |
+| `--metric` | Metric(s) to retrieve. |
+| `--interval` | Aggregation interval. |
+| `--aggregation` | Aggregation type. |
+| `--start-time` | Start of the time range. |
+| `--end-time` | End of the time range. |
 
 Example output (PII masked):
 ```json

--- a/docs/platform/security.md
+++ b/docs/platform/security.md
@@ -290,6 +290,12 @@ az functionapp cors add \
   --resource-group "$RG" \
   --allowed-origins "https://app.contoso.example"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp cors add` | Add an allowed CORS origin to the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--allowed-origins` | Origin(s) permitted by CORS. |
 
 Wildcard origin risks:
 
@@ -318,6 +324,12 @@ az functionapp function keys list \
   --resource-group "$RG" \
   --function-name "HttpExample"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp function keys list` | List the access keys for a function. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--function-name` | Name of the function. |
 
 ### Storing keys in Key Vault
 - Store shared keys in Key Vault.
@@ -341,6 +353,11 @@ az functionapp identity assign \
   --name "$APP_NAME" \
   --resource-group "$RG"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp identity assign` | Enable a managed identity on the function app. |
+| `--name` | Name of the target resource. |
+| `--resource-group` | Resource group that contains the resource. |
 
 ```bash
 az role assignment create \
@@ -348,6 +365,12 @@ az role assignment create \
   --role "Storage Blob Data Contributor" \
   --scope "/subscriptions/<subscription-id>/resourceGroups/$RG/providers/Microsoft.Storage/storageAccounts/$STORAGE_NAME"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az role assignment create` | Assign an Azure RBAC role to an identity. |
+| `--assignee` | Identity (object ID) receiving the role. |
+| `--role` | Azure RBAC role to assign. |
+| `--scope` | Scope at which the role applies. |
 
 Flex Consumption requires identity-based host storage configuration. Plan identity and RBAC early.
 

--- a/docs/platform/triggers-and-bindings.md
+++ b/docs/platform/triggers-and-bindings.md
@@ -116,6 +116,15 @@ If you validate configuration with Azure CLI, keep long flags for readability:
 az functionapp config appsettings list --resource-group $RG --name $APP_NAME
 az functionapp config show --resource-group $RG --name $APP_NAME
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings list` | List the application settings on the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `az functionapp config show` | Show the function app's site configuration. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+
 ## Portal Walkthrough
 
 This section shows portal blades relevant to trigger and binding configuration for a live Function App (Consumption Y1, Korea Central). PII is masked.
@@ -419,6 +428,19 @@ az functionapp config appsettings list --resource-group $RG --name $APP_NAME
 az functionapp function show --resource-group $RG --name $APP_NAME --function-name $FUNCTION_NAME
 az monitor app-insights query --app <application-insights-name> --analytics-query "traces | take 20"
 ```
+| Command/Parameter | Purpose |
+| --- | --- |
+| `az functionapp config appsettings list` | List the application settings on the function app. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `az functionapp function show` | Show details of a function. |
+| `--resource-group` | Resource group that contains the resource. |
+| `--name` | Name of the target resource. |
+| `--function-name` | Name of the function. |
+| `az monitor app-insights query` | Run a KQL query against Application Insights. |
+| `--app` | Application Insights component name. |
+| `--analytics-query` | KQL query to run. |
+
 !!! tip "Reliability Guide"
     For retry and poison-message design, see [Reliability](reliability.md).
 !!! tip "Language Guide"

--- a/scripts/validate_cli_explanations.py
+++ b/scripts/validate_cli_explanations.py
@@ -12,6 +12,17 @@ from pathlib import Path
 AZ_PATTERN = re.compile(r"(^|[^A-Za-z0-9_-])az\s+[A-Za-z0-9_-]")
 FENCE_PATTERN = re.compile(r"^(\s*)```")
 
+_HOUSE_FIRST_CELLS = {
+    "flag",
+    "parameter",
+    "code",
+    "setting",
+    "tool",
+    "variable",
+    "key",
+    "key flags",
+}
+
 
 @dataclass(frozen=True)
 class Finding:
@@ -70,9 +81,120 @@ def has_following_table(lines: list[str], start_index: int) -> bool:
     return False
 
 
+def _table_cells(line: str) -> list[str]:
+    """Split a Markdown table row into trimmed, lower-cased cell values.
+
+    Leading and trailing pipes produce empty edge cells, which are dropped.
+
+    >>> _table_cells("| Command | Purpose |")
+    ['command', 'purpose']
+    >>> _table_cells("| Command/Parameter | Purpose |")
+    ['command/parameter', 'purpose']
+    >>> _table_cells("| Key flags |")
+    ['key flags']
+    """
+    return [cell.strip().lower() for cell in line.strip().strip("|").split("|")]
+
+
+def _is_house_table_header(cells: list[str]) -> bool:
+    """Return True for an explanation-table header row.
+
+    Recognition is header-agnostic across the series' repository-local
+    conventions: any first cell beginning with ``command`` (covering
+    ``Command``, ``Command/Parameter``, ``Command/Code``, ``Command/Flag``,
+    ``Command part``, ``Command flag``, ``Command or Query``) or one of the
+    known callout headers (``Flag``, ``Parameter``, ``Code``, ``Setting``,
+    ``Tool``, ``Variable``, ``Key``, ``Key flags``). Column count is not
+    constrained, so three-column variants such as ``Command | Purpose | Key
+    flags`` and single-column ``Key flags`` callouts are both covered.
+
+    >>> _is_house_table_header(["command", "purpose"])
+    True
+    >>> _is_house_table_header(["command/parameter", "purpose"])
+    True
+    >>> _is_house_table_header(["command", "why it is used"])
+    True
+    >>> _is_house_table_header(["command", "purpose", "key flags"])
+    True
+    >>> _is_house_table_header(["flag", "description"])
+    True
+    >>> _is_house_table_header(["key flags"])
+    True
+    >>> _is_house_table_header(["name", "value"])
+    False
+    """
+    if not cells:
+        return False
+    first = cells[0]
+    return first.startswith("command") or first in _HOUSE_FIRST_CELLS
+
+
+def find_unterminated_tables(lines: list[str]) -> list[int]:
+    """Return the 1-based line numbers where an explanation table is immediately
+    followed by a non-blank line.
+
+    python-markdown's ``tables`` extension treats the first non-blank line after
+    a table as another table row (a phantom ``<td>...</td>`` cell) unless a blank
+    line terminates the table. Fenced code regions are tracked so that pipe-led
+    lines inside ```` ```kusto ```` blocks (``| where``, ``| summarize``) are not
+    mistaken for table rows.
+
+    >>> ok = ["| Command | Purpose |", "| --- | --- |", "| `az x` | y |", "", "next"]
+    >>> find_unterminated_tables(ok)
+    []
+    >>> bad = ["| Command | Purpose |", "| --- | --- |", "| `az x` | y |", "Example output:"]
+    >>> find_unterminated_tables(bad)
+    [4]
+    >>> variant = ["| Command/Parameter | Purpose |", "| --- | --- |", "| `az x` | y |", "prose"]
+    >>> find_unterminated_tables(variant)
+    [4]
+    >>> why = ["| Command | Why it is used |", "| --- | --- |", "| `az x` | y |", "prose"]
+    >>> find_unterminated_tables(why)
+    [4]
+    >>> eof = ["| Command | Purpose |", "| --- | --- |", "| `az x` | y |"]
+    >>> find_unterminated_tables(eof)
+    []
+    >>> kql = ["```kusto", "AzureActivity", "| where x == 1", "```", "prose"]
+    >>> find_unterminated_tables(kql)
+    []
+    """
+    hits: list[int] = []
+    i = 0
+    n = len(lines)
+    in_fence = False
+    while i < n:
+        if FENCE_PATTERN.match(lines[i]):
+            in_fence = not in_fence
+            i += 1
+            continue
+        if (
+            not in_fence
+            and lines[i].lstrip().startswith("|")
+            and _is_house_table_header(_table_cells(lines[i]))
+        ):
+            j = i
+            while j < n and lines[j].lstrip().startswith("|"):
+                j += 1
+            if j < n and lines[j].strip() != "":
+                hits.append(j + 1)
+            i = j
+            continue
+        i += 1
+    return hits
+
+
 def validate_file(path: Path) -> list[Finding]:
     lines = path.read_text(encoding="utf-8").splitlines()
     findings: list[Finding] = []
+    for line_no in find_unterminated_tables(lines):
+        findings.append(
+            Finding(
+                path=path,
+                line=line_no,
+                message="Explanation table must be followed by a blank line "
+                "(otherwise the next line is absorbed as a phantom table row).",
+            )
+        )
     in_fence = False
     fence_indent = ""
     block_start = 0
@@ -102,7 +224,8 @@ def validate_file(path: Path) -> list[Finding]:
                     Finding(
                         path=path,
                         line=block_start,
-                        message="Azure CLI code fence is missing a following explanation table.",
+                        message="Azure CLI code fence must be followed by a "
+                        "command explanation table.",
                     )
                 )
             in_fence = False


### PR DESCRIPTION
## Summary
- Harden `scripts/validate_cli_explanations.py` with `find_unterminated_tables()`, which fails when a CLI explanation table is not terminated by a blank line (or EOF) — the python-markdown block-level defect where the next line is absorbed as a phantom `<td>` row. Header recognition is house-style aware (`Command/Parameter | Purpose`).
- Add a dedicated **blocking** `Validate CLI Explanation Tables` CI job (doctest + validate steps, no `continue-on-error`), replacing the previous advisory step.
- **Author explanation tables for 92 previously-uncovered `az` code fences** across platform, best-practices, operations, and language-guide (powershell/python/dotnet) pages, plus fix 3 pre-existing unterminated tables. Each table lists the base command plus every long flag, one row each.
- Document the rule in AGENTS.md (blank-line termination is absolute; `Command/Parameter | Purpose` is this repo's variant).

## Verification
- `validate_cli_explanations.py`: 0 findings (was 92 missing + 3 unterminated)
- doctests: pass
- `mkdocs build --strict`: clean
- Rendered HTML: 0 phantom rows (spot-checked previously-unterminated tables render headings/admonitions outside the table)