### PR TITLE
docs: migrate documentation-site URLs to yeongseon.dev canonical domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Contributing Guide
-    url: https://yeongseon.github.io/azure-functions-practical-guide/contributing/
+    url: https://yeongseon.dev/azure-functions-python/practical-guide/contributing/
     about: Review repository contribution guidance before opening an issue or pull request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Guidance for AI agents working in this repository.
 
 **Azure Functions Practical Guide** — a unified documentation hub, reference applications, and hands-on troubleshooting labs for building and operating serverless applications on Azure Functions.
 
-- **Live site**: <https://yeongseon.github.io/azure-functions-practical-guide/>
+- **Live site**: <https://yeongseon.dev/azure-functions-python/practical-guide/>
 - **Repository**: <https://github.com/yeongseon/azure-functions-practical-guide>
 
 ## Series-Wide Documentation Contract

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing!
 
 To ensure consistency and quality across this guide, please refer to our full contributing documentation:
 
-**[Contributing Guide](https://yeongseon.github.io/azure-functions-practical-guide/contributing/)**
+**[Contributing Guide](https://yeongseon.dev/azure-functions-python/practical-guide/contributing/)**
 
 This guide covers:
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,6 @@
 # Azure Functions 実務ガイド
 
-📘 **ドキュメントサイト:** <https://yeongseon.github.io/azure-functions-practical-guide/>
+📘 **ドキュメントサイト:** <https://yeongseon.dev/azure-functions-python/practical-guide/>
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
@@ -21,23 +21,23 @@
 
 | シナリオ | 推奨プラン | ここから開始 |
 |---|---|---|
-| 新規サーバーレスアプリ | **Flex Consumption** | [Flex Consumption チュートリアル](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 既存の Consumption ワークロード | Consumption (レガシー) | [Consumption チュートリアル](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 常時稼働インスタンスまたは VNet 重視 | Premium | [Premium チュートリアル](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 既存の App Service プラン資産 | Dedicated | [Dedicated チュートリアル](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
+| 新規サーバーレスアプリ | **Flex Consumption** | [Flex Consumption チュートリアル](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 既存の Consumption ワークロード | Consumption (レガシー) | [Consumption チュートリアル](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 常時稼働インスタンスまたは VNet 重視 | Premium | [Premium チュートリアル](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 既存の App Service プラン資産 | Dedicated | [Dedicated チュートリアル](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
 | コンテナネイティブホスティング | Container Apps | 計画中 — [ホスティング範囲](#hosting-scope) を参照 |
 
 ## 主な内容
 
 | セクション | 説明 | 状態 |
 |---------|-------------|--------|
-| [ここから開始](https://yeongseon.github.io/azure-functions-practical-guide/) | 概要、学習パス、およびリポジトリマップ | 包括的 |
-| [プラットフォーム](https://yeongseon.github.io/azure-functions-practical-guide/platform/) | アーキテクチャ、ホスティングプラン、スケーリング、ネットワーク、セキュリティ | 包括的 |
-| [ベストプラクティス](https://yeongseon.github.io/azure-functions-practical-guide/best-practices/) | ホスティング選択、トリガー、スケーリング、信頼性、セキュリティ、デプロイ | 包括적 |
-| [言語別ガイド](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) | Python、Node.js、Java、および .NET のステップバイステップチュートリアル | 包括的 |
-| [運用](https://yeongseon.github.io/azure-functions-practical-guide/operations/) | デプロイ、モニタリング、アラート、コスト最適化、リカバリ | 包括的 |
-| [トラブルシューティング](https://yeongseon.github.io/azure-functions-practical-guide/troubleshooting/) | プレイブック、KQL クエリ、方法論、およびハンズオンラボ | ラボ検証済み |
-| [リファレンス](https://yeongseon.github.io/azure-functions-practical-guide/reference/) | CLI チートシート、host.json、プラットフォームの制限 | 包括的 |
+| [ここから開始](https://yeongseon.dev/azure-functions-python/practical-guide/) | 概要、学習パス、およびリポジトリマップ | 包括的 |
+| [プラットフォーム](https://yeongseon.dev/azure-functions-python/practical-guide/platform/) | アーキテクチャ、ホスティングプラン、スケーリング、ネットワーク、セキュリティ | 包括的 |
+| [ベストプラクティス](https://yeongseon.dev/azure-functions-python/practical-guide/best-practices/) | ホスティング選択、トリガー、スケーリング、信頼性、セキュリティ、デプロイ | 包括적 |
+| [言語別ガイド](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) | Python、Node.js、Java、および .NET のステップバイステップチュートリアル | 包括的 |
+| [運用](https://yeongseon.dev/azure-functions-python/practical-guide/operations/) | デプロイ、モニタリング、アラート、コスト最適化、リカバリ | 包括的 |
+| [トラブルシューティング](https://yeongseon.dev/azure-functions-python/practical-guide/troubleshooting/) | プレイブック、KQL クエリ、方法論、およびハンズオンラボ | ラボ検証済み |
+| [リファレンス](https://yeongseon.dev/azure-functions-python/practical-guide/reference/) | CLI チートシート、host.json、プラットフォームの制限 | 包括的 |
 
 **状態の凡例**: **ラボ検証済み** = 包括的 + 再現可能なラボによりガイダンスを実証済み · **包括的** = セクション全体が完了し、MSLearn で検証済みの本番環境対応 · **公開済み** = コアコンテンツは配置済みで、現在拡張中 · **進行中** = コンテンツの一部が作成済みで、活発に開発中 · **計画中** = プレースホルダーであり、コンテンツは未着手
 
@@ -101,7 +101,7 @@ Azure Functions のパターンを示す最小限のリファレンスアプリ�
 
 ## 貢献
 
-貢献を歓迎します！以下の点については [貢献ガイド](https://yeongseon.github.io/azure-functions-practical-guide/contributing/) を確認してください：
+貢献を歓迎します！以下の点については [貢献ガイド](https://yeongseon.dev/azure-functions-python/practical-guide/contributing/) を確認してください：
 
 - リポジトリ構造とコンテンツの構成
 - ドキュメントテンプレートと執筆基準

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 # Azure Functions 실무 가이드
 
-📘 **문서 사이트:** <https://yeongseon.github.io/azure-functions-practical-guide/>
+📘 **문서 사이트:** <https://yeongseon.dev/azure-functions-python/practical-guide/>
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
@@ -21,23 +21,23 @@
 
 | 시나리오 | 권장 플랜 | 시작하기 |
 |---|---|---|
-| 새로운 서버리스 앱 | **Flex Consumption** | [Flex Consumption 튜토리얼](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 기존 Consumption 워크로드 | Consumption (기존) | [Consumption 튜토리얼](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 상시 대기 인스턴스 또는 VNet 집중형 | Premium | [Premium 튜토리얼](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 기존 App Service 플랜 자산 | Dedicated | [Dedicated 튜토리얼](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
+| 새로운 서버리스 앱 | **Flex Consumption** | [Flex Consumption 튜토리얼](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 기존 Consumption 워크로드 | Consumption (기존) | [Consumption 튜토리얼](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 상시 대기 인스턴스 또는 VNet 집중형 | Premium | [Premium 튜토리얼](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 기존 App Service 플랜 자산 | Dedicated | [Dedicated 튜토리얼](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
 | 컨테이너 네이티브 호스팅 | Container Apps | 계획됨 — [호스팅 범위](#hosting-scope) 참조 |
 
 ## 주요 내용
 
 | 섹션 | 설명 | 상태 |
 |---------|-------------|--------|
-| [시작하기](https://yeongseon.github.io/azure-functions-practical-guide/) | 개요, 학습 경로 및 저장소 맵 | 포괄적임 |
-| [플랫폼](https://yeongseon.github.io/azure-functions-practical-guide/platform/) | 아키텍처, 호스팅 플랜, 스케일링, 네트워킹, 보안 | 포괄적임 |
-| [베스트 프랙티스](https://yeongseon.github.io/azure-functions-practical-guide/best-practices/) | 호스팅 선택, 트리거, 스케일링, 안정성, 보안, 배포 | 포괄적임 |
-| [언어별 가이드](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) | Python, Node.js, Java 및 .NET을 위한 단계별 튜토리얼 | 포괄적임 |
-| [운영](https://yeongseon.github.io/azure-functions-practical-guide/operations/) | 배포, 모니터링, 알림, 비용 최적화, 복구 | 포괄적임 |
-| [트러블슈팅](https://yeongseon.github.io/azure-functions-practical-guide/troubleshooting/) | 플레이북, KQL 쿼리, 방법론 및 실습 랩 | 랩 검증됨 |
-| [참조](https://yeongseon.github.io/azure-functions-practical-guide/reference/) | CLI 치트시트, host.json, 플랫폼 제한 사항 | 포괄적임 |
+| [시작하기](https://yeongseon.dev/azure-functions-python/practical-guide/) | 개요, 학습 경로 및 저장소 맵 | 포괄적임 |
+| [플랫폼](https://yeongseon.dev/azure-functions-python/practical-guide/platform/) | 아키텍처, 호스팅 플랜, 스케일링, 네트워킹, 보안 | 포괄적임 |
+| [베스트 프랙티스](https://yeongseon.dev/azure-functions-python/practical-guide/best-practices/) | 호스팅 선택, 트리거, 스케일링, 안정성, 보안, 배포 | 포괄적임 |
+| [언어별 가이드](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) | Python, Node.js, Java 및 .NET을 위한 단계별 튜토리얼 | 포괄적임 |
+| [운영](https://yeongseon.dev/azure-functions-python/practical-guide/operations/) | 배포, 모니터링, 알림, 비용 최적화, 복구 | 포괄적임 |
+| [트러블슈팅](https://yeongseon.dev/azure-functions-python/practical-guide/troubleshooting/) | 플레이북, KQL 쿼리, 방법론 및 실습 랩 | 랩 검증됨 |
+| [참조](https://yeongseon.dev/azure-functions-python/practical-guide/reference/) | CLI 치트시트, host.json, 플랫폼 제한 사항 | 포괄적임 |
 
 **상태 범례**: **랩 검증됨** = 포괄적임 + 재현 가능한 실습 랩을 통한 가이드 입증 · **포괄적임** = 전체 섹션 완료, MSLearn 검증됨, 운영 환경 준비 완료 · **게시됨** = 핵심 콘텐츠 준비됨, 계속 확장 중 · **진행 중** = 콘텐츠 일부 작성됨, 활발히 개발 중 · **계획됨** = 자리 표시자, 콘텐츠 아직 시작되지 않음
 
@@ -101,7 +101,7 @@ Azure Functions 패턴을 보여주는 최소한의 참조 애플리케이션들
 
 ## 기여하기
 
-기여는 언제나 환영합니다! 다음 사항은 [기여 가이드](https://yeongseon.github.io/azure-functions-practical-guide/contributing/)를 참조하세요:
+기여는 언제나 환영합니다! 다음 사항은 [기여 가이드](https://yeongseon.dev/azure-functions-python/practical-guide/contributing/)를 참조하세요:
 
 - 저장소 구조 및 콘텐츠 구성
 - 문서 템플릿 및 작성 표준

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Functions Practical Guide
 
-📘 **Documentation site:** <https://yeongseon.github.io/azure-functions-practical-guide/>
+📘 **Documentation site:** <https://yeongseon.dev/azure-functions-python/practical-guide/>
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
@@ -21,23 +21,23 @@ Comprehensive guide for running serverless applications on Azure Functions — f
 
 | Scenario | Recommended plan | Start here |
 |---|---|---|
-| New serverless app | **Flex Consumption** | [Flex Consumption tutorial](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| Existing Consumption workload | Consumption (legacy) | [Consumption tutorial](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| Always-ready instances or VNet-heavy | Premium | [Premium tutorial](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| Existing App Service Plan estate | Dedicated | [Dedicated tutorial](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
+| New serverless app | **Flex Consumption** | [Flex Consumption tutorial](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| Existing Consumption workload | Consumption (legacy) | [Consumption tutorial](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| Always-ready instances or VNet-heavy | Premium | [Premium tutorial](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| Existing App Service Plan estate | Dedicated | [Dedicated tutorial](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
 | Container-native hosting | Container Apps | Planned — see [Hosting Scope](#hosting-scope) |
 
 ## What's Inside
 
 | Section | Description | Status |
 |---------|-------------|--------|
-| [Start Here](https://yeongseon.github.io/azure-functions-practical-guide/) | Overview, learning paths, and repository map | Comprehensive |
-| [Platform](https://yeongseon.github.io/azure-functions-practical-guide/platform/) | Architecture, hosting plans, scaling, networking, security | Comprehensive |
-| [Best Practices](https://yeongseon.github.io/azure-functions-practical-guide/best-practices/) | Hosting selection, triggers, scaling, reliability, security, deployment | Comprehensive |
-| [Language Guides](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) | Step-by-step tutorials for Python, Node.js, Java, and .NET | Comprehensive |
-| [Operations](https://yeongseon.github.io/azure-functions-practical-guide/operations/) | Deployment, monitoring, alerts, cost optimization, recovery | Comprehensive |
-| [Troubleshooting](https://yeongseon.github.io/azure-functions-practical-guide/troubleshooting/) | Playbooks, KQL queries, methodology, and hands-on labs | Lab-validated |
-| [Reference](https://yeongseon.github.io/azure-functions-practical-guide/reference/) | CLI cheatsheet, host.json, platform limits | Comprehensive |
+| [Start Here](https://yeongseon.dev/azure-functions-python/practical-guide/) | Overview, learning paths, and repository map | Comprehensive |
+| [Platform](https://yeongseon.dev/azure-functions-python/practical-guide/platform/) | Architecture, hosting plans, scaling, networking, security | Comprehensive |
+| [Best Practices](https://yeongseon.dev/azure-functions-python/practical-guide/best-practices/) | Hosting selection, triggers, scaling, reliability, security, deployment | Comprehensive |
+| [Language Guides](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) | Step-by-step tutorials for Python, Node.js, Java, and .NET | Comprehensive |
+| [Operations](https://yeongseon.dev/azure-functions-python/practical-guide/operations/) | Deployment, monitoring, alerts, cost optimization, recovery | Comprehensive |
+| [Troubleshooting](https://yeongseon.dev/azure-functions-python/practical-guide/troubleshooting/) | Playbooks, KQL queries, methodology, and hands-on labs | Lab-validated |
+| [Reference](https://yeongseon.dev/azure-functions-python/practical-guide/reference/) | CLI cheatsheet, host.json, platform limits | Comprehensive |
 
 **Status legend**: **Lab-validated** = Comprehensive + reproducible labs prove the guidance · **Comprehensive** = Full section, MSLearn-verified, production-ready · **Published** = Core content in place, still expanding · **In progress** = Partial content, active development · **Planned** = Placeholder, content not yet started
 
@@ -101,7 +101,7 @@ Hands-on labs in `labs/` that reproduce real-world Azure Functions issues.
 
 ## Contributing
 
-Contributions welcome! Please see our [Contributing Guide](https://yeongseon.github.io/azure-functions-practical-guide/contributing/) for:
+Contributions welcome! Please see our [Contributing Guide](https://yeongseon.dev/azure-functions-python/practical-guide/contributing/) for:
 
 - Repository structure and content organization
 - Document templates and writing standards

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # Azure Functions 实操指南
 
-📘 **文档网站：** <https://yeongseon.github.io/azure-functions-practical-guide/>
+📘 **文档网站：** <https://yeongseon.dev/azure-functions-python/practical-guide/>
 
 [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
@@ -21,23 +21,23 @@
 
 | 场景 | 推荐计划 | 从这里开始 |
 |---|---|---|
-| 新的无服务器应用 | **Flex Consumption** | [Flex Consumption 教程](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 现有 Consumption 工作负载 | Consumption (旧版) | [Consumption 教程](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 常备实例或重度使用 VNet | Premium | [Premium 教程](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
-| 现有 App Service 计划资产 | Dedicated | [Dedicated 教程](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) |
+| 新的无服务器应用 | **Flex Consumption** | [Flex Consumption 教程](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 现有 Consumption 工作负载 | Consumption (旧版) | [Consumption 教程](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 常备实例或重度使用 VNet | Premium | [Premium 教程](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
+| 现有 App Service 计划资产 | Dedicated | [Dedicated 教程](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) |
 | 容器原生托管 | Container Apps | 已计划 — 参见 [托管范围](#hosting-scope) |
 
 ## 主要内容
 
 | 章节 | 描述 | 状态 |
 |---------|-------------|--------|
-| [从这里开始](https://yeongseon.github.io/azure-functions-practical-guide/) | 概述、学习路径和仓库地图 | 全面 |
-| [平台](https://yeongseon.github.io/azure-functions-practical-guide/platform/) | 架构、托管计划、扩展、网络、安全 | 全面 |
-| [最佳实践](https://yeongseon.github.io/azure-functions-practical-guide/best-practices/) | 托管选择、触发器、扩展、可靠性、安全、部署 | 全面 |
-| [语言指南](https://yeongseon.github.io/azure-functions-practical-guide/language-guides/) | Python、Node.js、Java 和 .NET 的分步教程 | 全面 |
-| [运营](https://yeongseon.github.io/azure-functions-practical-guide/operations/) | 部署、监控、告警、成本优化、恢复 | 全面 |
-| [故障排除](https://yeongseon.github.io/azure-functions-practical-guide/troubleshooting/) | 实战手册、KQL 查询、方法论和动手实验 | 实验已验证 |
-| [参考](https://yeongseon.github.io/azure-functions-practical-guide/reference/) | CLI 速查表、host.json、平台限制 | 全面 |
+| [从这里开始](https://yeongseon.dev/azure-functions-python/practical-guide/) | 概述、学习路径和仓库地图 | 全面 |
+| [平台](https://yeongseon.dev/azure-functions-python/practical-guide/platform/) | 架构、托管计划、扩展、网络、安全 | 全面 |
+| [最佳实践](https://yeongseon.dev/azure-functions-python/practical-guide/best-practices/) | 托管选择、触发器、扩展、可靠性、安全、部署 | 全面 |
+| [语言指南](https://yeongseon.dev/azure-functions-python/practical-guide/language-guides/) | Python、Node.js、Java 和 .NET 的分步教程 | 全面 |
+| [运营](https://yeongseon.dev/azure-functions-python/practical-guide/operations/) | 部署、监控、告警、成本优化、恢复 | 全面 |
+| [故障排除](https://yeongseon.dev/azure-functions-python/practical-guide/troubleshooting/) | 实战手册、KQL 查询、方法论和动手实验 | 实验已验证 |
+| [参考](https://yeongseon.dev/azure-functions-python/practical-guide/reference/) | CLI 速查表、host.json、平台限制 | 全面 |
 
 **状态图例**：**实验已验证** = 全面 + 可重现的实验证明了指南的可行性 · **全面** = 完整章节，经过 MSLearn 验证，生产就绪 · **已发布** = 核心内容已就绪，仍持续扩展中 · **进行中** = 部分内容已完成，处于活跃开发中 · **已计划** = 占位符，内容尚未开始
 
@@ -101,7 +101,7 @@ mkdocs serve
 
 ## 贡献
 
-欢迎贡献！有关以下内容，请参阅我们的 [贡献指南](https://yeongseon.github.io/azure-functions-practical-guide/contributing/)：
+欢迎贡献！有关以下内容，请参阅我们的 [贡献指南](https://yeongseon.dev/azure-functions-python/practical-guide/contributing/)：
 
 - 仓库结构和内容组织
 - 文档模板和编写标准

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Azure Functions Practical Guide
-site_url: https://yeongseon.github.io/azure-functions-practical-guide/
+site_url: https://yeongseon.dev/azure-functions-python/practical-guide/
 site_description: Comprehensive guide for running serverless applications on Azure Functions
 site_author: yeongseon
 


### PR DESCRIPTION
## Summary
- update this guide's in-scope self-referential documentation URLs to the canonical `https://yeongseon.dev/azure-functions-python/practical-guide/` base while preserving subpaths
- refresh MkDocs output locally with `mkdocs build --strict` and verify the generated site no longer emits old self-reference URLs
- preserve out-of-scope sibling-guide links for architecture, app service, and container apps

Closes #131