### PR TITLE
ci: stop auto-deploying docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Documentation
+name: Docs (strict build check)
 
 on:
   push:
@@ -11,12 +11,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
   build:
@@ -30,18 +24,3 @@ jobs:
         run: pip install -r requirements-docs.txt
       - name: Build documentation
         run: mkdocs build --strict
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
-        with:
-          path: site
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
Stop auto-deploying docs to GitHub Pages so the redirect stub on `gh-pages` (pointing to https://yeongseon.dev/azure-functions-python/) is not overwritten on push to main. The strict `mkdocs build --strict` build is retained as a CI check.

## Verification
- Deploy job removed; strict build job retained
- `permissions` downgraded to `contents: read`
- YAML validated with PyYAML

## Notes
- `gh-pages` branch is left untouched by CI going forward; redirect stub preserved.

Closes #129