### PR TITLE
chore(deps): bump azure-guide-capture-toolkit to v0.1.1

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,4 +4,4 @@ mkdocs-macros-plugin
 mkdocs-redirects
 pymdown-extensions
 PyYAML
-azure-guide-capture-toolkit @ git+https://github.com/yeongseon/azure-guide-capture-toolkit@v0.1.0
+azure-guide-capture-toolkit @ git+https://github.com/yeongseon/azure-guide-capture-toolkit@v0.1.1


### PR DESCRIPTION
## Summary
- Bump `azure-guide-capture-toolkit` pin from `@v0.1.0` to `@v0.1.1`.
- v0.1.1 fixes Jinja escaping in the `shot()` macro alt-text handling.

## Notes
- One-line change to `requirements-docs.txt`; docs-tooling only, no content change.